### PR TITLE
Optimization: Quick dataloader advancing after checkpoint resumed

### DIFF
--- a/cosmos_rl/utils/checkpoint.py
+++ b/cosmos_rl/utils/checkpoint.py
@@ -29,7 +29,7 @@ from cosmos_rl.utils.util import is_master_rank
 from cosmos_rl.utils.logging import logger
 from cosmos_rl.utils.parallelism import ParallelDims
 from cosmos_rl.policy.config import Config as CosmosConfig
-from typing import List
+from typing import List, Callable, Union
 
 
 def upload_file_to_s3(
@@ -307,7 +307,7 @@ class CheckpointMananger:
         self,
         model: torch.nn.Module,
         optimizer: torch.optim.Optimizer,
-        scheduler: torch.optim.lr_scheduler._LRScheduler,
+        scheduler: Union[torch.optim.lr_scheduler._LRScheduler, Callable],
     ):
         extra_vars = {}
         base_paths: List[str] = self.get_ckpt_path()
@@ -331,6 +331,20 @@ class CheckpointMananger:
                     extra_info_path = os.path.join(
                         base_path, f"extra_info_rank_{self.global_rank}.pth"
                     )
+                    extra_info = self.load_extra_info(extra_info_path)
+                    for key in extra_info:
+                        if key == "rng_state":
+                            self.set_rng_state(extra_info["rng_state"])
+                        else:
+                            extra_vars[key] = extra_info[key]
+
+                    outputs = [extra_vars]
+                    # Create a new scheduler upon ``training_steps``
+                    if isinstance(scheduler, torch.optim.lr_scheduler._LRScheduler):
+                        pass
+                    else:
+                        scheduler = scheduler(training_steps=extra_vars["total_steps"])
+                        outputs.append(scheduler)
 
                     model.load_state_dict(torch.load(model_path, weights_only=False))
                     optimizer.load_state_dict(
@@ -339,16 +353,10 @@ class CheckpointMananger:
                     scheduler.load_state_dict(
                         torch.load(scheduler_path, weights_only=False)
                     )
-                    extra_info = self.load_extra_info(extra_info_path)
-                    for key in extra_info:
-                        if key == "rng_state":
-                            self.set_rng_state(extra_info["rng_state"])
-                        else:
-                            extra_vars[key] = extra_info[key]
                     logger.info(
                         f"[Policy] Checkpoint loaded successfully from {base_path}."
                     )
-                    return extra_vars
+                    return outputs[0] if len(outputs) == 1 else outputs
             except Exception as e:
                 logger.error(
                     f"Error loading checkpoint from {base_path}: {e}, try next checkpoint..."


### PR DESCRIPTION
Before this change, we need to advance the dataloader iterator until it match the last training batch/sample position. This is correct but may materialize the underlying `dataset.__getitem__`, which could be very slow for VLM models with video/image processing.

This PR mainly alleviate this by advancing the `Sampler[int]`, which will not introduce the overhead brought by dataset sample processing.

Close: https://github.com/nvidia-cosmos/cosmos-rl/issues/233