### PR TITLE
fix: qwen2.5-vl torch.compile of GRPO

### DIFF
--- a/cosmos_rl/policy/model/qwen2_5_vl/parallelize.py
+++ b/cosmos_rl/policy/model/qwen2_5_vl/parallelize.py
@@ -454,7 +454,9 @@ def apply_compile(model: nn.Module, fullgraph: bool = True):
     # ``model.visual`` could get deleted by pipeline split
     if model.visual is not None:
         for layer_id, transformer_block in model.visual.blocks.named_children():
-            transformer_block = torch.compile(transformer_block, fullgraph=fullgraph)
+            transformer_block = torch.compile(
+                transformer_block, fullgraph=fullgraph, dynamic=True
+            )
             model.visual.blocks.register_module(layer_id, transformer_block)
 
     logger.info("Each TransformerBlock compiled with torch.compile")

--- a/cosmos_rl/policy/trainer/grpo_trainer.py
+++ b/cosmos_rl/policy/trainer/grpo_trainer.py
@@ -264,6 +264,7 @@ class GRPOTrainer(Trainer):
         self.is_master_replica = True
         self.prepare_shard_infos_for_weight_sync_insts()
 
+    @torch.no_grad()
     def prepare_shard_infos_for_weight_sync_insts(self):
         keys_n_ranks = []
         for name, tensor_or_callable in self.model.weight_sync_transforms:


### PR DESCRIPTION
Torch compilation of visual encoder is constrained for dynamic shape input. We can enable `dynamic=True` option for torch.compile.