### PR TITLE
[LoRA] Support `modules_to_save`

### DIFF
--- a/cosmos_rl/policy/config/__init__.py
+++ b/cosmos_rl/policy/config/__init__.py
@@ -631,6 +631,12 @@ class PolicyConfig(BaseModel):
         default=True, description="Whether to use gradient checkpointing"
     )
     lora: LoraConfig | None = Field(default=None, description="LoRA configuration")
+    trainable_map: Optional[Dict[str, bool]] = Field(
+        default=None,
+        description="Mapping of name -> bool. Keys can either be: "
+        "- exact parameter names (from model.named_parameters()) "
+        "- exact module paths (from model.named_modules()) ",
+    )
 
     @model_validator(mode="after")
     def check_params_value(self):

--- a/cosmos_rl/policy/config/__init__.py
+++ b/cosmos_rl/policy/config/__init__.py
@@ -586,7 +586,10 @@ class LoraConfig(BaseModel):
     r: int = Field(default=8, description="LoRA rank")
     lora_alpha: float = Field(default=8.0, description="LoRA alpha")
     lora_dropout: float = Field(default=0.0, description="LoRA dropout")
-    target_modules: List[str] = Field(default=None, description="LoRA target modules")
+    target_modules: Union[List[str], str] = Field(
+        default=None,
+        description="LoRA target modules, can be a list of strings or 'all-linear'",
+    )
     use_rslora: bool = Field(
         default=False,
         description="When set to True, uses [Rank-Stabilized LoRA](https://huggingface.co/papers/2312.03732)"
@@ -610,6 +613,14 @@ class LoraConfig(BaseModel):
         "Passing ‘gaussian’ results in Gaussian initialization scaled by the LoRA rank for linear and layers. Pass 'loftq' to use LoftQ initialization. Passing 'eva' results in a data-driven initialization of Explained Variance Adaptation."
         "EVA initializes LoRA based on the SVD of layer input activations and achieves SOTA performance due to its ability to adapt to the finetuning data. Pass 'olora' to use OLoRA initialization. Passing 'pissa' results in the initialization of https://huggingface.co/papers/2404.02948",
     )
+
+    @model_validator(mode="after")
+    def check_params_value(self):
+        if isinstance(self.target_modules, str):
+            assert (
+                self.target_modules == "all-linear"
+            ), "target_modules must be a list of strings or 'all-linear'"
+        return self
 
 
 class PolicyConfig(BaseModel):

--- a/cosmos_rl/policy/model/base.py
+++ b/cosmos_rl/policy/model/base.py
@@ -26,6 +26,7 @@ from transformers import AutoConfig
 from cosmos_rl.dispatcher.data.packer import DataPacker
 import collections
 from functools import partial
+from typing import Mapping
 
 
 class BaseModel(torch.nn.Module, ABC):
@@ -42,9 +43,7 @@ class BaseModel(torch.nn.Module, ABC):
         return next(self.parameters()).device
 
     @cached_property
-    def weight_sync_transforms(
-        self,
-    ) -> List[Tuple[str, Union[torch.Tensor, Callable]]]:
+    def weight_sync_transforms(self) -> List[Tuple[str, Union[torch.Tensor, Callable]]]:
         from cosmos_rl.utils.parallelism_map import DimSliceInfo, ParallelTopoMapper
 
         # 1. get all parameters, but not buffers
@@ -230,6 +229,55 @@ class BaseModel(torch.nn.Module, ABC):
                 weight_sync_transforms.append((name, transforms[name]))
         return weight_sync_transforms
 
