### PR TITLE
Revert "set default value of rollout seed to 42. (#138)"

### DIFF
--- a/cosmos_rl/policy/config/__init__.py
+++ b/cosmos_rl/policy/config/__init__.py
@@ -677,7 +677,7 @@ class RolloutConfig(BaseModel):
         choices=["none", "fp8"],
     )
 
-    seed: int = Field(default=42, description="random seed for rollout.")
+    seed: Optional[int] = Field(default=None, description="random seed for rollout.")
 
     sampling_config: SamplingConfig = Field(default_factory=SamplingConfig)
 


### PR DESCRIPTION
This reverts commit 2a951faa9f7b342e9c9f70a046dbd92ab084a16d.