### PR TITLE
Set qwen3-moe demo config type to bfloat16 to avoid error.

### DIFF
--- a/configs/qwen3-moe/qwen3-moe-30b-tp4-sft.toml
+++ b/configs/qwen3-moe/qwen3-moe-30b-tp4-sft.toml
@@ -14,6 +14,7 @@ optm_warmup_steps = 20
 optm_grad_norm_clip = 1.0
 async_tp_enabled = false
 compile = false
+master_dtype = "bfloat16"
 param_dtype = "bfloat16"
 fsdp_reduce_dtype = "float32"
 fsdp_offload = false


### PR DESCRIPTION
grouped gemm doesn't support float32.