### PR TITLE
Fix the optimizer check

### DIFF
--- a/cosmos_rl/policy/trainer/optm/__init__.py
+++ b/cosmos_rl/policy/trainer/optm/__init__.py
@@ -102,11 +102,17 @@ class OptimizersContainer(Optimizer, Generic[T]):
                     optimizer = optimizer_cls(params, **optimizer_kwargs_copy)
                     self.optimizers[model_id].append(optimizer)
                     # Check if there are duplicated keys from the optimizers.
-                    for optimizer_key in optimizer.state_dict().keys():
+                    optimizer_keys = get_optimizer_state_dict(
+                        model_parts[model_id],
+                        optimizer,
+                        options=StateDictOptions(flatten_optimizer_state_dict=True),
+                    ).keys()
+                    for optimizer_key in optimizer_keys:
                         if optimizer_key in all_optimizer_keys:
-                            raise ValueError(
+                            logger.error(
                                 f"Duplicated optimizer key is deteced! Key = {optimizer_key}"
                             )
+                            # raise ValueError(f"Duplicated optimizer key is deteced! Key = {optimizer_key}")
                         all_optimizer_keys.add(optimizer_key)
             else:
                 for p in model.parameters():

--- a/cosmos_rl/policy/trainer/optm/__init__.py
+++ b/cosmos_rl/policy/trainer/optm/__init__.py
@@ -80,6 +80,7 @@ class OptimizersContainer(Optimizer, Generic[T]):
         all_params = []
         self.model_parts = model_parts
         self.optimizers = [[] for _ in self.model_parts]
+        all_optimizer_keys = set()
         for model_id, (model, optimizer_kwargs_i) in enumerate(
             zip(self.model_parts, optimizer_kwargs)
         ):
@@ -100,6 +101,13 @@ class OptimizersContainer(Optimizer, Generic[T]):
                 for params in parameters_by_mesh.values():
                     optimizer = optimizer_cls(params, **optimizer_kwargs_copy)
                     self.optimizers[model_id].append(optimizer)
+                    # Check if there are duplicated keys from the optimizers.
+                    for optimizer_key in optimizer.state_dict().keys():
+                        if optimizer_key in all_optimizer_keys:
+                            raise ValueError(
+                                f"Duplicated optimizer key is deteced! Key = {optimizer_key}"
+                            )
+                        all_optimizer_keys.add(optimizer_key)
             else:
                 for p in model.parameters():
                     if p.requires_grad:


### PR DESCRIPTION
The original check implementation is wrong.
The optimizer state_dict is hard coded to have two keys: "state" and "param_groups"
https://github.com/pytorch/pytorch/blob/7b72e5b3ad989d02802909b64f322b2b7b69913b/torch/optim/optimizer.py#L749-L750

But the get_optim_state_dict() function actually append the key by the module's fully qualified name.
https://github.com/pytorch/pytorch/blob/v2.7.0/torch/distributed/checkpoint/state_dict.py#L781
So we should check the name returned by the get_optim_state_dict() instead.

Also changing the exception to an error so it does not affect other models for now. Will add back the exception when it is safe.