### PR TITLE
print env preset for users

### DIFF
--- a/cosmos_rl/launcher/launch_replica.sh
+++ b/cosmos_rl/launcher/launch_replica.sh
@@ -90,10 +90,10 @@ set_env "TORCH_CPP_LOG_LEVEL" "ERROR"
 
 if [ "$TYPE" == "rollout" ]; then
   DEFAULT_MODULE="cosmos_rl.rollout.rollout_entrance"
-  set_env "COSMOS_ROLE" "Rollout"
+  export COSMOS_ROLE="Rollout"
 elif [ "$TYPE" == "policy" ]; then
   DEFAULT_MODULE="cosmos_rl.policy.train"
-  set_env "COSMOS_ROLE" "Policy"
+  export COSMOS_ROLE="Policy"
 else
   echo "Error: Invalid --type value '$TYPE'. Must be 'rollout' or 'policy'."
   print_help

--- a/cosmos_rl/launcher/launch_replica.sh
+++ b/cosmos_rl/launcher/launch_replica.sh
@@ -27,6 +27,14 @@ print_help() {
   echo ""
 }
 
+set_env() {
+  local env_name="$1"
+  local env_value="$2"
+  local upper_type="${TYPE^^}"
+  echo "[Cosmos-RL] $upper_type Pre-setting environment variable $env_name=$env_value"
+  export "$env_name=$env_value"
+}
+
 while [[ $# -gt 0 ]]; do
   case "$1" in
   --ngpus)
@@ -75,14 +83,17 @@ if [ -z "$TYPE" ]; then
   exit 1
 fi
 
-export NCCL_CUMEM_ENABLE="1"
-export TORCH_CPP_LOG_LEVEL="ERROR"
+# NCCL related
+set_env "NCCL_CUMEM_ENABLE" "1"
+# Torch related
+set_env "TORCH_CPP_LOG_LEVEL" "ERROR"
+
 if [ "$TYPE" == "rollout" ]; then
   DEFAULT_MODULE="cosmos_rl.rollout.rollout_entrance"
-  export COSMOS_ROLE="Rollout"
+  set_env "COSMOS_ROLE" "Rollout"
 elif [ "$TYPE" == "policy" ]; then
   DEFAULT_MODULE="cosmos_rl.policy.train"
-  export COSMOS_ROLE="Policy"
+  set_env "COSMOS_ROLE" "Policy"
 else
   echo "Error: Invalid --type value '$TYPE'. Must be 'rollout' or 'policy'."
   print_help


### PR DESCRIPTION
We print all the envs that we set inside `launch_replica.sh`:
Output like:
```
[Cosmos-RL] POLICY Pre-setting environment variable NCCL_CUMEM_ENABLE=1
[Cosmos-RL] POLICY Pre-setting environment variable TORCH_CPP_LOG_LEVEL=ERROR
[Cosmos-RL] POLICY Pre-setting environment variable COSMOS_ROLE=Policy
[Cosmos-RL] ROLLOUT Pre-setting environment variable NCCL_CUMEM_ENABLE=1
[Cosmos-RL] ROLLOUT Pre-setting environment variable TORCH_CPP_LOG_LEVEL=ERROR
[Cosmos-RL] ROLLOUT Pre-setting environment variable COSMOS_ROLE=Rollout
```