### PR TITLE
Add DeepEP support based on megatron implementation. [Part 1]

### DIFF
--- a/cosmos_rl/policy/kernel/megatron_moe/README.md
+++ b/cosmos_rl/policy/kernel/megatron_moe/README.md
@@ -1,0 +1,467 @@
+# Overview of megatron_moe
+
+megatron_moe is forked from [megatron/core/transformer/moe](https://github.com/NVIDIA/Megatron-LM/blob/main/megatron/core/transformer/moe) with minor modifications to remove dependencies on megatron core.
+The following contents are the original [README.md](https://github.com/NVIDIA/Megatron-LM/blob/main/megatron/core/transformer/moe/README.md)
+
+# Megatron Core MoE
+
+Megatron-Core MoE provides comprehensive parallelism strategies, seamlessly integrating Expert Parallelism with tensor, data, sequence, and pipeline parallelism. With MCore v0.9, we've achieved remarkable performance of **468 TFLOPS** for Mixtral 8X7B bf16 training. Additionally, we support state-of-the-art MoE model architectures including DeepSeek-V3 and Qwen-MoE.
+
+### What's New
+- **Support for DeepSeek-V3 architecture**
+  - Enable TP for MLA and DeepSeek-V3
+  - Support aux-loss-free load balancing strategy
+  - Support node-limited routing
+  - Support Multi-Token Prediction (MTP)
+- **Support DeepSeek's DeepEP for efficient token dispatching and combining**
+- Add fusion for token permutation and unpermutation
+- Support Uneven virtual pipeline parallel split
+- Support output-discarding checkpointing on some submodules
+
+### Parallelism
+- **Expert Parallelism**
+    - A specific method of parallelism for MoE models, where experts are partitioned onto different workers and each worker processes a different batch of training samples, each worker process one or more experts for each MoE layer.
+- **3D Parallelism**: Data Parallelism, Tensor Parallelism, Pipeline Parallelism
+    - Note: When using MoE with expert parallelism and tensor parallelism, sequence parallelism must be enabled.
+- **Context Parallelism**:
+    - Split the sequence dimension to support long context training.
+- **Richer parallel mappings**: EP can be combined with DP/TP/PP/CP for handling larger MoE variants.
+- **MoE Parallel Folding**: Support for setting different parallelism strategies for Attention and MoE components, enabling more flexible and efficient model sharding. See detailed documentation below.
+- **Full distributed optimizer support.**
+
+### Router and Load Balancing
+- Router type:
+    - Top-K MLP router
+- Load Balancing algorithms:
+    - Sinkhorn (S-BASE)
+    - Aux loss / Load balancing loss
+    - Aux-loss-free load balancing strategy
+
+### Performance Optimizations
+- (Experimental) **DeepEP** is integrated for efficient token communication in large-scale MoE training.
+- GroupedGEMM when num local experts > 1
+    - Supported dtype: bf16
+    - Performance improvements for larger MoE models
+- Enable `--tp-comm-overlap` for MoE
+- FP8 training support
+
+### Token Dispatch Mechanism
+- Dropless / No token drop
+- Token drop, with or without padding to capacity
+- Token permutation / Unpermutation fusion
+
+### Ease of use
+- Checkpoint converter for Mixtral models, see the [example](https://github.com/NVIDIA/Megatron-LM/tree/main/examples/mixtral) for details.
+- MoE Layer Frequency to customize the hybrid MoE/Dense layer architecture
+- Distributed checkpoining
+- Per-layer logging
+- Upcycling Support
+
+## Upcoming features
+- TopK Router Fusion
+- Multi-token Prediction
+
+# User Guide
+
+## Usage
+
+### Quick Start
+To train a top-2 MoE model with 8 experts and auxiliary loss, include the following arguments:
+
+```bash
+--num-experts 8
+--expert-model-parallel-size 8
+--moe-grouped-gemm
+--moe-permute-fusion
+--moe-router-load-balancing-type aux_loss # options: aux_loss, sinkhorn, none. Default is aux_loss.
+--moe-router-topk 2
+--moe-aux-loss-coeff 1e-2
+--use-distributed-optimizer
+--moe-token-dispatcher-type alltoall
+```
+
+To enable the token drop mechanism, such as GShard and SwitchTransformer, include the following arguments:
+
+```bash
+--moe-expert-capacity-factor 1.0
+--moe-pad-expert-input-to-capacity # Optional
+```
+
+The following figure illustrates differenting dropping strategies in MCore:
+<!-- This image is uncommented for now as Sphinx cannot resolve this path. Sphinx imports this markdown file, and from the imported location this relative path does not exist anymore. Ideally, this markdown should not live here but rather in the `docs/` directory that Sphinx uses. -->
+<!-- ![Token Droppling Strategies](../../../../docs/source/images/moe/token_drop.png) -->
+
+1. The default dropless strategy will not drop or pad any token.
+2. By setting `--moe-expert-capacity-factor`, the tokens exceed the capacity of expert will be dropped based on their selected probabilities. 
+   The dropping is performed before the token exchange operation between EP ranks when EP > 1. 
+   The formula of capacity is `capacity = num_tokens_per_rank * topk * capacity_factor / num_experts`.
+3. By setting `--moe-pad-expert-input-to-capacity`, the experts with tokens less than capacity will be padded to the capacity.
+
+### Fine-tuning Mixtral Models
+Megatron-Core has full support for Mixtral MoE models, and we provide the checkpoint converter for Mixtral models from huggingface format to MCore format. 
+<!-- See more details in the [mixtral example](../../../../examples/mixtral/README.md). -->
+
+### Distributed Checkpointing
+MCore v0.7 introduced fully parallel and asynchronous saving capabilities to distributed checkpointing, 
+which addresses the issues of low efficiency in the traditional checkpoint saving methods. 
+It also solved the problem of incompatibility between checkpoints of different parallel mappings in the traditional format.
+With the new distributed checkpointing solution, MCore can achieve flexible parallelism configurations by saving and loading the unified format checkpoints.
+Compared to native PyTorch solution, MCore achieves up to 50x reduction in checkpointing overhead.
+
+From MCore v0.8, MoE supports Distributed Checkpointing, which means users can save and load with any combination of parallelism and it is currently available, including expert parallel.
+1. Loading weight and distributed optimizer states with TPxCPxEPxPP resharding with SequentialMLP is supported in version 0.8.
+2. GroupedMLP weight resharding is supported in version 0.8.0 and optimizer state resharding is supported in version 0.10.0. Switching between GroupedMLP/SequentialMLP when loading and saving is partially supported.
+3. TEGroupedMLP has fully support on distributed checkpointing and is fully exchangable with SequentialMLP in version 0.9.0.
+4. Optimizer state resharding cannot do across EP=1 with EP>1 due to the different optimizer type.
+
+Usage
+- `--ckpt-format torch_dist` The main argument, it will attempt to save and load using distributed checkpointing.
+- `--auto-detect-ckpt-format` With this, it can load both distributed checkpointing and legacy checkpointing.
+
+Checkpoint compatibility across SequentialMLP, GroupedMLP, and TEGroupedMLP:
+```text
+    ┌───────────────┐          ┌───────────────┐          ┌───────────────┐     
+    │   GroupedMLP  │          │ SequentialMLP │          │ TEGroupedMLP  │     
+    │               │          │               │          │               │     
+    │               │          │               │          │               │     
+    │ ┌───────────┐ │          │ ┌───────────┐ │          │ ┌───────────┐ │     
+    │ │legacy ckpt│ │          │ │legacy ckpt│ │          │ │legacy ckpt│ │     
+    │ └─────┬─────┘ │          │ └─────┬─────┘ │          │ └─────┬─────┘ │     
+    │       ▼       │          │       ▼       │          │       ▼       │     
+    │  ┌─────────┐  │          │  ┌─────────┐  │          │  ┌─────────┐  │     
+    │  │dist ckpt│  │          │  │dist ckpt│  │          │  │dist ckpt│  │     
+┌──►│  │ weight  │  │◄────────►│  │ weight  │  │◄────────►│  │ weight  │  │◄──┐ 
+│   │  └─────────┘  │          │  └─────────┘  │          │  └─────────┘  │   │ 
+└───┼───────────────┼──────────┼───────────────┼──────────┼───────────────┼───┘ 
+    │┌─────────────┐│          │┌─────────────┐│          │┌─────────────┐│     
+    ││  dist ckpt  ││          ││  dist ckpt  ││          ││  dist ckpt  ││     
+    ││optim states ││          ││optim states ││◄────────►││optim states ││     
+    │└─────────────┘│          │└─────────────┘│          │└─────────────┘│     
+    └───────────────┘          └───────────────┘          └───────────────┘     
+```
+
+Best practices for distributed checkpointing:
+1. Convert a legacy checkpoint to a distributed checkpoint. To achieve this, we can add both `--ckpt-format torch_dist --auto-detect-ckpt-format`, then it will load the legacy one and save as the distributed checkpoint format later when the training progress tries to save checkpoints.
+2. Convert checkpoint of the legacy GroupedMLP to TEGroupedMLP. This is only supported for the weight parts. To achieve this, we can use the above method to convert the legacy checkpoint to a distributed checkpoint of the legacy GroupedMLP. After updating the libraries and using TEGroupedMLP, we can directly load the previously saved checkpoint by adding argument `--no-load-optim`.
+
+### Shared Experts
+MCore v0.9 introduced the shared expert feature. We can enable this feature by setting suitable `--moe-shared-expert-intermediate-size`.
+
+The parallelism patterns of the shared experts follow the settings of the dense part, i.e., the attention module. The shared experts are not distributed but replicated in EP ranks.
+
+We also have an experimental feature that tries to overlap the communications and computations in the shared experts and the dispatcher.
+We can set `--moe-shared-expert-overlap` and use `alltoall` dispatcher to enable it.
+The overlapping relies on the envirionment setting `CUDA_DEVICE_MAX_CONNECTIONS=1`.
+The `AllGather` and `ReduceScatter` communications in the shared experts are overlapped with `permute`/`unpermute` in the dispatcher.
+The `MLP` computation part in the shared experts are overlapped with the `AlltoAll` communications in the dispatcher.
+Both the forward and the backward pass can overlap. But to get the overlapping in the backward pass, the PyTorch version should `>= 2.2.0`.
+
+### Checkpointing
+A new output-discarding checkpointing method is also supported. This method discards the output memory of certain submodules during the forward pass and recomputes them during the backward pass, which can save memory compared to standard checkpointing. This can be enabled for specific submodules using the `--recompute-granularity selective --recompute-modules [submodule1, submodule2, ...]` argument. The supported submodules are:
+
+* `moe_act`: Recompute the GroupedMLP activation function.
+* `layernorm`: Recompute the input_layernorm and pre_mlp_layernorm (when they are not `IdentityOp`).
+* `mla_up_proj`: Recompute the MLA up projection and RoPE applying parts.
+* `core_attn`: Recompute the core attention submodule (uses standard checkpointing rather than output-discarding).
+* `mlp`: Recompute the dense MLP submodule (uses standard checkpointing rather than output-discarding) which is useful for hybrid-models like DeepSeek-V3.
+* `moe`: Recompute the MoE layer submodule (uses standard checkpointing rather than output-discarding).
+
+### Upcycling
+Use `--moe-use-upcycling` to enable upcycling, which loads the dense model from the `--load` directory, converts it to an MoE model at runtime, and starts training. The converted model is saved to the `--save` path before training begins. Upcycling is built on distributed checkpointing, supporting parallel modes different from existing dense checkpoints, such as arbitrary expert parallelism during upcycling.
+
+In addition to the default upcycling strategy, we also support granular upcycling strategy which is a more state-of-the-art upcycling strategy from [our recent research work](https://arxiv.org/abs/2410.07524). For the default upcycling strategy, we duplicate the existing MLP to multiple experts, with each expert starting from a copy of the MLP. For the granular upcycling strategy, we use `--moe-upcycling-granularity` to specify how many times smaller is the expert hidden size compared with the original dense FFN hidden size. For using granular upcycling strategy, please set `--moe-upcycling-granularity` as a positive integer. If this param is set to 1, it means using the default upcycling strategy.
+
+Note: The MoE model structure is defined through script arguments. All MoE-related arguments (such as `--num-experts`) can be customized; however, other model structure arguments must be consistent with those of the dense model. For granular upcycling strategy, the moe's FFN hidden size should be set as dense FFN hidden size divided by `--moe-upcycling-granularity`.
+
+### Leverage DeepSeek's DeepEP for High-Performance Cross-Node Token Dispatching
+- [DeepSeek-DeepEP](https://github.com/deepseek-ai/deepep) provides a highly optimized implementation for MoE token dispatching and combining operations, specifically designed for large-scale MoE training scenarios.
+- DeepEP is particularly recommended for training large-scale, fine-grained MoE architectures such as DeepSeek-V3 and other advanced MoE models.
+- To enable DeepEP in your training configuration, simply set `--moe-token-dispatcher-type=flex` and `--moe-enable-deepep` in your command line arguments.
+
+### CUDA Graph Support
+CUDA Graph functionality can be enabled through two options:
+
+1. `--enable-cuda-graph`: Automatically captures graphs during runtime (just-in-time)
+2. `--external-cuda-graph`: Requires manual graph capture before runtime (ahead-of-time)
+
+Note: These two options cannot be enabled simultaneously.
+
+For manual capture with `--external-cuda-graph`, refer to the `cuda_graph_capture()` and `cuda_graph_set_manual_hooks()` functions in `megatron/training/training.py`.
+
+For MoE models, certain configurations may prevent CUDA Graph capture of MoE layers. Specifically, when `--moe-expert-capacity-factor` and `--moe-pad-expert-input-to-capacity` are not set, the resulting dynamic shapes make MoE layers uncapturable. In such cases, you can still leverage CUDA Graphs for attention layers by setting `--cuda-graph-scope=attn`, while leaving MoE layers unmodified. Note that the `--cuda-graph-scope` parameter is only applicable when using `--external-cuda-graph` mode.
+
+### MoE Related Arguments
+| Item | Description |
+| --- | --- |
+| --num-experts | Number of Experts in MoE (None means no MoE) |
+| --expert-model-parallel-size | Degree of expert model parallelism. Default is 1. |
+| --moe-ffn-hidden-size | MoE Feed-Forward Network hidden size. Default is None. |
+
+<details>
+<summary> View all MoE related arguments. </summary>
+
+| Item | Description |
+| --- | --- |
+| --num-experts | Number of Experts in MoE (None means no MoE) |
+| --expert-model-parallel-size | Degree of expert model parallelism. Default is 1. |
+| --moe-ffn-hidden-size | MoE Feed-Forward Network hidden size. Default is None. |
+| --expert-tensor-parallel-size | Degree of tensor model parallelism of expert layer. Default is same to --tensor-model-parallel-size. |
+| --moe-layer-freq | Frequency between MoE layers and Dense layers. Accepts either: 1) An integer N for 1:N ratio (one expert layer for every N-1 dense layers), 2) A string "N" for the same ratio, or 3) A string with Python list expression for custom patterns like `([1]*3+[0]*1)*3` which gives [1,1,1,0,1,1,1,0,1,1,1,0] where 1=expert layer and 0=dense layer. Examples: `([0]+[1]*23)` for 1 dense layer followed by 23 experts layers, `([1]*3+[0]*2)*2` for three expert layers followed by two dense layers, repeated twice. Default is 1. |
+| --moe-grouped-gemm | When there are multiple experts per rank, launch multiple local GEMM kernels in multiple streams to improve the utilization and performance with GroupedLinear in TransformerEngine. |
+| --moe-router-load-balancing-type | Determines the load balancing strategy for the router. "aux_loss" corresponds to the load balancing loss used in GShard and SwitchTransformer; "seq_aux_loss" corresponds to the load balancing loss used in DeepSeekV2 and DeepSeekV3, which computes the loss for each individual sample; "sinkhorn" corresponds to the balancing algorithm used in S-BASE, and "none" implies no load balancing. The default is "aux_loss". |
+| --moe-router-dtype | Data type for routing computation and expert output weighted averaging. Options are 'fp32' and 'fp64'. This can improve numerical stability, particularly when using a large number of experts. The throughput/memory impact should be negligible when used with --moe-permute-fusion. Default is None (no dtype promotion). |
+| --moe-router-topk | Number of experts to route to for each token. The default is 2. |  
+| --moe-router-score-function | Score function for MoE routing. Can be "softmax" or "sigmoid". Default is "softmax". |
+| --moe-router-pre-softmax | Enable pre-softmax routing for MoE, which means softmax is before the top-k selection. By default, softmax is done after top-k. |
+| --moe-router-num-groups | Number of groups to divide experts into for group-limited routing. When using group-limited routing: 1) Experts are divided into equal-sized groups, 2) For each token, a subset of groups are selected based on routing scores (sum of top-2 expert scores within each group), 3) From these selected groups, moe_router_topk experts are chosen.  Two common use cases: 1) Device-limited routing: Set equal to expert parallel size (EP) to limit each token to experts on a subset of devices (See DeepSeek-V2: https://arxiv.org/pdf/2405.04434) 2) Node-limited routing: Set equal to number of nodes in EP group to limit each token to experts on a subset of nodes (See DeepSeek-V3: https://arxiv.org/pdf/2412.19437)) |
+| --moe-router-group-topk | Number of selected groups for group-limited routing. |
+| --moe-router-topk-scaling-factor | Scaling factor for routing score in top-k selection, only works when --moe-router-pre-softmax enabled. Defaults to None, which means no scaling. |
+| --moe-router-enable-expert-bias | TopK routing with dynamic per-expert bias in the aux-loss-free load balancing strategy. The routing decision is based on the sum of the routing scores and the expert bias. See https://arxiv.org/abs/2408.15664 for details. |
+| --moe-router-bias-update-rate | The expert bias is updated based on the number of assigned tokens to each expert in a global batch, where the bias is increased for experts with less assigned tokens and decreased for experts with more assigned tokens. Default is 1e-3 same as that used in DeepSeekV3. |
+| --moe-router-force-load-balancing | (Experimental) Force override routing to balance token distribution using random logits for MoE routers, supporting naive top-k and group-limited top-k. This experimental feature is for benchmarking purposes only! |
+| --moe-router-padding-for-fp8 | Pad the routing_map to make sure the number of tokens each expert received is a multiple of 16/32 for FP8 precision. It is suggested to enable this for dropless training with FP8 precision when num_local_experts > 1. This is a more efficient way to pad for FP8 which eliminates the explicit padding in the GroupedMLP layer. |
+| --moe-aux-loss-coeff | Scaling coefficient for the aux loss: a starting value of 1e-2 is recommended. Default is 0.0. |
+| --moe-z-loss-coeff | Scaling coefficient for the z-loss: a starting value of 1e-3 is recommended. Default is None. |
+| --moe-input-jitter-eps | Add noise to the input tensor by applying jitter with a specified epsilon value. Default is None. |
+| --moe-token-dispatcher-type | Determines the token dispatcher type. Choices are "allgather", "alltoall". Default is "allgather". We recommend using 'alltoall' if expert parallelism is applied. We have upgraded the "alltoall" dispatcher in place during MCore v0.9, while the original implementation renamed as "alltoall_seq" is retained until MCore v0.13.|
+| --moe-enable-deepep | (Experimental) Enable DeepSeek/DeepEP for efficient token dispatching and combine in MoE models. Only works with flex token dispatcher by setting --moe-token-dispatcher-type=flex. |
+| --moe-per-layer-logging | Enable per-layer logging for MoE, currently supports auxiliary loss and z loss. |
+| --moe-expert-capacity-factor | The capacity factor for each expert, None means no token will be dropped. Default is None. |
+| --moe-pad-expert-input-to-capacity | Pads the input for each expert to match the expert capacity length, effective only after the --moe-expert-capacity-factor is set. |
+| --moe-token-drop-policy | The policy to drop tokens. Can be either "probs" or "position". If "probs", the tokens with the lowest probabilities will be dropped. If "position", tokens at the end of each batch will be dropped. |
+| --moe-layer-recompute | Enable activation checkpointing for moe_layer, should be used when memory is not sufficient. |
+| --moe-permute-fusion | Fuse token rearrangement ops during token dispatching. |
+| --moe-shared-expert-intermediate-size | Set shared expert total ffn hidden size. It should be equal to `num_shared_experts * ffn_size_of_each_shared_expert` if there are multiple shared experts. None means no shared expert. |
+| --moe-shared-expert-overlap | (Experimental, may change) If this is set, the communications/computations in the shared experts and the dispatcher will overlap (The `alltoall` dispatcher is needed.) Otherwise, the shared expert runs after the routed experts. |
+| --moe-use-upcycling | Load the dense model checkpoint, convert it into an MoE model at runtime and start training. The converted model will be saved to the path specified by `--save` before training begins. Upcycling is implemented on the top of distributed checkpointing, so it supports parallel modes different from the dense model.|
+| --pipeline-model-parallel-layout | (Experimental, may change) A string containing a Python list expression that defines a custom pipeline model parallel layout. |
+| --moe-upcycling-granularity | This param sepecifics how many times smaller is the expert hidden size compared with the original dense FFN hidden size. For using granular upcycling strategy, please set this param as a positive integer. If this param is set to 1, it means using the default upcycling strategy.|
+
+</details>
+
+## MoE training example:
+<details>
+<summary>Click here. </summary>
+
+```bash
+#!/bin/bash
+
+# Runs Mixtral 8x7B model on 32 H100/A100 GPUs
+# The Dropless MoE suffers from an imbalanced token distribution at the early stage of training (the first few hundred iterations), which may lead to poor performance and out-of-memory (OOM) issues.
+# To check the performance of a Dropless MoE model, we should run the model for at least 500 iterations or resume from trained checkpoints.
+
+export CUDA_DEVICE_MAX_CONNECTIONS=1
+
+GPUS_PER_NODE=8
+# Change for multinode config
+MASTER_ADDR=${MASTER_ADDR:-"localhost"}
+MASTER_PORT=${MASTER_PORT:-"6000"}
+NNODES=${NNODES:-"1"}
+NODE_RANK=${RANK:-"0"}
+WORLD_SIZE=$(($GPUS_PER_NODE*$NNODES))
+
+CHECKPOINT_PATH=$1
+TOKENIZER_MODEL=$2
+DATA_PATH=$3
+
+DISTRIBUTED_ARGS=(
+    --nproc_per_node $GPUS_PER_NODE
+    --nnodes $NNODES
+    --node_rank $NODE_RANK
+    --master_addr $MASTER_ADDR
+    --master_port $MASTER_PORT
+)
+
+MODEL_ARGS=(
+    --disable-bias-linear
+    --seq-length 4096
+    --max-position-embeddings 32768
+    --num-layers 32
+    --hidden-size 4096
+    --ffn-hidden-size 14336
+    --num-attention-heads 32
+    --init-method-std 0.01
+    --attention-dropout 0.0
+    --hidden-dropout 0.0
+    --normalization RMSNorm
+    --position-embedding-type rope
+    --swiglu
+    --untie-embeddings-and-output-weights
+    --group-query-attention
+    --num-query-groups 8
+    --no-masked-softmax-fusion
+    --no-position-embedding
+)
+
+MOE_ARGS=(
+    --num-experts 8
+    --expert-model-parallel-size 8
+    --moe-router-load-balancing-type aux_loss # options: aux_loss, sinkhorn, None. Default is aux_loss.
+    --moe-router-topk 2
+    --moe-aux-loss-coeff 1e-2
+    --moe-grouped-gemm
+    --moe-permute-fusion
+)
+
+DATA_ARGS=(
+    --tokenizer-type Llama2Tokenizer
+    --tokenizer-model ${TOKENIZER_MODEL}
+    --data-path $DATA_PATH
+    --split 99990,8,2
+)
+
+TRAINING_ARGS=(
+    --micro-batch-size 1
+    --global-batch-size 128
+    --lr 1e-4
+    --train-iters 500000
+    --lr-decay-iters 320000
+    --lr-decay-style cosine
+    --min-lr 1.0e-5
+    --weight-decay 0.1
+    --lr-warmup-iters 500
+    --clip-grad 1.0
+    --bf16
+    --overlap-grad-reduce
+    --overlap-param-gather
+)
+
+MODEL_PARALLEL_ARGS=(
+    --tensor-model-parallel-size 1
+    --pipeline-model-parallel-size 4
+    --num-layers-per-virtual-pipeline-stage 8
+    --sequence-parallel
+    --use-distributed-optimizer
+)
+
+LOGGING_ARGS=(
+    --log-interval 1 \
+    --save-interval 10000 \
+    --eval-interval 1000 \
+    --eval-iters 10 \
+    --save $CHECKPOINT_PATH \
+    --load $CHECKPOINT_PATH \
+    --tensorboard-dir "${CHECKPOINT_PATH}/tensorboard" \
+    --no-load-optim \
+    --no-load-rng
+)
+
+if [ -n "${WANDB_API_KEY}" ]; then
+    LOGGING_ARGS+=(
+        --wandb-project ${WANDB_PROJECT:-"Mixtral-Finetuning"}
+        --wandb-exp-name ${WANDB_NAME:-"Mixtral_8x7B"} 
+    )
+fi
+
+torchrun ${DISTRIBUTED_ARGS[@]} pretrain_gpt.py \
+    ${MODEL_ARGS[@]} \
+    ${MOE_ARGS[@]} \
+    ${DATA_ARGS[@]} \
+    ${TRAINING_ARGS[@]} \
+    ${MODEL_PARALLEL_ARGS[@]} \
+    ${LOGGING_ARGS[@]}
+```
+</details>
+
+# Performance Best Practice
+
+### Tuning Guide of Parallel Mappings
+
+To find a good parallel mapping that help you achieve a high throughput of a new model, there are some general rule that could help. Here is an overview of properties in different aspects for each parallel strategy.
+
+| Parallel Strategy | Peak Activation Memory          | Weight Memory  | Optimizer states                  | Communication (Per-Layer) |
+|:-----------------:|:-------------------------------:|:--------------:|:---------------------------------:|:-------------------------:|
+| TP                | 1/N (with SP on)                | 1/N            | 1/N                               |        High               |
+| EP                | 1                               | 1/N in MoELayer| 1/N                               |       Medium              |
+| PP                | 1 (>1 with virtual pipeline)    | 1/N            | 1/N                               |       Medium              |
+| CP                | 1/N                             | 1              | 1/N (with distributed optimizer)  |       Medium              |
+| DP                | 1                               | 1              | 1/N (with distributed optimizer)  |        Low                |
+
+For a specific model, the best parallel mapping varies based on the model architecture, trained sequence length and the hardware platform.
+Here we provide some general rules to get better performance:
+1. Keep the model parallism size as small as possible. 
+    - For the large language models, model parallism is often required to prevent OOM, but it will bring communication overhead and hurt performance. 
+    - With distributed optimizer, master weights and optimizer states will be sharded across all DP ranks with slight communication overhead.
+    So try to reduce the model parallism size and increase data parallism size when there are lots of free GPU memory during training.
+2. Ensure the EPxTP communication winthin the NVLink domain.
+    - Communications of EP and TP should remain within the NVLink domain as much as possible, as both are communication-intensive.
+    - If the model is too large and requires scaling across multiple nodes, consider PP before TP and EP. See item 3 for details.
+3. Use Pipeline Parallelism to scale the model further.
+    - Enable Virtual Pipeline Parallelism(VPP) to reduce pp bubbles when PP_size >= 2 by setting `num_layers_per_virtual_pipeline_stage`.
+    - VPP_size tuning: the legal values of vpp_size are all common divisors of num_layers/pp_size, E.g., num_layers=24, pp_size=4, then we can pick vpp_size from {1, 2, 3, 6}. The larger the vpp_size, the lower the pipeline bubbles, while the larger number of P2P communications between each PP stages. Empirically a value in the middle often gives the best trade-off. `VPP_size=num_layers / PP_size / num_layers_per_virtual_pipeline_stage`
+4. Prefer EP over TP for the expert layer when possible:
+    - TP saves more memory than EP, but EP can achieve better GEMM efficiency and less communication overhead than TP.
+    - If EP size increased to the number of expert, the local token permutation/un-permutation for experts computation are omitted.
+    - Simplify the computation graph of MoE layers, more convenient for performing potential comm-computation overlapping.
+    - In practice, EP8TP1 is better than EP4TP2 for 8x7B.
+5. Enable Context Parallelism for long context training.
+    - The efficiency of CP largely depends on whether its communication can be overlapped with computation. 
+    - Empirically, use CP when sequence length >= 8K.
+
+### MoE Parallel Folding
+
+MoE Parallel Folding separates the MoE related parallel groups from Dense groups.
+1. Traditional MoE parallel groups are entangled with dense by using a 5-dimension parallel group generator with default order `tp-cp-ep-dp-pp`. The EP group in MoE is a sub-group of DP in Attention.
+2. With MoE Parallel Folding, we use a parallel group generator with `tp-cp-dp-pp` for Attention, and another with `tp-ep-dp-pp` for MoE. The EPxTP group in MoE is a sub-group of DPxCPxTP in Attention.
+
+By setting `--expert-tensor-parallel-size`, we can set MoE-specific TP size.
+
+#### Advantages of MoE Parallel Folding
+1. The CP and EP group are folded together by defualt, such that:
+    1. It reduces the minimal required GPUs to turn on both CP and EP. For example, the traditional way with (CP=8, EP=8) needs at least 64 GPUs, for now it only requires 8 GPUs.
+    2. The CP and EP communication can be both put in the NVLink domain.
+2. We can set different TP sizes for Attention and MoE part.
+    1. For MoE, EP is often more efficient than TP. But in the traditional way, only using EP can get OOM for most models.
+    2. With MoE parallel folding, we can turn on TP for Attention part and setting TP=1 for MoE models, which often gets better MFU.
+
+### End-to-End Training Practice
+**Use the latest NVIDIA PyTorch or NeMo Docker Image**
+- [NGC PyTorch Image](https://catalog.ngc.nvidia.com/orgs/nvidia/containers/pytorch)
+- [NGC NeMo Image](https://catalog.ngc.nvidia.com/orgs/nvidia/containers/nemo)
+
+**Token Dispatcher Choices**
+- Token Dispatcher sends tokens to the designated expert, involves tensor rearangement and communications.
+- Dispatcher `allgather` is the default option. It achieves better performance and efficiency when only tensor parallelism is used or when the Top-k value is very large.
+- Dispatcher `alltoall` is recommended if expert parallelism is applied.
+- Dispatcher `flex` is a new dispatcher decouples communication group from model parallelism. Currently, only the DeepEP backend is supported for by setting `--moe-enable-deepep`.
+
+**Enable Communication Overlap**
+- Enable `--overlap-param-gather` and `--overlap-grad-reduce` with distributed optimizer.
+- Enable `--tp-comm-overlap` when TP>1.
+- Enable p2p comm overlap when PP > 1 by setting `num_layers_per_virtual_pipeline_stage`.
+
+**Enable GroupedGEMM when num_local_experts>1 with `--moe-grouped-gemm`**
+- GroupedGEMM has higher efficiency than vanilla sequential GEMMs for each expert.
+- Recommend to use the TE version of Grouped GEMM (by upgrading to MCore v0.8 and TE v1.9), which support Gradient Accumulation Fusion and FP8 Training.
+
+**OOM Caused by Token Distribution Imbalance when Training From Scratch**  
+MoE suffers from a severe load imbalance issue when the router is under-trained, leading to the model easily running out of memory (OOM), which typically occurs in the first 100~300 steps when training from scratch. 
+Therefore, there are two recommended ways during the first 200 steps to avoid the OOM problem, which can be removed after the token distribution is more stable:
+1. Increase the `expert-tensor-parallel-size` and decrease `expert-model-parallel-size` to replace EP with TP in MoELayer, this can prevent the load imbalancing between EP ranks. Since current ETP implementation has some memeory overhead, you can further enable activation recomputation only for MoE Layer by adding `--moe-layer-recompute`.
+2. Setting capacity factor to a relatively small number like 1.0 by adding `--moe-token-capacity-factor 1.0`.
+
+**Leverage DeepSeek's DeepEP for High-Performance Cross-Node Token Dispatching**
+- The primary advantage of DeepEP is its cross-node token communication efficiency, which delivers substantial performance improvements when deploying expert parallelism across multiple nodes with large TopK values.
+- To enable DeepEP in your training configuration, simply set `--moe-token-dispatcher-type=flex` and `--moe-enable-deepep` in your command line arguments.
+
+**FP8 Training Best Practice**
+- Using latest version of [TransformerEngine](https://github.com/NVIDIA/TransformerEngine).
+- Enable router padding with `--moe-router-padding-for-fp8` to reduce padding overhead.
+- Enable native FP8 weights with `--fp8-param-gather` to reduce weights memory cost.
+
+### Reference Best Parallel Mapping
+
+Here are the reference parallel mappings of MCore v0.8 for Mixtral 8x7B and 8x22B models:
+|        Model            | Vocab Size| Dispatcher | Precision | #GPUs | SEQ LEN | TP | EP | PP | VP | MBS | GBS |
+|:-----------------------:|:---------:|:----------:|:---------:|:-----:|:-------:|:--:|:--:|:--:|:--:|:---:|:---:|
+| Mixtral 8x7B(Dropless)  |   32K     | All-to-All | BF16      | 64    | 4096    | 1  | 8  | 4  | 8  | 1   | 256 |
+| Mixtral 8x22B(Dropless) |   32K     | All-to-All | BF16      | 128   | 4096    | 4  | 2  | 8  | 7  | 1   | 256 |
+
+Detailed Benchmark Information:  
+Server:
+- 8xH100 80GB HBM3 
+- NVLink 4th Generation
+- InfiniBand 8x400 Gbit/s
+
+Docker Image:
+- PyTorch 24.09 with TransformerEngine v1.11

--- a/cosmos_rl/policy/kernel/megatron_moe/__init__.py
+++ b/cosmos_rl/policy/kernel/megatron_moe/__init__.py
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/cosmos_rl/policy/kernel/megatron_moe/fused_a2a.py
+++ b/cosmos_rl/policy/kernel/megatron_moe/fused_a2a.py
@@ -1,0 +1,286 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Portions of this code are from DeepSeek DeepEP project
+# Copyright (c) 2025 DeepSeek
+# Licensed under the MIT License - https://github.com/deepseek-ai/DeepEP/blob/main/LICENSE
+
+import os
+
+try:
+    from deep_ep import Buffer
+    from deep_ep.utils import EventHandle, EventOverlap
+
+    HAVE_DEEP_EP = True
+    Buffer.set_num_sms(int(os.environ.get("DEEP_EP_SM_NUMS", 20)))
+except ImportError:
+    HAVE_DEEP_EP = False
+
+import torch
+
+_buffer = None
+
+
+def get_hidden_bytes(x: torch.Tensor) -> int:
+    """Calculate the number of hidden bytes for a tensor.
+
+    Args:
+        x (torch.Tensor): Input tensor
+
+    Returns:
+        int: Number of hidden bytes
+    """
+    return x.size(1) * max(x.element_size(), 2)
+
+
+def get_buffer(group: torch.distributed.ProcessGroup, hidden_bytes: int):
+    """Get or create a buffer for all-to-all communication.
+
+    Args:
+        group (torch.distributed.ProcessGroup): Process group for communication
+        hidden_bytes (int): Number of hidden bytes needed
+
+    Returns:
+        Buffer: Communication buffer
+    """
+    global _buffer
+    num_nvl_bytes, num_rdma_bytes = 0, 0
+    for config in (
+        Buffer.get_dispatch_config(group.size()),
+        Buffer.get_combine_config(group.size()),
+    ):
+        # Split long line for PEP8 compliance
+        num_nvl_bytes = max(
+            config.get_nvl_buffer_size_hint(hidden_bytes, group.size()), num_nvl_bytes
+        )
+        num_rdma_bytes = max(
+            config.get_rdma_buffer_size_hint(hidden_bytes, group.size()), num_rdma_bytes
+        )
+
+    # Allocate buffer if not existed or not enough buffer
+    # NOTES: the adaptive routing configuration of the network **must be off**
+    if (
+        _buffer is None
+        or _buffer.group != group
+        or _buffer.num_nvl_bytes < num_nvl_bytes
+        or _buffer.num_rdma_bytes < num_rdma_bytes
+    ):
+        _buffer = Buffer(group, num_nvl_bytes, num_rdma_bytes)
+    return _buffer
+
+
+class FusedDispatch(torch.autograd.Function):
+    """Fused dispatch operation for MoE routing combining computation and communication."""
+
+    @staticmethod
+    def forward(
+        ctx,
+        x,
+        token_indices,
+        token_probs,
+        num_experts,
+        group,
+        async_finish=False,
+        allocate_on_comm_stream=False,
+    ):
+        """Forward pass of fused dispatch."""
+        previous_event = None
+        if async_finish:
+            previous_event = EventOverlap(EventHandle())
+        # Calculate layout before actual dispatch
+        buffer = get_buffer(group, get_hidden_bytes(x))
+        (
+            num_tokens_per_rank,
+            num_tokens_per_rdma_rank,
+            num_tokens_per_expert,
+            is_token_in_rank,
+            event,
+        ) = buffer.get_dispatch_layout(
+            token_indices,
+            num_experts,
+            previous_event=previous_event,
+            async_finish=async_finish,
+            allocate_on_comm_stream=allocate_on_comm_stream,
+        )
+
+        # Do MoE dispatch
+        # NOTES: the CPU will wait for GPU's signal to arrive,
+        # so this is not compatible with CUDA graph
+        (
+            recv_x,
+            recv_token_indices,
+            recv_token_probs,
+            num_recv_tokens_per_expert_list,
+            handle,
+            after_event_overlap,
+        ) = buffer.dispatch(
+            x,
+            topk_idx=token_indices,
+            topk_weights=token_probs,  # DeepEP only supports float32 probs
+            num_tokens_per_rank=num_tokens_per_rank,
+            num_tokens_per_rdma_rank=num_tokens_per_rdma_rank,
+            is_token_in_rank=is_token_in_rank,
+            num_tokens_per_expert=num_tokens_per_expert,
+            previous_event=event,  # wait in deepep::intra/inter_dispatch
+            async_finish=async_finish,
+            allocate_on_comm_stream=allocate_on_comm_stream,
+        )
+
+        # Make sure current stream is synchronized
+        if async_finish:
+            after_event_overlap.current_stream_wait()
+
+        # Save for backward
+        ctx.group = group
+        ctx.handle = handle
+        ctx.async_finish = async_finish
+        ctx.allocate_on_comm_stream = allocate_on_comm_stream
+        tokens_per_expert = torch.tensor(num_recv_tokens_per_expert_list)
+
+        return (recv_x, recv_token_indices, recv_token_probs, tokens_per_expert, handle)
+
+    @staticmethod
+    def backward(
+        ctx,
+        grad_output,
+        grad_token_indices,
+        grad_token_probs,
+        grad_tokens_per_expert,
+        grad_handle,
+    ):
+        """Backward pass of fused dispatch."""
+        buffer = get_buffer(ctx.group, get_hidden_bytes(grad_output))
+        handle = ctx.handle
+        previous_event = None
+        if ctx.async_finish:
+            previous_event = EventOverlap(EventHandle())
+        grad_x, grad_token_probs, after_event = buffer.combine(
+            grad_output.contiguous(),
+            handle,
+            topk_weights=grad_token_probs.float(),
+            previous_event=previous_event,
+            async_finish=ctx.async_finish,
+            allocate_on_comm_stream=ctx.allocate_on_comm_stream,
+        )
+        # Make sure current stream is synchronized
+        if ctx.async_finish:
+            after_event.current_stream_wait()
+        return grad_x, None, grad_token_probs, None, None, None, None
+
+
+class FusedCombine(torch.autograd.Function):
+    """Fused combine operation for MoE output combining computation and communication."""
+
+    @staticmethod
+    def forward(
+        ctx, x, group, handle, async_finish=False, allocate_on_comm_stream=False
+    ):
+        """Forward pass of fused combine."""
+        previous_event = None
+        if async_finish:
+            previous_event = EventOverlap(EventHandle())
+        buffer = get_buffer(group, get_hidden_bytes(x))
+        combined_x, _, after_event = buffer.combine(
+            x,
+            handle=handle,
+            async_finish=async_finish,
+            previous_event=previous_event,
+            allocate_on_comm_stream=allocate_on_comm_stream,
+        )
+        # Make sure current stream is synchronized
+        if async_finish:
+            after_event.current_stream_wait()
+
+        ctx.handle = handle
+        ctx.group = group
+        ctx.async_finish = async_finish
+        ctx.allocate_on_comm_stream = allocate_on_comm_stream
+        return combined_x, None
+
+    @staticmethod
+    def backward(ctx, grad_output, previous_event=None):
+        """Backward pass of fused combine."""
+        previous_event = None
+        if ctx.async_finish:
+            previous_event = EventOverlap(EventHandle())
+        buffer = get_buffer(ctx.group, get_hidden_bytes(grad_output))
+        grad_x, _, _, _, _, after_event = buffer.dispatch(
+            grad_output.contiguous(),
+            handle=ctx.handle,
+            previous_event=previous_event,
+            async_finish=ctx.async_finish,
+            allocate_on_comm_stream=ctx.allocate_on_comm_stream,
+        )
+        # Make sure current stream is synchronized
+        if ctx.async_finish:
+            after_event.current_stream_wait()
+        return grad_x, None, None, None, None
+
+
+if HAVE_DEEP_EP:
+
+    def fused_dispatch(
+        x,
+        token_indices,
+        token_probs,
+        num_experts,
+        group,
+        async_finish=False,
+        allocate_on_comm_stream=False,
+    ):
+        """Perform fused dispatch operation if deep_ep is available.
+
+        Args:
+            x: Input tensor [num_tokens, hidden_size]
+            token_indices: Token routing indices [num_tokens, topk]
+            token_probs: Token routing probabilities [num_tokens, topk]
+            num_experts: Number of experts
+            group: Process group
+            previous_event: Previous CUDA event
+
+        Returns:
+            Result of FusedDispatch
+        """
+        return FusedDispatch.apply(
+            x.contiguous(),
+            token_indices,
+            token_probs,
+            num_experts,
+            group,
+            async_finish,
+            allocate_on_comm_stream,
+        )
+
+    def fused_combine(
+        x, group, handle, async_finish=False, allocate_on_comm_stream=False
+    ):
+        """Perform fused combine operation if deep_ep is available.
+
+        Args:
+            x: Input tensor
+            group: Process group
+            handle: Communication handle
+            previous_event: Previous CUDA event
+
+        Returns:
+            Result of FusedCombine
+        """
+        return FusedCombine.apply(
+            x, group, handle, async_finish, allocate_on_comm_stream
+        )
+
+else:
+    fused_dispatch = None
+    fused_combine = None

--- a/cosmos_rl/policy/kernel/megatron_moe/fused_indices_converter.py
+++ b/cosmos_rl/policy/kernel/megatron_moe/fused_indices_converter.py
@@ -1,0 +1,298 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import math
+
+import torch
+import triton
+import triton.language as tl
+
+
+# Assign a block to a row([1,topk]), generate a local routing map([1,num_of_local_experts])
+@triton.jit
+def _indices_to_multihot_kernel(
+    indices_ptr,
+    probs_in_indices_ptr,
+    multihot_indices_ptr,  # bool
+    probs_in_multihot_ptr,
+    position_map_ptr,
+    num_of_local_experts: tl.constexpr,
+    num_of_local_experts_next_power_of_2: tl.constexpr,
+    topk: tl.constexpr,
+    topk_next_power_of_2: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+):
+    """
+    Triton kernel for converting indices to multihot representation.
+
+    Input:
+        indices: [num_of_tokens, topk]
+        probs_in_indices: [num_of_tokens, topk]
+    Output:
+        multihot_indices: [num_of_tokens, num_of_local_experts]
+        probs_in_multihot: [num_of_tokens, num_of_local_experts]
+
+    Assume that topk = 2 , num_of_local_experts = 4, num_of_tokens = 2,
+    then the kernel can process the following conversion:
+
+    Input Example:
+        indices = [
+                [0, 1],
+                [1, 2]
+            ]
+        probs_in_indices = [
+                [0.1, 0.2],
+                [0.3, 0.4]
+            ]
+    Output Example:
+        multihot_indices = [
+                [1, 1, -1, -1],
+                [-1, 1, 1, -1]
+            ]
+        probs_in_multihot = [
+                [0.1, 0.2, 0.0, 0.0],
+                [0.0, 0.3, 0.4, 0.0]
+            ]
+    """
+    # Prepare the [0, topk) row
+    topk_row = tl.arange(0, topk_next_power_of_2)
+    topk_row = tl.where(topk_row < topk, topk_row, -1)
+    topk_row_mask = topk_row != -1
+    # Prepare the [0, num_of_local_experts) row
+    num_exp_row = tl.arange(0, num_of_local_experts_next_power_of_2)
+    num_exp_row = tl.where(num_exp_row < num_of_local_experts, num_exp_row, -1)
+    num_exp_row_mask = num_exp_row != -1
+
+    # Load a [1, topk] row from the indices buffer
+    row_idx = tl.program_id(0)
+    indices_row = tl.load(indices_ptr + row_idx * topk + topk_row, mask=topk_row_mask)
+    indices_row = tl.where(topk_row_mask, indices_row, -1)
+    probs_row = tl.load(
+        probs_in_indices_ptr + row_idx * topk + topk_row, mask=topk_row_mask
+    )
+
+    # Get the position of the each index in the indices_row, which is saved for backwards
+    position_row = tl.where(indices_row != -1, topk_row, -1)
+    # Mask of the valid indices
+    mask = (indices_row != -1) & (indices_row < num_of_local_experts)
+
+    row_idx_offset = row_idx * num_of_local_experts
+    # Store to initialize
+    tl.store(
+        multihot_indices_ptr + row_idx_offset + num_exp_row, 0, mask=num_exp_row_mask
+    )
+    tl.store(
+        probs_in_multihot_ptr + row_idx_offset + num_exp_row, 0, mask=num_exp_row_mask
+    )
+    tl.store(position_map_ptr + row_idx_offset + num_exp_row, -1, mask=num_exp_row_mask)
+    # Use barrier to make sure the initialization is done
+    tl.debug_barrier()
+    # Store the indices and probs_in_indices
+    tl.store(multihot_indices_ptr + row_idx_offset + indices_row, 1, mask)
+    tl.store(probs_in_multihot_ptr + row_idx_offset + indices_row, probs_row, mask)
+    # Store the position of the position_row for backwards
+    tl.store(position_map_ptr + row_idx_offset + indices_row, position_row, mask)
+
+
+# Assign a block to a row([1,topk]), generate a probs_indices([1,topk])
+@triton.jit
+def _multihot_to_indices_kernel(
+    probs_in_multihot_ptr,
+    position_map_ptr,
+    probs_indices_ptr,
+    num_of_local_experts: tl.constexpr,
+    num_of_local_experts_next_power_of_2: tl.constexpr,
+    topk: tl.constexpr,
+    topk_next_power_of_2: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+):
+    """
+    Triton kernel for converting multihot representation to indices.
+
+    Input:
+        probs_in_multihot: [num_of_tokens, num_of_local_experts]
+        position_map: [num_of_tokens, num_of_local_experts]
+    Output:
+        probs_indices: [num_of_tokens, topk]
+
+    Assume that topk = 2 , num_of_local_experts = 4, num_of_tokens = 2,
+    then the kernel can process the following conversion:
+
+    Input Example:
+        probs_in_multihot = [
+                [0.7, 0.8, 0.0, 0.0],
+                [0.0, 0.1, 0.9, 0.0]
+            ]
+        position_map = [
+                [1, 1, -1, -1],
+                [-1, 1, 1, -1]
+            ]
+    Output Example:
+        probs_indices = [
+                [0.7, 0.8],
+                [0.1, 0.9]
+            ]
+    """
+    # Prepare the [0, topk) row
+    topk_row = tl.arange(0, topk_next_power_of_2)
+    topk_row = tl.where(topk_row < topk, topk_row, -1)
+    topk_row_mask = topk_row != -1
+    # Prepare the [0, num_of_local_experts) row
+    num_exp_row = tl.arange(0, num_of_local_experts_next_power_of_2)
+    num_exp_row = tl.where(num_exp_row < num_of_local_experts, num_exp_row, -1)
+    num_exp_row_mask = num_exp_row != -1
+
+    # Load a [1, num_of_local_experts] row from the local routing map
+    row_idx = tl.program_id(0)
+    ptr_offset = row_idx * num_of_local_experts + num_exp_row
+    probs_in_multihot_row = tl.load(
+        probs_in_multihot_ptr + ptr_offset, mask=num_exp_row_mask
+    )
+
+    # Get the original position of the valid value in the the indices
+    position_map_row = tl.load(position_map_ptr + ptr_offset, mask=num_exp_row_mask)
+    position_map_row = tl.where(num_exp_row_mask, position_map_row, -1)
+    mask = position_map_row != -1
+
+    # Store to initialize
+    tl.store(probs_indices_ptr + row_idx * topk + topk_row, 0, mask=topk_row_mask)
+    # Use barrier to make sure the initialization is done
+    tl.debug_barrier()
+    # Restore the indices and probs_indices
+    tl.store(
+        probs_indices_ptr + row_idx * topk + position_map_row,
+        probs_in_multihot_row,
+        mask,
+    )
+
+
+class IndicesToMultihot(torch.autograd.Function):
+    """Convert moe topk indices to multihot representation.
+
+    This class implements a custom forward and backward propagation
+    operation for efficiently converting indices to multihot
+    representation.
+    It is an experimental feature and may change in future versions.
+    """
+
+    @staticmethod
+    def forward(ctx, indices, probs_indices, num_of_local_experts):
+        """Forward function for IndicesToMultihot
+
+        Convert indices to multihot representation.
+
+        Args:
+            indices: [num_of_tokens, topk]
+            probs_indices: [num_of_tokens, topk]
+            num_of_local_experts: int
+
+        Returns:
+            multihot_indices: [num_of_tokens, num_of_local_experts]
+            probs_in_multihot: [num_of_tokens, num_of_local_experts]
+        """
+        num_of_tokens = indices.shape[0]
+        assert (
+            indices.shape == probs_indices.shape
+        ), "indices and probs_indices must have the same shape"
+        topk = indices.shape[1]
+        multihot_indices = torch.empty(
+            (num_of_tokens, num_of_local_experts), dtype=torch.bool, device="cuda"
+        )
+        probs_in_multihot = torch.empty(
+            (num_of_tokens, num_of_local_experts),
+            dtype=probs_indices.dtype,
+            device="cuda",
+        )
+        position_map = torch.empty(
+            (num_of_tokens, num_of_local_experts), dtype=torch.int32, device="cuda"
+        )
+        # Compute the next power of 2 for the topk and num_of_local_experts
+        topk_next_power_of_2 = 2 ** int(math.ceil(math.log2(topk)))
+        num_of_local_experts_next_power_of_2 = 2 ** int(
+            math.ceil(math.log2(num_of_local_experts))
+        )
+        grid = (num_of_tokens,)
+        _indices_to_multihot_kernel[grid](
+            indices,
+            probs_indices,
+            multihot_indices,
+            probs_in_multihot,
+            position_map,
+            num_of_local_experts,
+            num_of_local_experts_next_power_of_2,
+            topk,
+            topk_next_power_of_2,
+            BLOCK_SIZE=32,  # use only 1 warp per block
+            num_warps=1,
+        )
+
+        ctx.save_for_backward(position_map)
+        ctx.num_of_tokens = num_of_tokens
+        ctx.num_of_local_experts = num_of_local_experts
+        ctx.topk = topk
+        return multihot_indices, probs_in_multihot
+
+    @staticmethod
+    def backward(ctx, grad_multihot_indices, grad_probs_in_multihot):
+        """Backward function for IndicesToMultihot
+
+        Convert multihot probs representation to indices.
+        indices is ignored in the backward function.
+
+        Args:
+            grad_multihot_indices: [num_of_tokens, num_of_local_experts]
+            grad_probs_in_multihot: [num_of_tokens, num_of_local_experts]
+
+        Returns:
+            grad_probs_indices: [num_of_tokens, topk]
+        """
+        position_map = ctx.saved_tensors[0]
+        num_of_tokens = ctx.num_of_tokens
+        num_of_local_experts = ctx.num_of_local_experts
+        topk = ctx.topk
+
+        # Initialize the gradient of the indices and probs_indices
+        grad_probs_indices = torch.empty(
+            (num_of_tokens, topk), dtype=grad_probs_in_multihot.dtype, device="cuda"
+        )
+        # Compute the next power of 2 for the topk and num_of_local_experts
+        topk_next_power_of_2 = 2 ** int(math.ceil(math.log2(topk)))
+        num_of_local_experts_next_power_of_2 = 2 ** int(
+            math.ceil(math.log2(num_of_local_experts))
+        )
+
+        grid = (num_of_tokens,)
+        _multihot_to_indices_kernel[grid](
+            # if the grad_probs_in_multihot is all-one/all-zero,
+            # overlapping stride will cause error without contiguous()
+            grad_probs_in_multihot.contiguous(),
+            position_map,
+            grad_probs_indices,
+            num_of_local_experts,
+            num_of_local_experts_next_power_of_2,
+            topk,
+            topk_next_power_of_2,
+            BLOCK_SIZE=32,  # use only 1 warp per block
+            num_warps=1,
+        )
+        return None, grad_probs_indices, None, None
+
+
+def fused_indices_to_multihot(indices, probs_indices, num_of_local_experts):
+    """Convert moe topk indices to multihot representation.
+
+    This function is an experimental feature and may change in future versions.
+    """
+    return IndicesToMultihot.apply(indices, probs_indices, num_of_local_experts)

--- a/cosmos_rl/policy/kernel/megatron_moe/moe_utils.py
+++ b/cosmos_rl/policy/kernel/megatron_moe/moe_utils.py
@@ -1,0 +1,276 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Optional
+
+import torch
+import torch.nn.functional as F
+
+try:
+    from transformer_engine.pytorch import (
+        moe_permute,
+        moe_permute_with_probs,
+        moe_unpermute,
+    )
+
+    HAVE_TE = True
+except ImportError:
+    HAVE_TE = False
+
+
+def permute(
+    tokens,
+    routing_map,
+    probs: Optional[torch.Tensor] = None,
+    num_out_tokens: Optional[int] = None,
+    fused: bool = False,
+    drop_and_pad: bool = False,
+):
+    """Permute the tokens and probs based on the mask.
+    Tokens with the same designated expert will be grouped together.
+    The shape of mask is [tokens, num_experts], it indicates which experts were selected
+    by each token.
+
+    When drop_and_pad=True, in routing_map, the number of non-zeros in each column equals to
+    expert capacity. This function exploits this feature to use ops that support cuda graph.
+
+    Args:
+        tokens (torch.Tensor): The input token tensor, [num_tokens, hidden].
+        routing_map (torch.Tensor): The sparse token to expert mapping, [num_tokens, num_experts].
+        probs (torch.Tensor, optional): The probs tensor, [num_tokens, num_experts].
+        num_out_tokens (int, optional): The number of output tokens. If None, it's set to
+                                        the number of input tokens.
+        fused (bool, optional): Whether use the fused permute function.
+        drop_and_pad (bool, optional): Whether or not the token dispatcher uses token-drop
+                                       and pads the number of tokens to the expert capacity.
+                                       If set to true, routing_map has a fixed number of non-zeros
+                                       in each column.
+
+    Returns:
+        permuted_input (torch.Tensor): The permuted token tensor.
+        permuted_probs (torch.Tensor, optional): The permuted probs tensor.
+        sorted_indices (torch.Tensor): The tensor of a mapping table for sorted indices used to unpermute the tokens.
+    """
+    if fused and probs is None:
+        if not HAVE_TE or moe_permute is None:
+            raise ValueError(
+                "moe_permute is not available. Please install TE >= 2.1.0."
+            )
+        permuted_input, sorted_indices = moe_permute(
+            tokens, routing_map, num_out_tokens=num_out_tokens
+        )
+        return permuted_input, None, sorted_indices
+
+    if fused and probs is not None:
+        if not HAVE_TE or moe_permute_with_probs is None:
+            raise ValueError(
+                "moe_permute_with_probs is not available. Please install TE >= 2.1.0."
+            )
+        return moe_permute_with_probs(
+            tokens, probs, routing_map, num_out_tokens=num_out_tokens
+        )
+
+    num_tokens, hidden = tokens.shape
+    num_experts = routing_map.shape[1]
+    permuted_probs = None
+    if drop_and_pad and num_out_tokens is not None:
+        capacity = num_out_tokens // num_experts
+        assert not routing_map.requires_grad
+        # mask [num_tokens, num_experts] -> [num_experts, num_tokens]
+        routing_map = routing_map.to(dtype=torch.int8).T.contiguous()
+        # use argsort to put indices of all non-zeros in the beginning of list
+        # and keep the first `capacity` number of indices
+        sorted_indices = routing_map.argsort(dim=-1, descending=True, stable=True)[
+            :, :capacity
+        ].contiguous()
+        # flatten from [num_experts, capacity] to 1D
+        sorted_indices = sorted_indices.view(-1)
+
+        if probs is not None:
+            # [num_tokens, num_experts] -> num_experts * num_tokens
+            probs_T_1D = probs.T.contiguous().view(-1)
+            # get 1D indices of the probs selected by routing_map
+            indices_dim0 = torch.arange(
+                num_experts, device=routing_map.device
+            ).unsqueeze(-1)
+            indices_dim1 = sorted_indices.view(num_experts, capacity)
+            indices_1D = (indices_dim0 * num_tokens + indices_dim1).view(-1)
+            # get probs from indices
+            permuted_probs = probs_T_1D.index_select(0, indices_1D)
+    else:
+        # mask [num_tokens, num_experts] -> [num_experts, num_tokens]
+        routing_map = routing_map.bool().T.contiguous()
+
+        # Create a dense expert-to-token mapping from the sparse token-to-expert mapping
+        token_indices = (
+            torch.arange(num_tokens, device=routing_map.device)
+            .unsqueeze(0)
+            .expand(num_experts, -1)
+        )
+        sorted_indices = token_indices.masked_select(routing_map)
+
+        if probs is not None:
+            permuted_probs = probs.T.contiguous().masked_select(routing_map)
+
+    # use the mapping to permute the tokens
+    permuted_input = tokens.index_select(0, sorted_indices)
+
+    return permuted_input, permuted_probs, sorted_indices
+
+
+def unpermute(
+    permuted_tokens: torch.Tensor,
+    sorted_indices: torch.Tensor,
+    restore_shape: torch.Size,
+    probs: torch.Tensor = None,
+    routing_map: torch.Tensor = None,
+    fused: bool = False,
+    drop_and_pad: bool = False,
+):
+    """
+    Restore the original order of tokens after permutation. If probs are provided, it
+    will also apply them to the tokens before restoring the order.
+
+    When drop_and_pad=True, the tensors will have the following properties:
+      - In routing_map, the number of non-zeros in each column equals to expert capacity
+      - The size of sorted_indices equals to num_experts * capacity, each split of `capacity`
+        contains the indices of tokens routed to an expert.
+    This function exploits these features to use ops that support cuda graph.
+
+    Args:
+        permuted_tokens (torch.Tensor): The permuted token tensor.
+        sorted_indices (torch.Tensor): The indices used to sort the tokens.
+        restore_shape (torch.Size): The shape of the unpermuted tensor.
+        probs (torch.Tensor, optional): The unpermuted probs tensor,
+        routing_map (torch.Tensor, optional): Token to expert mapping, shape
+            [num_tokens, num_experts].
+        fused (bool, optional): Whether use the fused unpermute function.
+        drop_and_pad (bool, optional): Whether or not the token dispatcher uses token-drop
+                                       and pads the number of tokens to the expert capacity.
+
+    Returns:
+        torch.Tensor: The tokens restored to their original order.
+    """
+    if fused:
+        if not HAVE_TE or moe_unpermute is None:
+            raise ValueError(
+                "moe_unpermute is not available. Please install TE >= 2.1.0."
+            )
+        return moe_unpermute(
+            permuted_tokens,
+            sorted_indices,
+            merging_probs=probs,
+            restore_shape=restore_shape,
+        )
+
+    _, hidden = restore_shape
+    input_dtype = permuted_tokens.dtype
+
+    if probs is not None:
+        assert routing_map is not None, "Mask must be provided to permute the probs."
+        if drop_and_pad:
+            num_experts = routing_map.size(1)
+            num_permuted_tokens = sorted_indices.size(0)
+            capacity = num_permuted_tokens // num_experts
+            num_unpermuted_tokens = probs.size(0)
+
+            # [num_unpermuted_tokens, num_experts] -> num_experts * num_unpermuted_tokens
+            probs_T_1D = probs.T.contiguous().view(-1)
+
+            # get 1D indices of the probs selected by routing_map
+            indices_dim0 = torch.arange(
+                num_experts, device=routing_map.device
+            ).unsqueeze(-1)
+            indices_dim1 = sorted_indices.view(num_experts, capacity)
+            indices_1D = (indices_dim0 * num_unpermuted_tokens + indices_dim1).view(-1)
+
+            # get probs from indices
+            permuted_probs = probs_T_1D.index_select(0, indices_1D)
+        else:
+            permuted_probs = probs.T.contiguous().masked_select(
+                routing_map.T.contiguous()
+            )
+        # Here may promote permuted_tokens to higher precision (fp32/fp64) if probs is in
+        # higher precision due to moe_router_dtype being enabled. This can lead to
+        # additional GPU memory usage. Use --moe-permute-fusion flag to avoid this extra memory
+        # allocation.
+        permuted_tokens = permuted_tokens * permuted_probs.unsqueeze(-1)
+
+    # Create an output tensor filled with zeros
+    output_tokens = torch.zeros(
+        restore_shape, dtype=permuted_tokens.dtype, device=permuted_tokens.device
+    )
+    # Scatter add the permuted_input back to the original positions
+    output_tokens.scatter_add_(
+        0, sorted_indices.unsqueeze(1).expand(-1, hidden), permuted_tokens
+    )
+    return output_tokens.to(dtype=input_dtype)
+
+
+@torch.compile
+def swiglu(y):
+    y_1, y_2 = torch.chunk(y, 2, -1)
+    return F.silu(y_1) * y_2
+
+
+@torch.compile
+def weighted_swiglu(y, weights):
+    dtype = y.dtype
+    res = swiglu(y) * weights
+    return res.to(dtype)
+
+
+# gradient of tanh approximation of gelu
+# gradient of actual gelu is:
+# 0.5 * (1. + torch.erf(x * 0.70710678)) + 0.3989423 * x * torch.exp(-0.5 * x * x)
+@torch.compile
+def swiglu_back(g, y):
+    y_1, y_2 = torch.chunk(y, 2, -1)
+    return torch.cat(
+        (
+            g * torch.sigmoid(y_1) * (1 + y_1 * (1 - torch.sigmoid(y_1))) * y_2,
+            g * F.silu(y_1),
+        ),
+        -1,
+    )
+
+
+@torch.compile
+def weighted_swiglu_back(g, y, weights):
+    input_dtype = y.dtype
+    w_dtype = weights.dtype
+    input_grad = swiglu_back(g * weights, y)
+    # precison of w may be higher than y and g, so we need to cast g to w_dtype
+    weights_grad = swiglu(y) * g.to(w_dtype)
+    weights_grad = torch.sum(weights_grad, dim=-1, keepdim=True)
+    return input_grad.to(input_dtype), weights_grad.to(w_dtype)
+
+
+class WeightedSwiGLUFunction(torch.autograd.Function):
+    @staticmethod
+    # bias is an optional argument
+    def forward(ctx, input, weights, fp8_input_store):
+        input_for_backward = input.to(torch.float8_e4m3fn) if fp8_input_store else input
+        ctx.save_for_backward(input_for_backward, weights)
+        ctx.ori_input_dtype = input.dtype
+        ctx.fp8_input_store = fp8_input_store
+        return weighted_swiglu(input, weights)
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        input, weights = ctx.saved_tensors
+        input = input.to(ctx.ori_input_dtype) if ctx.fp8_input_store else input
+        tmp, wgrad = weighted_swiglu_back(grad_output, input, weights)
+        return tmp, wgrad, None

--- a/cosmos_rl/policy/kernel/megatron_moe/token_dispatcher.py
+++ b/cosmos_rl/policy/kernel/megatron_moe/token_dispatcher.py
@@ -1,0 +1,616 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from typing import List, Optional, Tuple
+
+import torch
+
+from .fused_a2a import (
+    fused_combine,
+    fused_dispatch,
+)
+from .fused_indices_converter import (
+    fused_indices_to_multihot,
+)
+from .moe_utils import (
+    permute,
+    unpermute,
+)
+
+SHARING_DEEPEP_MANAGER = True
+
+""" We use the following notation throughout this file:
+     H: hidden size
+     B: micro batch size
+     S: sequence length
+     TP: tensor model parallel size
+     EP: expert model parallel size
+     num_local_tokens: S/TP*B
+     num_global_tokens: num_local_tokens*TP*EP
+"""
+
+
+class _DispatchManager(ABC):
+    """
+    A manager class to handle dispatch and combine processes for MoE models.
+
+    DispatcherManager handles token dispatching according to the routing_map of format
+    [num_local_tokens, world_size, num_instances]. The routing_map is a 3D tensor where each
+    element indicates whether a token should be sent to a specific rank.
+
+    num_instances is the maximum number of tokens instances dispatched into a target rank, it
+    can be the number of local experts, or the size of sub_group.
+    """
+
+    @abstractmethod
+    def setup_metadata(self, routing_map: torch.Tensor, probs: torch.Tensor):
+        """Set up metadata of routing_map and probs."""
+        pass
+
+    @abstractmethod
+    def dispatch(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        """Dispatch the hidden_states according to the routing_map."""
+        pass
+
+    @abstractmethod
+    def combine(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        """Combine the hidden_states after expert processing."""
+        pass
+
+    @abstractmethod
+    def get_dispached_metadata(self) -> torch.Tensor:
+        """Get the metadata of the dispatched hidden_states."""
+        pass
+
+    @abstractmethod
+    def get_permuted_hidden_states_by_experts(
+        self, hidden_states: torch.Tensor
+    ) -> torch.Tensor:
+        """Get the permuted hidden states by instances."""
+        pass
+
+    @abstractmethod
+    def get_restored_hidden_states_by_experts(
+        self, hidden_states: torch.Tensor
+    ) -> torch.Tensor:
+        """Get the restored hidden states by instances."""
+        pass
+
+
+class _DeepepManager(_DispatchManager):
+    """
+    A manager class to handle fused all-to-all communication processes for MoE models using
+    DeepEP backend. See https://github.com/deepseek-ai/deepep for more details.
+
+    The workflow of the DeepEP dispatcher is:
+    (1) setup_metadata(): Process routing map and probabilities to prepare dispatch metadata
+    (2) dispatch():
+        - Use fused kernel to permute tokens and perform all-to-all communication in single step
+    (3) get_permuted_hidden_states_by_instances():
+        - Convert routing map and probabilities to multihot format
+        - Permute tokens using fused kernel
+    (4) get_restored_hidden_states_by_instances():
+        - Reverse permutation using fused kernel
+    (5) combine():
+        - Reverse process using fused kernel to unpermute and perform all-to-all in single step
+
+    This implementation uses fused communication kernels (fused_dispatch/fused_combine) that
+    combine permutation and communication operations for improved efficiency compared to
+    separate permute+alltoall steps.
+    """
+
+    def __init__(
+        self,
+        group: torch.distributed.ProcessGroup,
+        router_topk: int,
+        permute_fusion: bool = False,
+        capacity_factor: Optional[float] = None,
+        num_experts: Optional[int] = None,
+        num_local_experts: Optional[int] = None,
+        router_dtype: Optional[str] = None,
+        moe_router_expert_pad_multiple: Optional[int] = None,
+    ):
+        self.group = group
+        self.router_topk = router_topk
+        self.capacity_factor = capacity_factor
+        self.permute_fusion = permute_fusion
+        self.num_experts = num_experts
+        self.num_local_experts = num_local_experts
+        self.router_dtype = router_dtype
+        self.moe_router_expert_pad_multiple = moe_router_expert_pad_multiple
+
+        # Metadata
+        self.token_indices: Optional[torch.Tensor] = None
+        self.token_probs: Optional[torch.Tensor] = None
+        # Handle used for combine operation
+        self.handle = None
+
+        if fused_dispatch is None:
+            raise ImportError(
+                "DeepEP is not installed. Please install DeepEP package from "
+                "https://github.com/deepseek-ai/deepep."
+            )
+
+    def setup_metadata(self, num_local_tokens: int, probs: torch.Tensor):
+        """
+        Process routing map and probabilities to prepare dispatch metadata
+        """
+        probs = probs.reshape(num_local_tokens, self.num_experts)
+        # Convert the format of routing map from multihot to indices.
+        self.token_probs, self.token_indices = torch.topk(
+            probs, self.router_topk, dim=-1
+        )
+        # Mask the indices of dropped tokens with -1
+        if self.capacity_factor is not None:
+            mask = self.token_probs == 0
+            self.token_indices = self.token_indices.masked_fill(mask, -1)
+
+    def dispatch(
+        self,
+        hidden_states: torch.Tensor,
+        async_finish: bool = False,
+        allocate_on_comm_stream: bool = False,
+    ) -> torch.Tensor:
+        """
+        Dispatch the hidden_states
+        """
+        # DeepEP only supports float32 probs
+        if self.token_probs.dtype != torch.float32:
+            if self.token_probs.dtype in [torch.bfloat16, torch.float16]:
+                # print("DeepEP only supports float32 probs, please set --moe-router-dtype=fp32")
+                # TODO: remove this
+                pass
+            self.token_probs = self.token_probs.float()  # downcast or upcast
+        (
+            hidden_states,
+            dispatched_indices,
+            dispatched_probs,
+            num_tokens_per_expert,
+            handle,
+        ) = fused_dispatch(
+            hidden_states,
+            self.token_indices,
+            self.token_probs,
+            self.num_experts,
+            self.group,
+            async_finish=async_finish,
+            allocate_on_comm_stream=allocate_on_comm_stream,
+        )
+        self.handle = handle
+        self.tokens_per_expert = num_tokens_per_expert
+        self.dispatched_indices = dispatched_indices
+        self.dispatched_probs = dispatched_probs
+
+        return hidden_states
+
+    def _indices_to_multihot(self, indices, probs):
+        """
+        Converts a tensor of indices to a multihot vector.
+
+        Args:
+            indices (torch.Tensor): [num_tokens, topk] token indices, where -1 means masked out.
+            probs (torch.Tensor): [num_tokens, topk] token probabilities.
+
+        Returns:
+            Tuple[torch.Tensor, torch.Tensor]:
+                - routing_map: Multihot vector.
+                - probs: Multihot probabilities.
+        """
+        batch_size = indices.shape[0]
+        multihot_routing_map = torch.zeros(
+            (batch_size, self.num_local_experts),
+            dtype=torch.long,
+            device=indices.device,
+        )
+
+        multihot_probs = torch.zeros(
+            (batch_size, self.num_local_experts),
+            dtype=torch.float,
+            device=indices.device,
+        )
+
+        mask = indices != -1
+        valid_indices = indices[mask]
+        row_indices = torch.arange(batch_size, device=indices.device).repeat_interleave(
+            mask.sum(dim=1)
+        )
+        multihot_routing_map[row_indices, valid_indices] = 1
+        multihot_probs[row_indices, valid_indices] = probs[mask]
+        return multihot_routing_map.bool(), multihot_probs
+
+    def get_dispached_metadata(self) -> torch.Tensor:
+        return self.dispatched_indices, self.dispatched_probs
+
+    def get_number_of_tokens_per_expert(self) -> torch.Tensor:
+        """
+        Get the number of tokens per expert.
+        """
+        return self.tokens_per_expert
+
+    def combine(
+        self,
+        hidden_states: torch.Tensor,
+        async_finish: bool = False,
+        allocate_on_comm_stream: bool = False,
+    ) -> torch.Tensor:
+        """
+        Reverse process using fused kernel to unpermute and perform all-to-all in single step
+        """
+        hidden_states, _ = fused_combine(
+            hidden_states,
+            self.group,
+            self.handle,
+            async_finish=async_finish,
+            allocate_on_comm_stream=allocate_on_comm_stream,
+        )
+        # Release the handle after combine operation
+        self.handle = None
+        return hidden_states
+
+    def get_permuted_hidden_states_by_experts(
+        self, hidden_states: torch.Tensor
+    ) -> torch.Tensor:
+        """
+        - Convert routing map and probabilities to multihot format
+        - Permute tokens using fused kernel
+        """
+        if self.permute_fusion:
+            self.dispatched_routing_map, self.dispatched_probs = (
+                fused_indices_to_multihot(
+                    self.dispatched_indices,
+                    self.dispatched_probs,
+                    self.num_local_experts,
+                )
+            )
+        else:
+            self.dispatched_routing_map, self.dispatched_probs = (
+                self._indices_to_multihot(
+                    self.dispatched_indices, self.dispatched_probs
+                )
+            )
+        if self.moe_router_expert_pad_multiple:
+            with torch.cuda.nvtx.range("pad_routing_map"):
+                from megatron.core.transformer.moe.moe_utils import pad_routing_map
+
+                self.dispatched_routing_map = pad_routing_map(
+                    self.dispatched_routing_map, self.moe_router_expert_pad_multiple
+                )
+            # self.tokens_per_expert = self.dispatched_routing_map.sum(dim=0)
+            self.tokens_per_expert = (
+                torch.ceil(self.tokens_per_expert / self.moe_router_expert_pad_multiple)
+                * self.moe_router_expert_pad_multiple
+            )
+            self.tokens_per_expert = self.tokens_per_expert.long()
+
+        self.hidden_shape_before_permute = hidden_states.shape
+        assert (
+            self.dispatched_probs.dtype == torch.float32
+        ), "DeepEP only supports float32 probs"
+        hidden_states, permuted_probs, self.reversed_mapping_for_combine = permute(
+            hidden_states,
+            self.dispatched_routing_map,
+            probs=self.dispatched_probs,
+            num_out_tokens=self.tokens_per_expert.sum().item(),
+            fused=self.permute_fusion,
+        )
+        if self.router_dtype == "fp64":
+            permuted_probs = permuted_probs.to(torch.float64)
+        return hidden_states, permuted_probs
+
+    def get_restored_hidden_states_by_experts(
+        self, hidden_states: torch.Tensor
+    ) -> torch.Tensor:
+        """
+        Restore the hidden states to their original ordering before expert processing
+        """
+        hidden_states = unpermute(
+            hidden_states,
+            self.reversed_mapping_for_combine,
+            restore_shape=self.hidden_shape_before_permute,
+            routing_map=self.dispatched_routing_map,
+            fused=self.permute_fusion,
+        )
+        return hidden_states
+
+
+@dataclass
+class MoEConfig:
+    moe_enable_deepep: bool = True
+    """Enable DeepEP for efficient token dispatching and combine in MoE models."""
+
+    moe_permute_fusion: bool = False
+    """Fuse token rearrangement ops during token dispatching."""
+
+    moe_expert_capacity_factor: Optional[float] = None
+    """moe_expert_capacity_factor (float): The capacity factor for each expert, None means no token
+    will be dropped. The default is None."""
+
+    moe_router_topk: int = 2
+    """Number of experts to route to for each token."""
+
+    moe_router_expert_pad_multiple: Optional[int] = None
+    """Number of tokens to pad to a multiple of for each expert."""
+
+    num_moe_experts: int = 64
+    """Number of experts to use for MoE layer. When set, it replaces MLP with MoE layer. Set to None
+    for no MoE."""
+
+    moe_router_dtype: str = "fp32"
+    """Data type for routing and expert output weighted averaging. Using fp32 or fp64 can
+    improve stability especially when the number of experts is large (e.g. finegrained-moe).
+    None means no changes for dtype."""
+
+
+class MoEFlexTokenDispatcher:
+    """
+    Flex token dispatcher using DeepEP.
+    """
+
+    shared_comm_manager: _DeepepManager = (
+        None  # shared by all instances of MoEFlexTokenDispatcher
+    )
+
+    def __init__(
+        self,
+        num_local_experts: int,
+        local_expert_indices: List[int],
+        config: MoEConfig,
+        ep_group: torch.distributed.ProcessGroup,
+    ):
+        """
+        Initialize the Flex token dispatcher.
+
+        Args:
+            num_local_experts (int): Number of local experts on the current device.
+            local_expert_indices (List[int]): Indices of local experts on the current device.
+            config (MoEConfig): Configuration for the transformer model.
+            group (torch.distributed.ProcessGroup): Process group for MoE operations.
+        """
+        self.config = config
+        self.shared_experts = None
+
+        self.group = ep_group
+        self.ep_size = ep_group.size()
+        # use model_comm_pgs.expt_tp_group as tensor parallel group in this module.
+        # self.tp_group = tp_group
+        # self.tp_group = tp_ep_group
+
+        self.tp_size = 1  # TP is not used in Cosmos-R1
+        # self.tp_rank = self.tp_group.rank()
+
+        self.num_local_experts = num_local_experts
+        self.local_expert_indices = local_expert_indices
+        assert (
+            self.tp_size * self.ep_size > 1
+        ), "Flex token dispatcher requires TPxEP > 1"
+        assert self.config.moe_enable_deepep, "DeepEP is not enabled. Please set --moe-enable-deepep to use DeepEP backend."
+        if SHARING_DEEPEP_MANAGER:
+            if MoEFlexTokenDispatcher.shared_comm_manager is None:
+                MoEFlexTokenDispatcher.shared_comm_manager = _DeepepManager(
+                    group=ep_group,
+                    router_topk=self.tp_size * self.config.moe_router_topk,
+                    permute_fusion=self.config.moe_permute_fusion,
+                    capacity_factor=self.config.moe_expert_capacity_factor,
+                    num_experts=self.tp_size * self.config.num_moe_experts,
+                    num_local_experts=self.num_local_experts,
+                    router_dtype=self.config.moe_router_dtype,
+                    moe_router_expert_pad_multiple=self.config.moe_router_expert_pad_multiple,
+                )
+            self._comm_manager = MoEFlexTokenDispatcher.shared_comm_manager
+        else:
+            self._comm_manager = _DeepepManager(
+                group=ep_group,
+                router_topk=self.tp_size * self.config.moe_router_topk,
+                permute_fusion=self.config.moe_permute_fusion,
+                capacity_factor=self.config.moe_expert_capacity_factor,
+                num_experts=self.tp_size * self.config.num_moe_experts,
+                num_local_experts=self.num_local_experts,
+                router_dtype=self.config.moe_router_dtype,
+                moe_router_expert_pad_multiple=self.config.moe_router_expert_pad_multiple,
+            )
+
+    def _initialize_metadata(
+        self, num_local_tokens: int, probs: torch.Tensor
+    ) -> torch.Tensor:
+        """
+        Initialize the routing map and probs to a unified format covering the TPxEP group.
+        This design decouples the communication group from underlying model parallelism groups,
+        such that the communication strategy of tokens can be agnostic of TP size and EP size.
+        """
+        world_size = self.tp_size * self.ep_size
+        probs = (
+            probs.reshape(num_local_tokens, self.ep_size, 1, self.num_local_experts)
+            .expand(-1, -1, self.tp_size, -1)
+            .reshape(num_local_tokens, world_size, self.num_local_experts)
+        ).contiguous()
+        return probs
+
+    def dispatch_preprocess2(
+        self,
+        hidden_states: torch.Tensor,
+        num_local_tokens: int,
+        token_probs: torch.Tensor,
+        token_indices: torch.Tensor,
+    ):
+        """
+        Preprocesses the hidden states and routing information before dispatching tokens to experts.
+        """
+        self.hidden_shape = hidden_states.shape
+        hidden_states = hidden_states.view(-1, self.hidden_shape[-1])
+        self._comm_manager.token_probs = token_probs
+        self._comm_manager.token_indices = token_indices
+        return hidden_states, self._comm_manager.token_probs
+
+    def dispatch_preprocess(
+        self, hidden_states: torch.Tensor, num_local_tokens: int, probs: torch.Tensor
+    ):
+        """
+        Preprocesses the hidden states and routing information before dispatching tokens to experts.
+        Args:
+            hidden_states (torch.Tensor): Input hidden states to be processed
+            num_local_tokens (int): Number of tokens to be processed
+            probs (torch.Tensor): Routing probabilities for each token-expert pair
+
+        Returns:
+            Tuple containing:
+            - torch.Tensor: Reshaped hidden states
+            - torch.Tensor: Token probabilities from the communication manager
+            - None: Placeholder for compatibility
+        """
+        self.hidden_shape = hidden_states.shape
+        hidden_states = hidden_states.view(-1, self.hidden_shape[-1])
+
+        # Initialize metadata
+        probs = self._initialize_metadata(
+            num_local_tokens=num_local_tokens, probs=probs
+        )
+
+        self._comm_manager.setup_metadata(
+            num_local_tokens=num_local_tokens, probs=probs
+        )
+        return hidden_states, self._comm_manager.token_probs
+
+    def dispatch_all_to_all(
+        self,
+        hidden_states: torch.Tensor,
+        probs: torch.Tensor = None,
+        async_finish: bool = True,
+        allocate_on_comm_stream: bool = True,
+    ):
+        """
+        Performs all-to-all communication to dispatch tokens across expert parallel ranks.
+        """
+        return (
+            self._comm_manager.dispatch(
+                hidden_states, async_finish, allocate_on_comm_stream
+            ),
+            self._comm_manager.dispatched_probs,
+        )
+
+    def dispatch_postprocess(self, hidden_states: torch.Tensor):
+        """
+        Post-processes the dispatched hidden states after all-to-all communication.
+
+        This method retrieves the permuted hidden states by experts, calculates the number of tokens
+        per expert, and returns the processed data ready for expert processing.
+        """
+        global_input_tokens, permuted_probs = (
+            self._comm_manager.get_permuted_hidden_states_by_experts(hidden_states)
+        )
+        tokens_per_expert = self._comm_manager.get_number_of_tokens_per_expert()
+        return global_input_tokens, tokens_per_expert, permuted_probs
+
+    def token_permutation(
+        self, hidden_states: torch.Tensor, num_local_tokens: int, probs: torch.Tensor
+    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        """
+        Permutes tokens according to probs and dispatches them to experts.
+
+        This method implements the token permutation process in three steps:
+        1. Preprocess the hidden states
+        2. Perform all-to-all communication to dispatch tokens
+        3. Post-process the dispatched tokens for expert processing
+        """
+        hidden_states, _ = self.dispatch_preprocess(
+            hidden_states=hidden_states, num_local_tokens=num_local_tokens, probs=probs
+        )
+        hidden_states, _ = self.dispatch_all_to_all(
+            hidden_states, async_finish=False, allocate_on_comm_stream=False
+        )
+        global_input_tokens, tokens_per_expert, permuted_probs = (
+            self.dispatch_postprocess(hidden_states)
+        )
+
+        return global_input_tokens, tokens_per_expert, permuted_probs
+
+    def token_permutation2(
+        self,
+        hidden_states: torch.Tensor,
+        num_local_tokens: int,
+        token_probs: torch.Tensor,
+        token_indices: torch.Tensor,
+    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        """
+        Permutes tokens according to probs and dispatches them to experts.
+
+        This method implements the token permutation process in three steps:
+        1. Preprocess the hidden states
+        2. Perform all-to-all communication to dispatch tokens
+        3. Post-process the dispatched tokens for expert processing
+        """
+        hidden_states, _ = self.dispatch_preprocess2(
+            hidden_states=hidden_states,
+            num_local_tokens=num_local_tokens,
+            token_probs=token_probs,
+            token_indices=token_indices,
+        )
+        hidden_states, _ = self.dispatch_all_to_all(
+            hidden_states, async_finish=False, allocate_on_comm_stream=False
+        )
+        global_input_tokens, tokens_per_expert, permuted_probs = (
+            self.dispatch_postprocess(hidden_states)
+        )
+
+        return global_input_tokens, tokens_per_expert, permuted_probs
+
+    def combine_preprocess(self, hidden_states: torch.Tensor):
+        """
+        Pre-processes the hidden states before combining them after expert processing.
+
+        This method restores the hidden states to their original ordering before expert processing
+        by using the communication manager's restoration function.
+        """
+        hidden_states = self._comm_manager.get_restored_hidden_states_by_experts(
+            hidden_states
+        )
+        return hidden_states
+
+    def combine_all_to_all(
+        self,
+        hidden_states: torch.Tensor,
+        async_finish: bool = True,
+        allocate_on_comm_stream: bool = True,
+    ):
+        """
+        Performs all-to-all communication to combine tokens after expert processing.
+        """
+        return self._comm_manager.combine(
+            hidden_states, async_finish, allocate_on_comm_stream
+        )
+
+    def combine_postprocess(self, hidden_states: torch.Tensor):
+        """
+        Post-processes the combined hidden states after all-to-all communication.
+
+        This method reshapes the combined hidden states to match the original input shape.
+        """
+        return hidden_states.view(self.hidden_shape)
+
+    def token_unpermutation(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        """
+        Reverses the token permutation process to restore the original token order.
+
+        This method implements the token unpermutation process in three steps:
+        1. Pre-process the hidden states to restore their original ordering
+        2. Perform all-to-all communication to combine tokens
+        3. Post-process the combined tokens to match the original input shape
+        """
+        hidden_states = self.combine_preprocess(hidden_states)
+        hidden_states = self.combine_all_to_all(hidden_states, False, False)
+        hidden_states = self.combine_postprocess(hidden_states)
+
+        return hidden_states


### PR DESCRIPTION
megatron_moe is forked from [megatron/core/transformer/moe](https://github.com/NVIDIA/Megatron-LM/blob/main/megatron/core/transformer/moe) with minor modifications to remove dependencies on megatron core.