### PR TITLE
chore: update dockerfile to support build with AWS efa or not

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,28 +17,8 @@ ENV TZ=Etc/UTC
 
 RUN apt-get update -y && apt-get upgrade -y
 
-RUN rm -rf /opt/hpcx \
-    && rm -rf /usr/local/mpi \
-    && rm -f /etc/ld.so.conf.d/hpcx.conf \
-    && ldconfig
-
-ENV OPAL_PREFIX=
-
 RUN DEBIAN_FRONTEND=noninteractive apt-get install -y --allow-unauthenticated \
-    apt-utils \
-    autoconf \
-    automake \
-    build-essential \
-    check \
-    cmake \
-    curl \
-    debhelper \
-    devscripts \
-    git \
-    gcc \
-    gdb \
-    pkg-config \
-    wget
+    curl git gpg lsb-release tzdata wget 
 RUN apt-get purge -y cuda-compat-*
 
 #################################################
@@ -52,7 +32,6 @@ RUN git clone -b ${GDRCOPY_VERSION} https://github.com/NVIDIA/gdrcopy.git /tmp/g
 
 ENV LD_LIBRARY_PATH=/opt/gdrcopy/lib:$LD_LIBRARY_PATH
 ENV LIBRARY_PATH=/opt/gdrcopy/lib:$LIBRARY_PATH
-ENV CPATH=/opt/gdrcopy/include:$CPATH
 ENV PATH=/opt/gdrcopy/bin:$PATH
 
 ###################################################
@@ -80,10 +59,8 @@ RUN apt-get update -qq && \
 ###################################################
 ## Install python
 RUN apt-get update -qq && \
-DEBIAN_FRONTEND=noninteractive apt-get install -qq -y --allow-change-held-packages \
-build-essential tzdata netcat \
-python3.10 python3.10-dev python3.10-venv python3-pip python-is-python3 \
-lsb-release gpg
+    DEBIAN_FRONTEND=noninteractive apt-get install -qq -y --allow-change-held-packages \
+    python3.10 python3.10-dev python3.10-venv python3-pip python-is-python3
 
 RUN pip install -U pip setuptools wheel packaging
 # even though we don't depend on torchaudio, vllm does. in order to
@@ -101,6 +78,12 @@ RUN pip install \
 
 ###################################################
 FROM base AS aws_efa_base
+
+# Remove HPCX and MPI to avoid conflicts with AWS-EFA
+RUN rm -rf /opt/hpcx \
+    && rm -rf /usr/local/mpi \
+    && rm -f /etc/ld.so.conf.d/hpcx.conf \
+    && ldconfig
 
 RUN apt-get remove -y --purge --allow-change-held-packages \
     ibverbs-utils \

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ ENV TZ=Etc/UTC
 RUN apt-get update -y && apt-get upgrade -y
 
 RUN DEBIAN_FRONTEND=noninteractive apt-get install -y --allow-unauthenticated \
-    curl git gpg lsb-release tzdata wget 
+    curl git gpg lsb-release tzdata wget
 RUN apt-get purge -y cuda-compat-*
 
 #################################################

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,20 +45,9 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get install -y --allow-unauthenticated \
     git \
     gcc \
     gdb \
-    kmod \
-    libsubunit-dev \
-    libtool \
-    openssh-client \
-    openssh-server \
     pkg-config \
-    python3-distutils \
-    vim
+    wget
 RUN apt-get purge -y cuda-compat-*
-
-RUN mkdir -p /var/run/sshd
-RUN sed -i 's/[ #]\(.*StrictHostKeyChecking \).*/ \1no/g' /etc/ssh/ssh_config && \
-    echo "    UserKnownHostsFile /dev/null" >> /etc/ssh/ssh_config && \
-    sed -i 's/#\(StrictModes \).*/\1no/g' /etc/ssh/sshd_config
 
 ENV LD_LIBRARY_PATH /usr/local/cuda/extras/CUPTI/lib64:/opt/amazon/openmpi/lib:/opt/amazon/efa/lib:/opt/aws-ofi-nccl/install/lib:/usr/local/lib:$LD_LIBRARY_PATH
 ENV PATH /opt/amazon/openmpi/bin/:/opt/amazon/efa/bin:/usr/bin:/usr/local/bin:$PATH

