### PR TITLE
fix: controller exit logic

### DIFF
--- a/cosmos_rl/policy/trainer/grpo_trainer.py
+++ b/cosmos_rl/policy/trainer/grpo_trainer.py
@@ -262,15 +262,16 @@ class GRPOTrainer(Trainer):
                 self.fetch_command_thread.join()
                 self.fetch_command_thread = None
 
-            if hasattr(self, "heartbeat_thread") and self.heartbeat_thread is not None:
-                self.heartbeat_thread.join()
-                self.heartbeat_thread = None
-
             if hasattr(self, "upload_thread") and self.upload_thread is not None:
                 logger.info("[Policy] Waiting for upload thread to finish...")
                 self.upload_thread.join()
                 logger.info("[Policy] Upload thread finished.")
                 self.upload_thread = None
+
+            if hasattr(self, "heartbeat_thread") and self.heartbeat_thread is not None:
+                self.heartbeat_thread.join()
+                self.heartbeat_thread = None
+
             # Manually unregister from controller
             self.unregister_from_controller()
 


### PR DESCRIPTION
Finalizer of GRPOTrainer:
```python
    def handle_shutdown(self):
        if not hasattr(self, "_handle_shutdown_called"):
            self._handle_shutdown_called = True

            self.shutdown_signal.set()
            self.inter_policy_nccl.shutdown()
            if self.fetch_rollouts_thread is not None:
                self.fetch_rollouts_thread.join()
                self.fetch_rollouts_thread = None

            if self.fetch_command_thread is not None:
                self.fetch_command_thread.join()
                self.fetch_command_thread = None

            if hasattr(self, "heartbeat_thread") and self.heartbeat_thread is not None:
                self.heartbeat_thread.join()
                self.heartbeat_thread = None

            if hasattr(self, "upload_thread") and self.upload_thread is not None:
                logger.info("[Policy] Waiting for upload thread to finish...")
                self.upload_thread.join()
                logger.info("[Policy] Upload thread finished.")
                self.upload_thread = None

            # Manually unregister from controller
            self.unregister_from_controller()
```

Uploading thread may take a lot time to finish. So controller could get notified that replica is dead (but actually not).

We should do `self.unregister_from_controller()` in advance of ` self.upload_thread.join()` to prevent such issue.
