### PR TITLE
Simplify and generalize slice_tensor_with_strategy

### DIFF
--- a/cosmos_rl/utils/parallelism_map.py
+++ b/cosmos_rl/utils/parallelism_map.py
@@ -48,44 +48,10 @@ def slice_tensor_with_strategy(
     length = (
         view.shape[idx] // tensor_split_strategy.size * tensor_split_strategy.length
     )
-    if view.dim() == 1:
-        if idx == 0:
-            view = view[start : start + length]
-        else:
-            raise ValueError(f"Invalid index {idx} for 1D tensor.")
-    elif view.dim() == 2:
-        if idx == 0:
-            view = view[start : start + length, :]
-        elif idx == 1:
-            view = view[:, start : start + length]
-        else:
-            raise ValueError(f"Invalid index {idx} for 2D tensor.")
-    elif view.dim() == 3:
-        if idx == 0:
-            view = view[start : start + length, :, :]
-        elif idx == 1:
-            view = view[:, start : start + length, :]
-        elif idx == 2:
-            view = view[:, :, start : start + length]
-        else:
-            raise ValueError(f"Invalid index {idx} for 3D tensor.")
-    elif view.dim() == 4:
-        if idx == 0:
-            view = view[start : start + length, :, :, :]
-        elif idx == 3:
-            view = view[:, :, :, start : start + length]
-        else:
-            raise ValueError(f"Invalid index {idx} for 4D tensor.")
-    elif view.dim() == 5:
-        if idx == 0:
-            view = view[start : start + length, :, :, :, :]
-        elif idx == 4:
-            view = view[:, :, :, :, start : start + length]
-        else:
-            raise ValueError(f"Invalid index {idx} for 5D tensor.")
-    else:
-        raise ValueError(f"Invalid tensor dimension {view.dim()}.")
-    return view
+    dim = view.dim()
+    assert idx < view.dim(), f"Invalid index {idx} for {dim}D tensor."
+    slices = [slice(None, None)] * idx + [slice(start, start + length)] + [slice(None, None)] * (dim - idx - 1)
+    return view[slices]
 
 
 def slice_tensor_with_strategies(

--- a/cosmos_rl/utils/parallelism_map.py
+++ b/cosmos_rl/utils/parallelism_map.py
@@ -50,7 +50,11 @@ def slice_tensor_with_strategy(
     )
     dim = view.dim()
     assert idx < view.dim(), f"Invalid index {idx} for {dim}D tensor."
-    slices = [slice(None, None)] * idx + [slice(start, start + length)] + [slice(None, None)] * (dim - idx - 1)
+    slices = (
+        [slice(None, None)] * idx
+        + [slice(start, start + length)]
+        + [slice(None, None)] * (dim - idx - 1)
+    )
     return view[slices]
 
 


### PR DESCRIPTION
Simplify and generalize logic for splitting tensors for weight transfer. Before-hand only a few dimensions were supported. Now it supports splitting in any dimension of the tensor.