### PR TITLE
fix: Move upload thread finish ahead to prevent it from running too long to break exiting normally

### DIFF
--- a/cosmos_rl/policy/trainer/grpo_trainer.py
+++ b/cosmos_rl/policy/trainer/grpo_trainer.py
@@ -264,6 +264,12 @@ class GRPOTrainer(Trainer):
 
     def handle_shutdown(self):
         if not hasattr(self, "_handle_shutdown_called"):
+            if hasattr(self, "upload_thread") and self.upload_thread is not None:
+                logger.info("[Policy] Waiting for upload thread to finish...")
+                self.upload_thread.join()
+                logger.info("[Policy] Upload thread finished.")
+                self.upload_thread = None
+
             self._handle_shutdown_called = True
 
             self.shutdown_signal.set()
@@ -282,12 +288,6 @@ class GRPOTrainer(Trainer):
 
             # Manually unregister from controller
             self.unregister_from_controller()
-
-            if hasattr(self, "upload_thread") and self.upload_thread is not None:
-                logger.info("[Policy] Waiting for upload thread to finish...")
-                self.upload_thread.join()
-                logger.info("[Policy] Upload thread finished.")
-                self.upload_thread = None
 
             # TODO(jiaxin)
             # The background threads are daemon threads, so that they will exit when the main thread exits


### PR DESCRIPTION
Upload thread may take minutes to finish, but the shutdown_signal set will stop heartbeat to make controller regard it as exited. Upload thread should be finished before he shutdown_signal set to keep the heartbeat thread to the end of the process.