### PR TITLE
feat: add fullly on-policy support for GRPO

### DIFF
--- a/cosmos_rl/policy/config/__init__.py
+++ b/cosmos_rl/policy/config/__init__.py
@@ -335,6 +335,11 @@ class GrpoConfig(BaseModel):
         "then rollout engine traffic will be throttled. ",
     )
 
+    fully_on_policy: bool = Field(
+        default=False,
+        description="Enable fully synchronized (on-policy) rollout. If set to True, the rollout engine will wait until the expected weight version is updated before next generation starts.",
+    )
+
     min_filter_prefix_tokens: Optional[int] = Field(
         default=None,
         description="Minimum number of tokens to filter the prefix tokens for the rollouts inside the same group. "
@@ -514,6 +519,13 @@ class TrainingConfig(BaseModel):
             )
         if self.max_num_steps is not None and self.max_num_steps <= 0:
             raise ValueError("max_num_steps must be positive if specified")
+
+        if isinstance(self.train_policy, GrpoConfig):
+            if self.train_policy.fully_on_policy:
+                assert (
+                    self.sync_weight_interval == 1
+                ), "sync_weight_interval must be 1 when fully_on_policy is enabled"
+
         return self
 
 

--- a/cosmos_rl/policy/trainer/optm/__init__.py
+++ b/cosmos_rl/policy/trainer/optm/__init__.py
@@ -87,7 +87,7 @@ class OptimizersContainer(Optimizer, Generic[T]):
                 continue
             optimizer_kwargs_copy = deepcopy(optimizer_kwargs_i)
 
-            if optimizer_kwargs_copy["fused"]:
+            if optimizer_kwargs_copy.get("fused", False):
                 # Group the parameters by device mesh to do optimizer fusion.
                 parameters_by_mesh = collections.defaultdict(list)
                 for p in model.parameters():


### PR DESCRIPTION
This is a feature just for `ON-POLICY` rollout verification, NOT recommended for production usage.

Add fully on-policy rollout support:
1. To enable this feature, set `config.train.train_policy.fully_on_policy = true`;
2. `config.train.weight_sync_interval` must be `1` if on-policy is forced, otherwise weight-version checking does not work;
3. If some `rollout` replicas scale down or crash, the prompt will be dropped, then the ongoing training may be stuck because there will be no enough rollout for next step anymore. In this case, we simply fallback to async mode as soon as `scaling down` event occurs;

Behavior changes:
1. We used to filter the rollout completions with length of zero, `""`. Somehow this will lead to the unexpected decrease number of rollouts/samples received by controller. Further `on-policy` mode can be stuck due to not enough rollout for a step. So we always return the samples no matter its length. (replace `""` with `"<eos_token>"`)