--- a/Dockerfile
+++ b/Dockerfile
@@ -64,7 +64,7 @@ RUN wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86
     && dpkg -i cuda-keyring_1.1-1_all.deb \
     && rm cuda-keyring_1.1-1_all.deb \
     && apt-get update -y \
-    && apt-get install -y libnccl2=${NCCL_VERSION}
+    && apt-get install -y libnccl2=${NCCL_VERSION} libnccl-dev=${NCCL_VERSION}
 
 ###################################################
 ## Install redis

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,13 +11,19 @@ ARG NCCL_VERSION=2.26.2-1+cuda12.8
 ENV TZ=Etc/UTC
 
 RUN apt-get update -y && apt-get upgrade -y
-RUN apt-get remove -y --purge --allow-change-held-packages \
-    ibverbs-utils \
-    libibverbs-dev \
-    libibverbs1 \
-    libmlx5-1 \
-    libnccl2 \
-    libnccl-dev
+RUN if [ "${ENABLE_AWS_EFA}" == "true" ]; then \
+        apt-get remove -y --purge --allow-change-held-packages \
+        ibverbs-utils \
+        libibverbs-dev \
+        libibverbs1 \
+        libmlx5-1 \
+        libnccl2 \
+        libnccl-dev; \
+    else \
+        apt-get remove -y --purge --allow-change-held-packages \
+        libnccl2 \
+        libnccl-dev; \
+    fi
 
 RUN rm -rf /opt/hpcx \
     && rm -rf /usr/local/mpi \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,25 +1,77 @@
-FROM nvidia/cuda:12.8.1-devel-ubuntu22.04 AS base
+ARG CUDA_VERSION=12.8.1
+FROM nvcr.io/nvidia/cuda:${CUDA_VERSION}-devel-ubuntu22.04 AS base
 
-ARG DEBIAN_FRONTEND=noninteractive
+ARG ENABLE_AWS_EFA=true
+ARG GDRCOPY_VERSION=v2.4.4
+ARG EFA_INSTALLER_VERSION=1.42.0
+ARG AWS_OFI_NCCL_VERSION=v1.16.0
+ARG NCCL_VERSION=v2.27.5-1
+ARG NCCL_TESTS_VERSION=v2.16.4
+
 ENV TZ=Etc/UTC
 
-RUN apt-get update -qq && apt-get install -qq -y --allow-change-held-packages \
-    build-essential tzdata git openssh-server curl netcat elfutils \
-    python3.10 python3.10-dev python3.10-venv python3-pip python-is-python3 \
-    lsb-release gpg
+RUN apt-get update -y && apt-get upgrade -y
+RUN apt-get remove -y --allow-change-held-packages \
+    ibverbs-utils \
+    libibverbs-dev \
+    libibverbs1 \
+    libmlx5-1 \
+    libnccl2 \
+    libnccl-dev
 
-# Download and add Redis GPG key
-RUN curl -fsSL https://packages.redis.io/gpg  | gpg --dearmor -o /usr/share/keyrings/redis-archive-keyring.gpg && \
-    chmod 644 /usr/share/keyrings/redis-archive-keyring.gpg
+RUN rm -rf /opt/hpcx \
+    && rm -rf /usr/local/mpi \
+    && rm -f /etc/ld.so.conf.d/hpcx.conf \
+    && ldconfig
 
-# Add Redis APT repository
-RUN echo "deb [signed-by=/usr/share/keyrings/redis-archive-keyring.gpg] https://packages.redis.io/deb  $(lsb_release -cs) main" | tee /etc/apt/sources.list.d/redis.list
+ENV OPAL_PREFIX=
 
-# Update package list
-RUN apt-get update -qq
+RUN DEBIAN_FRONTEND=noninteractive apt-get install -y --allow-unauthenticated \
+    apt-utils \
+    autoconf \
+    automake \
+    build-essential \
+    check \
+    cmake \
+    curl \
+    debhelper \
+    devscripts \
+    git \
+    gcc \
+    gdb \
+    kmod \
+    libsubunit-dev \
+    libtool \
+    openssh-client \
+    openssh-server \
+    pkg-config \
+    python3-distutils \
+    vim
+RUN apt-get purge -y cuda-compat-*
 
