### PR TITLE
Update vllm version to latest v0.10.0 to fix CI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -72,7 +72,7 @@ RUN pip install torch==2.7.0 torchvision==0.22.0 torchaudio==2.7.0 --index-url h
 COPY requirements.txt /workspace/cosmos_rl/requirements.txt
 RUN pip install \
     torchao==0.11.0 \
-    vllm==0.9.1 \
+    vllm==0.10.0 \
     flash-attn==2.8.0.post2 \
     https://download.pytorch.org/whl/cu128/flashinfer/flashinfer_python-0.2.6.post1%2Bcu128torch2.7-cp39-abi3-linux_x86_64.whl \
     -r /workspace/cosmos_rl/requirements.txt


### PR DESCRIPTION
```
  File "/usr/local/lib/python3.10/dist-packages/transformers/models/auto/configuration_auto.py", line 993, in register
    raise ValueError(f"'{key}' is already used by a Transformers config, pick another name.")
ValueError: 'aimv2' is already used by a Transformers config, pick another name.
    raise ValueError(f"'{key}' is already used by a Transformers config, pick another name.")
ValueError: 'aimv2' is already used by a Transformers config, pick another name.
    raise ValueError(f"'{key}' is already used by a Transformers config, pick another name.")
    ValueErrorraise ValueError(f"'{key}' is already used by a Transformers config, pick another name.")
```

Include [fix](https://github.com/vllm-project/vllm/commit/3fc964433a84bad785d9d0656fd56195462321b8) from vllm 