### PR TITLE
tempfix: vllm-0.9.1 patch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -83,4 +83,8 @@ COPY tools /workspace/cosmos_rl/tools
 COPY configs /workspace/cosmos_rl/configs
 COPY cosmos_rl /workspace/cosmos_rl/cosmos_rl
 
+# Apply patch to vllm-0.9.1 where qwen-vl-utils get error during init
+COPY patch/vllm_0_9_1.patch /workspace/cosmos_rl/vllm_0_9_1.patch
+
+RUN cd $(python -c "import sysconfig; print(sysconfig.get_paths()['purelib'])") && patch -p1 < /workspace/cosmos_rl/vllm_0_9_1.patch && cd -
 RUN cd /workspace/cosmos_rl && pip install -e . && cd -

--- a/patch/vllm_0_9_1.patch
+++ b/patch/vllm_0_9_1.patch
@@ -1,0 +1,99 @@
+From e881e2906327f7885d2e330a11efad2e6e5c6688 Mon Sep 17 00:00:00 2001
+From: Isotr0py <2037008807@qq.com>
+Date: Mon, 30 Jun 2025 15:03:11 +0800
+Subject: [PATCH 1/3] disable tokenizer override for processor in transformers
+ 4.53.0
+
+Signed-off-by: Isotr0py <2037008807@qq.com>
+---
+ vllm/inputs/registry.py | 11 ++++++++++-
+ 1 file changed, 10 insertions(+), 1 deletion(-)
+
+diff --git a/vllm/inputs/registry.py b/vllm/inputs/registry.py
+index 66e78833f52..143cb883629 100644
+--- a/vllm/inputs/registry.py
++++ b/vllm/inputs/registry.py
+@@ -5,6 +5,8 @@
+ from typing import TYPE_CHECKING, Any, NamedTuple, Optional, Union
+ 
+ import torch
++from packaging.version import Version
++from packaging.version import __version__ as TRANSFORMERS_VERSION
+ from transformers import BatchFeature, PretrainedConfig, ProcessorMixin
+ from typing_extensions import TypeVar
+ 
+@@ -128,9 +130,16 @@ def get_hf_processor(
+         /,
+         **kwargs: object,
+     ) -> _P:
++        # Transformers 4.53.0 has issue with passing tokenizer to
++        # initialize processor. We disable it for this version.
++        # See: https://github.com/vllm-project/vllm/issues/20224
++        if Version(TRANSFORMERS_VERSION) == Version("4.53.0"):
++            tokenizer = None
++        else:
++            tokenizer = self.tokenizer
+         return super().get_hf_processor(
+             typ,
+-            tokenizer=self.tokenizer,
++            tokenizer=tokenizer,
+             **kwargs,
+         )
+ 
+
+From e06fc926c6d0abc22dcfa35c19e2e44b5a1e277f Mon Sep 17 00:00:00 2001
+From: Isotr0py <2037008807@qq.com>
+Date: Mon, 30 Jun 2025 15:17:53 +0800
+Subject: [PATCH 2/3] ooops
+
+Signed-off-by: Isotr0py <2037008807@qq.com>
+---
+ vllm/inputs/registry.py | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/vllm/inputs/registry.py b/vllm/inputs/registry.py
+index 143cb883629..44ba783fe87 100644
+--- a/vllm/inputs/registry.py
++++ b/vllm/inputs/registry.py
+@@ -6,8 +6,8 @@
+ 
+ import torch
+ from packaging.version import Version
+-from packaging.version import __version__ as TRANSFORMERS_VERSION
+ from transformers import BatchFeature, PretrainedConfig, ProcessorMixin
++from transformers import __version__ as TRANSFORMERS_VERSION
+ from typing_extensions import TypeVar
+ 
+ from vllm.jsontree import JSONTree, json_map_leaves
+
+From 54ac5c9709719b1b0604584d3582b9fe1016ab1d Mon Sep 17 00:00:00 2001
+From: Isotr0py <2037008807@qq.com>
+Date: Mon, 30 Jun 2025 15:21:12 +0800
+Subject: [PATCH 3/3] fix
+
+Signed-off-by: Isotr0py <2037008807@qq.com>
+---
+ vllm/inputs/registry.py | 7 ++-----
+ 1 file changed, 2 insertions(+), 5 deletions(-)
+
+diff --git a/vllm/inputs/registry.py b/vllm/inputs/registry.py
+index 44ba783fe87..fc6e190e548 100644
+--- a/vllm/inputs/registry.py
++++ b/vllm/inputs/registry.py
+@@ -133,13 +133,10 @@ def get_hf_processor(
+         # Transformers 4.53.0 has issue with passing tokenizer to
+         # initialize processor. We disable it for this version.
+         # See: https://github.com/vllm-project/vllm/issues/20224
+-        if Version(TRANSFORMERS_VERSION) == Version("4.53.0"):
+-            tokenizer = None
+-        else:
+-            tokenizer = self.tokenizer
++        if Version(TRANSFORMERS_VERSION) != Version("4.53.0"):
++            kwargs["tokenizer"] = self.tokenizer
+         return super().get_hf_processor(
+             typ,
+-            tokenizer=tokenizer,
+             **kwargs,
+         )
+ 
+


### PR DESCRIPTION
According to https://github.com/vllm-project/vllm-ascend/issues/1470#issuecomment-3021980435, vllm need to be patched to behave correctly with qwen-vl-util.