### PR TITLE
Raise exception when encountering duplicated optimizer state_dict keys

### DIFF
--- a/cosmos_rl/policy/trainer/optm/__init__.py
+++ b/cosmos_rl/policy/trainer/optm/__init__.py
@@ -80,6 +80,7 @@ class OptimizersContainer(Optimizer, Generic[T]):
         all_params = []
         self.model_parts = model_parts
         self.optimizers = [[] for _ in self.model_parts]
+        all_optimizer_keys = set()
         for model_id, (model, optimizer_kwargs_i) in enumerate(
             zip(self.model_parts, optimizer_kwargs)
         ):
@@ -100,6 +101,13 @@ class OptimizersContainer(Optimizer, Generic[T]):
                 for params in parameters_by_mesh.values():
                     optimizer = optimizer_cls(params, **optimizer_kwargs_copy)
                     self.optimizers[model_id].append(optimizer)
+                    # Check if there are duplicated keys from the optimizers.
+                    for optimizer_key in optimizer.state_dict().keys():
+                        if optimizer_key in all_optimizer_keys:
+                            raise ValueError(
+                                f"Duplicated optimizer key is deteced! Key = {optimizer_key}"
+                            )
+                        all_optimizer_keys.add(optimizer_key)
             else:
                 for p in model.parameters():
                     if p.requires_grad:


### PR DESCRIPTION
Given that we might form multiple groups of the parameters in one model part, would like to add checks to ensure that the optimizers from different groups have unique keys. This is because we flattened all optimizer state_dicts in checkpoint saving/loading. So add the check to ensure it is safe to keep the parameter groups.