### PR TITLE
Change default value of rollout seed to 42.

### DIFF
--- a/cosmos_rl/policy/config/__init__.py
+++ b/cosmos_rl/policy/config/__init__.py
@@ -678,7 +678,7 @@ class RolloutConfig(BaseModel):
         choices=["none"],
     )
 
-    seed: Optional[int] = Field(default=None, description="random seed for rollout.")
+    seed: int = Field(default=42, description="random seed for rollout.")
 
     sampling_config: SamplingConfig = Field(default_factory=SamplingConfig)
 


### PR DESCRIPTION
If users don't set rollout `seed` value, we set it to `42`, a certain value, not `None`.