### PR TITLE
fix: padding when `model_max_length < max(sample)`

### DIFF
--- a/cosmos_rl/dispatcher/data/packer/decoder_only_llm_data_packer.py
+++ b/cosmos_rl/dispatcher/data/packer/decoder_only_llm_data_packer.py
@@ -102,13 +102,17 @@ class DecoderOnlyLLMDataPacker(DataPacker):
         collated_dict = {}
         collated_dict["input_ids"] = torch.tensor(
             [
-                x + [self.tokenizer.pad_token_id] * (max(0, computed_max_len - len(x)))
+                x[:computed_max_len]
+                + [self.tokenizer.pad_token_id] * (max(0, computed_max_len - len(x)))
                 for x in input_ids
             ],
             dtype=torch.long,
         ).to(device)
         collated_dict["logprob_masks"] = torch.tensor(
-            [x + [0] * (max(0, computed_max_len - len(x))) for x in logprob_masks],
+            [
+                x[:computed_max_len] + [0] * (max(0, computed_max_len - len(x)))
+                for x in logprob_masks
+            ],
             dtype=torch.bool,
         ).to(device)
 
@@ -277,7 +281,8 @@ class DecoderOnlyLLMDataPacker(DataPacker):
         # Then pad the samples to the computed_max_len
         input_ids = torch.tensor(
             [
-                x + [pad_token_id] * (max(0, computed_max_len - len(x)))
+                x[:computed_max_len]
+                + [pad_token_id] * (max(0, computed_max_len - len(x)))
                 for x in list_of_input_ids
             ],
             dtype=torch.long,
@@ -285,7 +290,8 @@ class DecoderOnlyLLMDataPacker(DataPacker):
         # Model accept unshifted label_ids for loss computation
         label_ids = torch.tensor(
             [
-                x + [ignore_label_id] * (max(0, computed_max_len - len(x)))
+                x[:computed_max_len]
+                + [ignore_label_id] * (max(0, computed_max_len - len(x)))
                 for x in list_of_label_ids
             ],
             dtype=torch.long,

--- a/cosmos_rl/dispatcher/data/packer/qwen2_5_vlm_data_packer.py
+++ b/cosmos_rl/dispatcher/data/packer/qwen2_5_vlm_data_packer.py
@@ -308,7 +308,7 @@ class Qwen2_5_VLM_DataPacker(DataPacker):
         # Pad the input_ids, logprob_masks
         batch["input_ids"] = torch.tensor(
             [
-                x["input_ids"]
+                x["input_ids"][:computed_max_len]
                 + [self.tokenizer.pad_token_id]
                 * (max(0, computed_max_len - len(x["input_ids"])))
                 for x in processed_samples
@@ -318,7 +318,7 @@ class Qwen2_5_VLM_DataPacker(DataPacker):
         if "label_ids" in processed_samples[0]:
             batch["label_ids"] = torch.tensor(
                 [
-                    x["label_ids"]
+                    x["label_ids"][:computed_max_len]
                     + [IGNORE_LABEL_ID]
                     * (max(0, computed_max_len - len(x["label_ids"])))
                     for x in processed_samples
@@ -327,7 +327,7 @@ class Qwen2_5_VLM_DataPacker(DataPacker):
             )
         batch["logprob_masks"] = torch.tensor(
             [
-                x["logprob_masks"]
+                x["logprob_masks"][:computed_max_len]
                 + [0] * (max(0, computed_max_len - len(x["logprob_masks"])))
                 for x in processed_samples
             ],


### PR DESCRIPTION
When `model_max_length` specified by config is less than max context length of a batch, we should do slice to the `input_ids, label_ids, masks` to prevent issue.