### PR TITLE
fix: hostname setting problem for lepton case when cross node replica 

### DIFF
--- a/cosmos_rl/launcher/launch_all.py
+++ b/cosmos_rl/launcher/launch_all.py
@@ -26,6 +26,7 @@ import argparse
 from typing import List, Dict, Optional, Any, Callable
 import toml
 import tempfile
+import cosmos_rl.utils.network_util as network_util
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger("cosmos")
@@ -1100,8 +1101,12 @@ cosmos-rl --config config.toml"""
         )
         subdomain = os.environ.get("LEPTON_SUBDOMAIN", "")
         hostname = f"{prefix}-{cur_work_idx}.{subdomain}"
-        logger.info(f"Setting hostname to {hostname} for worker index {cur_work_idx}")
-        os.system(f"hostname {hostname}")
+        ips = network_util.get_eth_ips()
+        assert len(ips) > 0, "No IPs found for the current machine"
+        logger.info(
+            f"Setting hostname to {hostname} {ips[0]} for worker index {cur_work_idx}"
+        )
+        os.system(f"hostname {ips[0]}")
 
     control_url = None
     if args.url is not None:


### PR DESCRIPTION
In lepton for torch run one replica on multiple nodes, we need set hostname to make the connection work.
But sometimes the previous used `hostname` in lepton manner is too long and cannot be set.
So, we use the eth ip as the `hostname` to be set, and can work in the failed cases.
Tested:
grpo:
https://dashboard.dgxc-lepton.nvidia.com/workspace/b5k2m9x7/compute/jobs/detail/ccot-base-lightr1-debug-w97c/replicas/list
sft:
https://dashboard.dgxc-lepton.nvidia.com/workspace/b5k2m9x7/compute/jobs/detail/echo-sft-test-46z4/replicas/list