### PR TITLE
Fix parameter synchronization to include persistent buffers in rollout broadcast

### DIFF
--- a/cosmos_rl/rollout/vllm_rollout/vllm_rollout_worker.py
+++ b/cosmos_rl/rollout/vllm_rollout/vllm_rollout_worker.py
@@ -706,7 +706,7 @@ class vLLMRolloutWorker(RolloutWorkerBase):
 
                 src_rank = self.replica_name_to_rank[src_replica_name]
 
-                for parameter in self.get_underlying_model().parameters():
+                for parameter in self.get_underlying_model().state_dict().values():
                     recv_tensor = parameter
                     if not parameter.is_contiguous():
                         recv_tensor = parameter.contiguous()


### PR DESCRIPTION
## Summary
This PR fixes a synchronization issue in the rollout broadcast mechanism to ensure consistency with vLLM's dummy load mode initialization.

## Problem
In vLLM's dummy load mode, the `initialize_dummy_weights` function performs random initialization on all tensors in `model.state_dict()`, which includes both parameters and persistent buffers. However, our current Rollout-to-Rollout broadcast mechanism only synchronizes tensors from `model.parameters()`, leaving persistent buffers unsynchronized.

## Solution
Modified the parameter iteration from:
```python
for parameter in self.get_underlying_model().parameters():
```
to:
```python
for parameter in self.get_underlying_model().state_dict().values():
```

This change ensures that all tensors in the model's state dictionary (including persistent buffers) are properly synchronized during rollout broadcast, maintaining consistency with vLLM's initialization behavior.

## Impact
- Fixes synchronization inconsistency between parameters and persistent buffers
- Aligns with vLLM's dummy load mode behavior
- Ensures complete model state synchronization during rollout operations