-# Install specific Redis version
-RUN apt-get install -qq -y redis-server
+RUN mkdir -p /var/run/sshd
+RUN sed -i 's/[ #]\(.*StrictHostKeyChecking \).*/ \1no/g' /etc/ssh/ssh_config && \
+    echo "    UserKnownHostsFile /dev/null" >> /etc/ssh/ssh_config && \
+    sed -i 's/#\(StrictModes \).*/\1no/g' /etc/ssh/sshd_config
+
+ENV LD_LIBRARY_PATH /usr/local/cuda/extras/CUPTI/lib64:/opt/amazon/openmpi/lib:/opt/nccl/build/lib:/opt/amazon/efa/lib:/opt/aws-ofi-nccl/install/lib:/usr/local/lib:$LD_LIBRARY_PATH
+ENV PATH /opt/amazon/openmpi/bin/:/opt/amazon/efa/bin:/usr/bin:/usr/local/bin:$PATH
+
+
+
+#################################################
+## Install NVIDIA GDRCopy
+##
+## NOTE: if `nccl-tests` or `/opt/gdrcopy/bin/sanity -v` crashes with incompatible version, ensure
+## that the cuda-compat-xx-x package is the latest.
+RUN git clone -b ${GDRCOPY_VERSION} https://github.com/NVIDIA/gdrcopy.git /tmp/gdrcopy \
+    && cd /tmp/gdrcopy \
+    && make prefix=/opt/gdrcopy install
+
+ENV LD_LIBRARY_PATH /opt/gdrcopy/lib:$LD_LIBRARY_PATH
+ENV LIBRARY_PATH /opt/gdrcopy/lib:$LIBRARY_PATH
+ENV CPATH /opt/gdrcopy/include:$CPATH
+ENV PATH /opt/gdrcopy/bin:$PATH
 
 ###################################################
 ## Remove AWS-EFA related packages
@@ -36,21 +88,29 @@ ENV PATH=/opt/amazon/openmpi/bin/:/opt/amazon/efa/bin:/usr/bin:/usr/local/bin:$P
 
 #################################################
 ## Install EFA installer
-ARG EFA_INSTALLER_VERSION=1.42.0
-RUN cd $HOME \
+RUN ! ${ENABLE_AWS_EFA} || ( \
+    cd $HOME \
     && curl -O https://efa-installer.amazonaws.com/aws-efa-installer-${EFA_INSTALLER_VERSION}.tar.gz \
     && tar -xf $HOME/aws-efa-installer-${EFA_INSTALLER_VERSION}.tar.gz \
     && cd aws-efa-installer \
     && ./efa_installer.sh -y -g -d --skip-kmod --skip-limit-conf --no-verify \
-    && rm -rf $HOME/aws-efa-installer
+    && rm -rf $HOME/aws-efa-installer \
+    )
+
+###################################################
+## Install NCCL
+RUN git clone -b ${NCCL_VERSION} https://github.com/NVIDIA/nccl.git  /opt/nccl \
+    && cd /opt/nccl \
+    && make -j $(nproc) src.build CUDA_HOME=/usr/local/cuda \
+    NVCC_GENCODE="-gencode=arch=compute_80,code=sm_80 -gencode=arch=compute_86,code=sm_86 -gencode=arch=compute_89,code=sm_89 -gencode=arch=compute_90,code=sm_90 -gencode=arch=compute_100,code=sm_100"
 
 ###################################################
 ## Install AWS-OFI-NCCL plugin
-ARG AWS_OFI_NCCL_VERSION=v1.16.0
 RUN DEBIAN_FRONTEND=noninteractive apt-get install -y libhwloc-dev
 #Switch from sh to bash to allow parameter expansion
 SHELL ["/bin/bash", "-c"]