+    def apply_trainable(self, trainable_map: Mapping[str, bool]) -> dict:
+        """
+        Apply trainable flags to modules and parameters.
+
+        Args:
+            trainable_map: mapping of name -> bool.
+                    Keys may be:
+                    - exact parameter names (from model.named_parameters())
+                    - exact module paths (from model.named_modules())
+
+        Returns:
+            A dict with lists of which params/modules were touched.
+
+        Raises:
+            TypeError: for non-bool values.
+            TrainablePathError: if a key matches neither a param nor a module.
+        """
+        if not isinstance(trainable_map, Mapping):
+            raise TypeError("trainable_map must be a mapping[str, bool]")
+
+        # Build lookup tables
+        param_map = dict(self.named_parameters())
+        module_map = dict(self.named_modules())
+        module_map.pop("", None)  # drop root entry to avoid confusion
+
+        touched_params, touched_modules = [], []
+
+        # Process in the insertion order of `config`.
+        for name, flag in trainable_map.items():
+            if not isinstance(flag, bool):
+                raise TypeError(
+                    f"value for '{name}' must be bool, got {type(flag).__name__}"
+                )
+
+            if name in param_map:
+                param_map[name].requires_grad = flag
+                touched_params.append(name)
+                continue
+
+            if name in module_map:
+                for p in module_map[name].parameters(recurse=True):
+                    p.requires_grad = flag
+                touched_modules.append(name)
+                continue
+
+            # Not found: raise with fuzzy suggestions
+            raise KeyError(f"Path '{name}' not found among parameters or modules.")
+        return {"touched_params": touched_params, "touched_modules": touched_modules}
+
     """
     Abstract methods
     """
@@ -406,6 +454,7 @@ class ModelRegistry:
                         model_name_or_path,
                         max_position_embeddings=config.policy.model_max_length,
                     )
+                    # Apply LoRA to the model
                     if config.policy.lora is not None:
                         logger.info(f"Applying LoRA to the model: {config.policy.lora}")
                         from cosmos_rl.policy.lora.plugin import (
@@ -415,6 +464,16 @@ class ModelRegistry:
 
                         model, _ = inject_lora_adapters(model, config.policy.lora)
                         mark_only_lora_as_trainable(model, config.policy.lora)
+
+                    # If we further need finer-grained control over trainable parameters, we need to apply trainable flags after LoRA is applied
+                    if config.policy.trainable_map is not None:
+                        if config.policy.lora is not None:
+                            raise RuntimeError(
+                                "If LoRA is applied, please do not set trainable_map in config.train.policy."
+                                "Instead, set trainable_map in config.policy.lora.modules_to_save to explicitly specify which modules to train."
+                            )
+                        model.apply_trainable(config.policy.trainable_map)
+
                 except Exception as e:
                     logger.error(
                         f"Failed to load model {model_name_or_path} with error: {e}"

--- a/cosmos_rl/policy/trainer/optm/__init__.py
+++ b/cosmos_rl/policy/trainer/optm/__init__.py
@@ -83,6 +83,7 @@ class OptimizersContainer(Optimizer, Generic[T]):
         self.optimizers = [[] for _ in self.model_parts]
         # Compute total number of parameters
         total_trainable_params = 0
+        all_trainable_params = []
         for model_id, (model, optimizer_kwargs_i) in enumerate(
             zip(self.model_parts, optimizer_kwargs)
         ):
@@ -93,8 +94,9 @@ class OptimizersContainer(Optimizer, Generic[T]):
             if optimizer_kwargs_copy.get("fused", False):
                 # Group the parameters by device mesh to do optimizer fusion.
                 parameters_by_mesh = collections.defaultdict(list)
-                for p in model.parameters():
+                for name, p in model.named_parameters():
                     if p.requires_grad:
+                        all_trainable_params.append(name)
                         device_mesh = (
                             p.device_mesh if hasattr(p, "device_mesh") else "default"
                         )
@@ -111,7 +113,9 @@ class OptimizersContainer(Optimizer, Generic[T]):
                         self.optimizers[model_id].append(optimizer)
                         all_params.append(p)
                         total_trainable_params += p.numel()
+                        all_trainable_params.append(name)
         logger.info(f"Total number of trainable parameters: {total_trainable_params}")
+        logger.debug(f"Trainable parameters: {all_trainable_params}")
 
         self._post_init(all_params, optimizer_kwargs)
 


### PR DESCRIPTION
For LoRA, users may want to train some modules while freezing others. By default, `peft` support `modules_to_save` to specify which parts of the model can be trained in full volume of params. This PR support this feature.

BTW, we also add a config named `config.train.policy.trainable_map: Dict[str: bool]` to enable user to specify what modules are trainable or not. By default all params are trainable.

Note: `modules_to_save` cannot be specified together with `trainable_map`, because the LoRA training output `adapter_model.safetensors` could be consumed by `peft` framework, then only `modules_to_save` will be read by it and may ignore the fully-trained parameters enabled in `trainable_map`.