### PR TITLE
optimize: GRPO logits memory

### DIFF
--- a/cosmos_rl/policy/model/gpt/__init__.py
+++ b/cosmos_rl/policy/model/gpt/__init__.py
@@ -429,6 +429,7 @@ class GPT(BaseModel):
         self,
         input_ids: torch.Tensor,
         position_ids: torch.Tensor = None,
+        interested_tokens: Optional[torch.BoolTensor] = None,
         *args,
         **kwargs,
     ):
@@ -446,6 +447,11 @@ class GPT(BaseModel):
 
         # Add `if` check just in case `pp` is enabled
         if self.norm is not None:
+            if interested_tokens is not None:
+                assert not isinstance(
+                    h, torch.distributed.tensor.DTensor
+                ), "logprob_masks must be a local tensor"
+                h = h[interested_tokens]
             h = self.norm(h)
             if not self.tie_embed_tokens:
                 output = self.lm_head(h)

--- a/cosmos_rl/policy/model/qwen2_5_vl/__init__.py
+++ b/cosmos_rl/policy/model/qwen2_5_vl/__init__.py
@@ -819,6 +819,7 @@ class Qwen2_5_VLModel(nn.Module):
         self,
         inputs_embeds: Optional[torch.FloatTensor] = None,
         position_ids: Optional[torch.LongTensor] = None,
+        interested_tokens: Optional[torch.BoolTensor] = None,
     ):
         h = self.identity_layer(inputs_embeds)
 
@@ -829,6 +830,11 @@ class Qwen2_5_VLModel(nn.Module):
 
         # Add `if` check just in case `pp` is enabled
         if self.norm is not None:
+            if interested_tokens is not None:
+                assert not isinstance(
+                    h, torch.distributed.tensor.DTensor
+                ), "interested_tokens must be a local tensor"
+                h = h[interested_tokens]
             assert self.lm_head is not None, "lm_head must be provided in last stage"
             h = self.lm_head(self.norm(h))
         return h
@@ -940,10 +946,13 @@ class Qwen2_5_VLConditionalModel(BaseModel):
             ), "input of pipeline stage > 0 must be of floating point type"
             inputs_embeds = input_ids
 
+        # For GRPO, we can pass in the logprob_masks to the model
+        # to avoid computing the logits which are not needed for the model
         outputs = self.model(
             inputs_embeds=inputs_embeds,
             # Permute back to [3, batch_size, seq_len] for Pipeline Parallelism micro batch
             position_ids=position_ids.permute(1, 0, 2).contiguous(),
+            interested_tokens=kwargs.get("interested_tokens", None),
         )
         return outputs
 

--- a/cosmos_rl/policy/model/qwen3_moe/__init__.py
+++ b/cosmos_rl/policy/model/qwen3_moe/__init__.py
@@ -664,6 +664,7 @@ class Qwen3MoE(BaseModel):
         self,
         input_ids: torch.Tensor,
         position_ids: torch.Tensor = None,
+        interested_tokens: Optional[torch.BoolTensor] = None,
         *args,
         **kwargs,
     ):
@@ -681,6 +682,11 @@ class Qwen3MoE(BaseModel):
 
         # Add `if` check just in case `pp` is enabled
         if self.norm is not None:
+            if interested_tokens is not None:
+                assert not isinstance(
+                    h, torch.distributed.tensor.DTensor
+                ), "interested_tokens must be a local tensor"
+                h = h[interested_tokens]
             h = self.norm(h)
             if not self.tie_embed_tokens:
                 output = self.lm_head(h)


### PR DESCRIPTION
By default, we compute all logits for GPRO including `prompt` and `completion`, while sometimes the `prompt` is pretty long, which introduces both compute and memory overhead.

While for GRPO training, `logits[:, :len(prompt) - 1]` is not needed for loss computation. So we could just drop them during logits computation.

According to my test, average memory utilization decreases by about 12-15% for `cosmos-reason1` GRPO dataset.