### PR TITLE
Add custom script config

### DIFF
--- a/cosmos_rl/policy/config/__init__.py
+++ b/cosmos_rl/policy/config/__init__.py
@@ -728,7 +728,9 @@ class LoggingConfig(BaseModel):
 
 
 class Config(BaseModel):
-    custom: Dict[str, Any] = Field(default_factory=dict, description="Custom script configuration.")
+    custom: Dict[str, Any] = Field(
+        default_factory=dict, description="Custom script configuration."
+    )
     train: TrainingConfig = Field(default_factory=TrainingConfig)
     rollout: RolloutConfig = Field(default_factory=RolloutConfig)
     policy: PolicyConfig = Field(default_factory=PolicyConfig)

--- a/cosmos_rl/policy/config/__init__.py
+++ b/cosmos_rl/policy/config/__init__.py
@@ -728,6 +728,7 @@ class LoggingConfig(BaseModel):
 
 
 class Config(BaseModel):
+    custom: Dict[str, Any] = Field(default_factory=dict, description="Custom script configuration.")
     train: TrainingConfig = Field(default_factory=TrainingConfig)
     rollout: RolloutConfig = Field(default_factory=RolloutConfig)
     policy: PolicyConfig = Field(default_factory=PolicyConfig)


### PR DESCRIPTION
Add a custom config that is parsed by the user provided script.

This allows adding custom config parameters without polluting the global configs.

Example usage: https://github.com/nvidia-cosmos/cosmos-reason1/blob/f239ad357e9e4f8fb209b1560a974a18feb893e1/tools/dataset/cosmos_sft.py#L108

## Verification

Doesn't affect existing code. Manually tested using above example.