### PR TITLE
Pass trust_remote_code in call to from_pretrained

### DIFF
--- a/cosmos_rl/rollout/vllm_rollout/vllm_rollout.py
+++ b/cosmos_rl/rollout/vllm_rollout/vllm_rollout.py
@@ -63,7 +63,9 @@ class vLLMRollout(RolloutBase):
         model_path = policy_config.model_name_or_path
 
         # Check if the model has MoE
-        model_config = util.retry(AutoConfig.from_pretrained)(model_path, trust_remote_code=trust_remote_code)
+        model_config = util.retry(AutoConfig.from_pretrained)(
+            model_path, trust_remote_code=trust_remote_code
+        )
 
         enable_ep_parallelism = False
         disable_mm_preprocessor_cache = False

--- a/cosmos_rl/rollout/vllm_rollout/vllm_rollout.py
+++ b/cosmos_rl/rollout/vllm_rollout/vllm_rollout.py
@@ -63,7 +63,7 @@ class vLLMRollout(RolloutBase):
         model_path = policy_config.model_name_or_path
 
         # Check if the model has MoE
-        model_config = util.retry(AutoConfig.from_pretrained)(model_path)
+        model_config = util.retry(AutoConfig.from_pretrained)(model_path, trust_remote_code=trust_remote_code)
 
         enable_ep_parallelism = False
         disable_mm_preprocessor_cache = False

--- a/cosmos_rl/rollout/vllm_rollout/vllm_rollout_worker.py
+++ b/cosmos_rl/rollout/vllm_rollout/vllm_rollout_worker.py
@@ -204,7 +204,7 @@ class vLLMRolloutWorker(RolloutWorkerBase):
 
         # For Polocy to Rollout weight mapping
         hf_config = util.retry(AutoConfig.from_pretrained)(
-            self.config.policy.model_name_or_path
+            self.config.policy.model_name_or_path,
             trust_remote_code=True,
         )
 

--- a/cosmos_rl/rollout/vllm_rollout/vllm_rollout_worker.py
+++ b/cosmos_rl/rollout/vllm_rollout/vllm_rollout_worker.py
@@ -205,6 +205,7 @@ class vLLMRolloutWorker(RolloutWorkerBase):
         # For Polocy to Rollout weight mapping
         hf_config = util.retry(AutoConfig.from_pretrained)(
             self.config.policy.model_name_or_path
+            trust_remote_code=True,
         )
 
         if not ModelRegistry.check_model_type_supported(hf_config.model_type):


### PR DESCRIPTION
This was missing -- even though trust_remote_code is hardcoded as True a few lines below. 