### PR TITLE
feat: support custom validaion reward function

### DIFF
--- a/cosmos_rl/dispatcher/run_web_panel.py
+++ b/cosmos_rl/dispatcher/run_web_panel.py
@@ -349,7 +349,7 @@ async def validation_report(request: ValidationReportRequest):
     ]
 
     rollouts_list: List[List[Rollout]] = [
-        rollout_group.compute_rollouts(controller.rl_algo)
+        rollout_group.compute_rollouts(controller.val_rl_algo)
         for rollout_group in rollout_groups
     ]
     controller.policy_status_manager.validation_report_validation_results(
@@ -533,6 +533,7 @@ def main(
     data_packer: Optional[DataPacker] = None,
     reward_fns: Optional[List[Callable]] = None,
     val_dataset: Optional[Dataset] = None,
+    val_reward_fns: Optional[List[Callable]] = None,
     val_data_packer: Optional[DataPacker] = None,
     **kwargs,
 ):
@@ -624,6 +625,7 @@ def main(
             reward_fns=reward_fns,
             data_packer=data_packer,
             val_dataset=val_dataset,
+            val_reward_fns=val_reward_fns,
             val_data_packer=val_data_packer,
         )
         logger.info(f"Successfully loaded configuration from {args.config_file}")

--- a/cosmos_rl/launcher/worker_entry.py
+++ b/cosmos_rl/launcher/worker_entry.py
@@ -11,6 +11,7 @@ def main(
     data_packer: Optional[DataPacker] = None,
     reward_fns: Optional[List[Callable]] = None,
     val_dataset: Optional[Dataset] = None,
+    val_reward_fns: Optional[List[Callable]] = None,
     val_data_packer: Optional[DataPacker] = None,
     *args,
     **kwargs,
@@ -28,6 +29,7 @@ def main(
             data_packer=data_packer,
             reward_fns=reward_fns,
             val_dataset=val_dataset,
+            val_reward_fns=val_reward_fns,
             val_data_packer=val_data_packer,
         )
     elif role == "Policy":

--- a/cosmos_rl/policy/config/__init__.py
+++ b/cosmos_rl/policy/config/__init__.py
@@ -610,6 +610,9 @@ class ValidationConfig(BaseModel):
         default=2048,
         description="Max output length of rollout generation during validation.",
     )
+    reward_function: Optional[Union[str, List[str]]] = Field(
+        default=None, description="Reward function for validation."
+    )
 
 
 class RolloutConfig(BaseModel):

--- a/tools/dataset/cosmos_grpo.py
+++ b/tools/dataset/cosmos_grpo.py
@@ -186,6 +186,12 @@ def custom_reward_fn(
     )
 
 
+def custom_val_reward_fn(
+    to_be_evaluated: str, reference: Optional[str] = None, *args, **kwargs
+) -> float:
+    return single_choice_reward_fn(to_be_evaluated, reference, *args, **kwargs)
+
+
 class DemoDataPacker(DataPacker):
     """
     This is a demo data packer that wraps the underlying data packer of the selected model.
@@ -276,5 +282,6 @@ if __name__ == "__main__":
         reward_fns=[custom_reward_fn],
         data_packer=DemoDataPacker(),
         val_dataset=get_val_dataset,
+        val_reward_fns=[custom_val_reward_fn],
         val_data_packer=DemoDataPacker(),
     )


### PR DESCRIPTION
We indeed need this function. The validation reward function should be customized for the user.  For the Cosmos-Reason1 cases, the training reward function contains format_reward, which is not useful for validation. Current priority is:

- The default is to use the same reward function for training & validation
- The user can configure the validation `reward_function`  in toml, or can pass a `val_reward_fns` in the custom launcher, then the training & validation will use separate reward.