-RUN curl -OL https://github.com/aws/aws-ofi-nccl/releases/download/${AWS_OFI_NCCL_VERSION}/aws-ofi-nccl-${AWS_OFI_NCCL_VERSION//v}.tar.gz \
+RUN ! ${ENABLE_AWS_EFA} || ( \
+    curl -OL https://github.com/aws/aws-ofi-nccl/releases/download/${AWS_OFI_NCCL_VERSION}/aws-ofi-nccl-${AWS_OFI_NCCL_VERSION//v}.tar.gz \
     && tar -xf aws-ofi-nccl-${AWS_OFI_NCCL_VERSION//v}.tar.gz \
     && cd aws-ofi-nccl-${AWS_OFI_NCCL_VERSION//v} \
     && ./configure --prefix=/opt/aws-ofi-nccl/install \
@@ -62,17 +122,28 @@ RUN curl -OL https://github.com/aws/aws-ofi-nccl/releases/download/${AWS_OFI_NCC
     && make install \
     && cd .. \
     && rm -rf aws-ofi-nccl-${AWS_OFI_NCCL_VERSION//v} \
-    && rm aws-ofi-nccl-${AWS_OFI_NCCL_VERSION//v}.tar.gz
+    && rm aws-ofi-nccl-${AWS_OFI_NCCL_VERSION//v}.tar.gz \
+    )
 
-#################################################
-## Install NVIDIA GDRCopy
-##
-## NOTE: if `nccl-tests` or `/opt/gdrcopy/bin/sanity -v` crashes with incompatible version, ensure
-## that the cuda-compat-xx-x package is the latest.
-ARG GDRCOPY_VERSION=v2.4.4
-RUN git clone -b ${GDRCOPY_VERSION} https://github.com/NVIDIA/gdrcopy.git /tmp/gdrcopy \
-    && cd /tmp/gdrcopy \
-    && make prefix=/opt/gdrcopy install
+
+###################################################
+## Install python
+RUN apt-get update -qq && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -qq -y --allow-change-held-packages \
+    build-essential tzdata netcat \
+    python3.10 python3.10-dev python3.10-venv python3-pip python-is-python3 \
+    lsb-release gpg
+
+###################################################
+## Install redis
+# Download and add Redis GPG key, Redis APT repository
+RUN curl -fsSL https://packages.redis.io/gpg  | gpg --dearmor -o /usr/share/keyrings/redis-archive-keyring.gpg && \
+    chmod 644 /usr/share/keyrings/redis-archive-keyring.gpg && \
+    echo "deb [signed-by=/usr/share/keyrings/redis-archive-keyring.gpg] https://packages.redis.io/deb  $(lsb_release -cs) main" | tee /etc/apt/sources.list.d/redis.list
+
+# Update package list
+RUN apt-get update -qq && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -qq -y redis-server
 
 RUN pip install -U pip setuptools wheel packaging
 # even though we don't depend on torchaudio, vllm does. in order to
@@ -87,6 +158,9 @@ RUN pip install \
     https://download.pytorch.org/whl/cu128/flashinfer/flashinfer_python-0.2.6.post1%2Bcu128torch2.7-cp39-abi3-linux_x86_64.whl \
     -r /workspace/cosmos_rl/requirements.txt
 
+
+###################################################
+## Install cosmos_rl
 FROM base AS package
 
 COPY . /workspace/cosmos_rl

--- a/Dockerfile
+++ b/Dockerfile
@@ -50,10 +50,10 @@ RUN git clone -b ${GDRCOPY_VERSION} https://github.com/NVIDIA/gdrcopy.git /tmp/g
     && cd /tmp/gdrcopy \
     && make prefix=/opt/gdrcopy install
 
-ENV LD_LIBRARY_PATH /opt/gdrcopy/lib:$LD_LIBRARY_PATH
-ENV LIBRARY_PATH /opt/gdrcopy/lib:$LIBRARY_PATH
-ENV CPATH /opt/gdrcopy/include:$CPATH
-ENV PATH /opt/gdrcopy/bin:$PATH
+ENV LD_LIBRARY_PATH=/opt/gdrcopy/lib:$LD_LIBRARY_PATH
+ENV LIBRARY_PATH=/opt/gdrcopy/lib:$LIBRARY_PATH
+ENV CPATH=/opt/gdrcopy/include:$CPATH
+ENV PATH=/opt/gdrcopy/bin:$PATH
 
 ###################################################
 ## Install NCCL with specific version
@@ -136,8 +136,8 @@ RUN curl -OL https://github.com/aws/aws-ofi-nccl/releases/download/${AWS_OFI_NCC
     && rm -rf aws-ofi-nccl-${AWS_OFI_NCCL_VERSION//v} \
     && rm aws-ofi-nccl-${AWS_OFI_NCCL_VERSION//v}.tar.gz
 
-ENV LD_LIBRARY_PATH /usr/local/cuda/extras/CUPTI/lib64:/opt/amazon/openmpi/lib:/opt/amazon/efa/lib:/opt/aws-ofi-nccl/install/lib:/usr/local/lib:$LD_LIBRARY_PATH
-ENV PATH /opt/amazon/openmpi/bin/:/opt/amazon/efa/bin:/usr/bin:/usr/local/bin:$PATH
+ENV LD_LIBRARY_PATH=/usr/local/cuda/extras/CUPTI/lib64:/opt/amazon/openmpi/lib:/opt/amazon/efa/lib:/opt/aws-ofi-nccl/install/lib:/usr/local/lib:$LD_LIBRARY_PATH
+ENV PATH=/opt/amazon/openmpi/bin/:/opt/amazon/efa/bin:/usr/bin:/usr/local/bin:$PATH
 
 
 ###################################################

--- a/docs/quickstart/installation.rst
+++ b/docs/quickstart/installation.rst
@@ -24,6 +24,8 @@ You can either build docker image from source or install dependencies inside you
 
 .. note::
     EFA driver is included in the docker image specifically for aws instances with EFA net interface (Sagemaker AI Pod).
+    
+    If you are not using EFA, you can build the docker image with `docker build -t cosmos-rl-dev:dev --build-arg ENABLE_AWS_EFA=false .` flag.
 
 🔨 Option 2: Run in your own environment
 :::::::::::::::::::::::::::::::::::::::::

--- a/docs/quickstart/installation.rst
+++ b/docs/quickstart/installation.rst
@@ -19,13 +19,13 @@ You can either build docker image from source or install dependencies inside you
 
 .. code-block:: bash
 
-    docker build -t cosmos-rl-dev:dev --target package_aws_efa .
+    docker build -t cosmos-rl-dev:dev .
     docker run -it --gpus all --shm-size=24G -w /workspace/cosmos-rl cosmos-rl-dev:dev
 
 .. note::
     EFA driver is included in the docker image specifically for aws instances with EFA net interface (Sagemaker AI Pod).
 
-    If you are not using EFA, you can build the docker image with `docker build -t cosmos-rl-dev:dev --target package .`.
+    If you are not using EFA, you can build the docker image with `docker build --build-arg COSMOS_RL_BUILD_MODE=no-efa -t cosmos-rl-dev:dev --target package .`.
 
 🔨 Option 2: Run in your own environment
 :::::::::::::::::::::::::::::::::::::::::

--- a/docs/quickstart/installation.rst
+++ b/docs/quickstart/installation.rst
@@ -19,13 +19,13 @@ You can either build docker image from source or install dependencies inside you
 
 .. code-block:: bash
 
-    docker build -t cosmos-rl-dev:dev .
+    docker build -t cosmos-rl-dev:dev --target package_aws_efa .
     docker run -it --gpus all --shm-size=24G -w /workspace/cosmos-rl cosmos-rl-dev:dev
 
 .. note::
     EFA driver is included in the docker image specifically for aws instances with EFA net interface (Sagemaker AI Pod).
 
-    If you are not using EFA, you can build the docker image with `docker build -t cosmos-rl-dev:dev --build-arg ENABLE_AWS_EFA=false .`.
+    If you are not using EFA, you can build the docker image with `docker build -t cosmos-rl-dev:dev --target package .`.
 
 🔨 Option 2: Run in your own environment
 :::::::::::::::::::::::::::::::::::::::::

--- a/docs/quickstart/installation.rst
+++ b/docs/quickstart/installation.rst
@@ -24,8 +24,8 @@ You can either build docker image from source or install dependencies inside you
 
 .. note::
     EFA driver is included in the docker image specifically for aws instances with EFA net interface (Sagemaker AI Pod).
-    
-    If you are not using EFA, you can build the docker image with `docker build -t cosmos-rl-dev:dev --build-arg ENABLE_AWS_EFA=false .` flag.
+
+    If you are not using EFA, you can build the docker image with `docker build -t cosmos-rl-dev:dev --build-arg ENABLE_AWS_EFA=false .`.
 
 🔨 Option 2: Run in your own environment
 :::::::::::::::::::::::::::::::::::::::::


### PR DESCRIPTION
Refactor dockerfile to enable EFA or not
- To build with AWS-EFA, `docker build -t cosmos_rl:latest -f Dockerfile .`
- To build without AWS-EFA, `docker build --build-arg COSMOS_RL_BUILD_MODE=no-efa -t cosmos_rl:latest -f Dockerfile .`