### PR TITLE
Fix: Slurm: Use launcher script on policy and rollout too

### DIFF
--- a/tools/slurm/cosmos_rl_job_multi_node.sh
+++ b/tools/slurm/cosmos_rl_job_multi_node.sh
@@ -78,7 +78,7 @@ srun \
     bash -c \
     '
     cd /opt/cosmos-rl
-    python ./tools/slurm/cosmos_rl_slurm_launch.py --type policy
+    python ./tools/slurm/cosmos_rl_slurm_launch.py --type policy --script [[LAUNCHER]]
     ' \
     &
 pid_policy=$!
@@ -97,7 +97,7 @@ srun \
     bash -c \
     '
     cd /opt/cosmos-rl
-    python ./tools/slurm/cosmos_rl_slurm_launch.py --type rollout
+    python ./tools/slurm/cosmos_rl_slurm_launch.py --type rollout --script [[LAUNCHER]]
     ' \
     &
 pid_rollout=$!

--- a/tools/slurm/cosmos_rl_slurm_launch.py
+++ b/tools/slurm/cosmos_rl_slurm_launch.py
@@ -34,8 +34,12 @@ logging.basicConfig(level=logging.INFO)
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument(
-        "--type", type=str, required=True, choices=["policy", "rollout"]
+        "--type",
+        type=str,
+        required=True,
+        choices=["policy", "rollout"],
     )
+    parser.add_argument("--script", type=str)
     args = parser.parse_args()
 
     node_list = os.environ["LOCAL_NODE_LIST"].split(" ")
@@ -74,19 +78,20 @@ if __name__ == "__main__":
             "launcher",
             "launch_replica.sh",
         )
-        cmds.append(
-            [
-                replica_launch_script,
-                "--type",
-                args.type,
-                "--rdzv-endpoint",
-                f"{rendezvous_node}:{rendezvous_port}",
-                "--ngpus",
-                str(len(visible_gpus)),
-                "--nnodes",
-                str(nnode),
-            ]
-        )
+        cmd = [
+            replica_launch_script,
+            "--type",
+            args.type,
+            "--rdzv-endpoint",
+            f"{rendezvous_node}:{rendezvous_port}",
+            "--ngpus",
+            str(len(visible_gpus)),
+            "--nnodes",
+            str(nnode),
+        ]
+        if args.script:
+            cmd += ["--script", args.script]
+        cmds.append(cmd)
         envs.append(env)
 
     procs = [subprocess.Popen(cmd, env=env) for cmd, env in zip(cmds, envs)]


### PR DESCRIPTION
Propagate launcher script to launch_replica.sh when launching from slurm. 