### PR TITLE
fix sft total steps computation

### DIFF
--- a/cosmos_rl/policy/trainer/sft_trainer.py
+++ b/cosmos_rl/policy/trainer/sft_trainer.py
@@ -265,7 +265,10 @@ class SFTTrainer(Trainer):
         # For iteration control
         self.epoch = config.train.epoch
         steps_by_dataset = (
-            len(self.train_data_loader) * self.epoch // self.dp_world_size
+            len(train_dataset)
+            * self.epoch
+            // self.dp_world_size
+            // self.config.train.train_batch_per_replica
         )
 
         if config.train.max_num_steps is not None:

--- a/cosmos_rl/policy/trainer/sft_trainer.py
+++ b/cosmos_rl/policy/trainer/sft_trainer.py
@@ -253,6 +253,7 @@ class SFTTrainer(Trainer):
             prefetch_factor=config.train.train_policy.dataloader_prefetch_factor,
             sampler=train_sampler,
             collate_fn=collate_fn,
+            drop_last=True,
         )
         self.val_data_loader = DataLoader(
             val_dataset,
@@ -261,6 +262,7 @@ class SFTTrainer(Trainer):
             prefetch_factor=config.train.train_policy.dataloader_prefetch_factor,
             sampler=val_sampler,
             collate_fn=collate_fn,
+            drop_last=True,
         )
         # For iteration control
         self.epoch = config.train.epoch


### PR DESCRIPTION
https://github.com/pytorch/pytorch/blob/134179474539648ba7dee1317959529fbd0e7f89/torch/utils/data/dataloader.py#L541

Length of a `torch.data.DataLoader` is defined in two ways. So it may lead to unexpected behavior. We can compute this on our own.