### PR TITLE
add sanity check for train_ack

### DIFF
--- a/cosmos_rl/policy/trainer/grpo_trainer.py
+++ b/cosmos_rl/policy/trainer/grpo_trainer.py
@@ -22,7 +22,6 @@ import torch
 import inspect
 import os
 from cosmos_rl.utils.logging import logger
-from cosmos_rl.utils.util import compute_mfu
 import cosmos_rl.utils.distributed as dist_util
 import time
 import torch.distributed as dist
@@ -46,6 +45,8 @@ from cosmos_rl.utils.util import (
     msgpack_c_long,
     msgunpack_c_long,
     fix_data_type_size,
+    sanitize,
+    compute_mfu,
 )
 from cosmos_rl.utils.parallelism_map import (
     ParallelTopoMapperGroup,
@@ -855,7 +856,7 @@ class GRPOTrainer(Trainer):
                             "weight_step": command.global_step,
                             "total_steps": command.total_steps,
                             "profile_finished": self.profiler.check_finished(),
-                            "report_data": report_data,
+                            "report_data": sanitize(report_data),
                         },
                     ),
                     self.get_alternative_urls(COSMOS_API_POLICY_TRAIN_ACK_SUFFIX),
@@ -1533,7 +1534,6 @@ class GRPOTrainer(Trainer):
 
         # For profiling
         self.profiler.step()
-
         return report_data
 
     @property

--- a/cosmos_rl/utils/util.py
+++ b/cosmos_rl/utils/util.py
@@ -52,6 +52,7 @@ import functools
 from cosmos_rl.utils.logging import logger
 from safetensors import safe_open
 from cosmos_rl.utils.constant import CACHE_DIR
+import math
 
 
 def create_cached_dir_if_needed():
@@ -1020,3 +1021,14 @@ class RollingDict(OrderedDict):
         super().__setitem__(key, value)
         if len(self) > self.maxlen:
             self.popitem(last=False)
+
+
+def sanitize(obj):
+    if isinstance(obj, float):
+        return obj if math.isfinite(obj) else None
+    elif isinstance(obj, dict):
+        return {k: sanitize(v) for k, v in obj.items()}
+    elif isinstance(obj, list):
+        return [sanitize(v) for v in obj]
+    else:
+        return obj


### PR DESCRIPTION
`report_data` may contains `nan, inf` which cause:
```
[rank0]:RuntimeError: [Policy] Failed in in send train ack to controller after retries Out of range float values are not JSON compliant.
```
This will lead to hang of training process.