### PR TITLE
Compute grad norm among all model parts

### DIFF
--- a/cosmos_rl/policy/trainer/grpo_trainer.py
+++ b/cosmos_rl/policy/trainer/grpo_trainer.py
@@ -881,20 +881,23 @@ class GRPOTrainer(Trainer):
                     [p for p in model_part.parameters()], self.inter_policy_nccl
                 )
 
-            if self.config.train.optm_grad_norm_clip > 0:
-                # Then clipping gradient norm
-                dist_util.gradient_norm_clipping(
-                    # Must pass empty list even if model_part is None,
-                    # GradNorm across pp stages will fail if some rank does not join the barrier
-                    [p for p in model_part.parameters()]
-                    if model_part is not None
-                    else [],
-                    self.config.train.optm_grad_norm_clip,
-                    foreach=True,
-                    pp_mesh=self.parallel_dims.mesh["pp"]
-                    if self.parallel_dims.pp_enabled
-                    else None,
-                )
+        """
+        Compute the global grad norm on all parameters and then apply
+        gradient clipping using the global grad norm.
+        """
+        if self.config.train.optm_grad_norm_clip > 0:
+            # Must pass empty list even if model_part is None,
+            # GradNorm across pp stages will fail if some rank does not join the barrier
+            all_params = [p for m in self.model_parts for p in m.parameters()]
+            dist_util.gradient_norm_clipping(
+                all_params,
+                self.config.train.optm_grad_norm_clip,
+                foreach=True,
+                pp_mesh=self.parallel_dims.mesh["pp"]
+                if self.parallel_dims.pp_enabled
+                else None,
+            )
+
         self.optimizers.step()
         self.lr_schedulers.step()
         self.optimizers.zero_grad()

--- a/cosmos_rl/policy/trainer/sft_trainer.py
+++ b/cosmos_rl/policy/trainer/sft_trainer.py
@@ -484,23 +484,22 @@ class SFTTrainer(Trainer):
                     loss.backward()
                 loss = loss.detach()
 
-                for model_part in self.model_parts:
-                    """
-                    Do gradient clipping in group for unsymmetric sharding compatibility
-                    """
-                    if self.config.train.optm_grad_norm_clip > 0:
-                        dist_util.gradient_norm_clipping(
-                            # Must pass empty list even if model_part is None,
-                            # GradNorm across pp stages will fail if some rank does not join the barrier
-                            [p for p in model_part.parameters()]
-                            if model_part is not None
-                            else [],
-                            self.config.train.optm_grad_norm_clip,
-                            foreach=True,
-                            pp_mesh=self.parallel_dims.mesh["pp"]
-                            if self.parallel_dims.pp_enabled
-                            else None,
-                        )
+                """
+                Compute the global grad norm on all parameters and then apply
+                gradient clipping using the global grad norm.
+                """
+                if self.config.train.optm_grad_norm_clip > 0:
+                    # Must pass empty list even if model_part is None,
+                    # GradNorm across pp stages will fail if some rank does not join the barrier
+                    all_params = [p for m in self.model_parts for p in m.parameters()]
+                    dist_util.gradient_norm_clipping(
+                        all_params,
+                        self.config.train.optm_grad_norm_clip,
+                        foreach=True,
+                        pp_mesh=self.parallel_dims.mesh["pp"]
+                        if self.parallel_dims.pp_enabled
+                        else None,
+                    )
 
                 self.optimizers.step()
                 self.lr_schedulers.step()


### PR DESCRIPTION
Before this PR, the gradient clipping is operated at the granularity of model parts.
For each model part, we will compute the grad norms of that model part, and then clip on the parameters in the model part.

This PR computes the global grad norm among all model parts, and the use the global grad norm to clip all gradients.

The primary purpose is to match the torchtitan implementation here: https://github.com/pytorch/torchtitan/blob/main/torchtitan/train.py#L454C13-L454C66

This is also the preferred way to perform gradient clipping instead of clip different subset of parameters independently: https://www.lunartech.ai/blog/mastering-gradient-clipping-enhancing-neural-networks-for-optimal-training
This is because the overall gradient direction is preserved with the global norm.