### PR TITLE
[3/n] Support Deepseek V3 GRPO / Deepseek R1

### DIFF
--- a/configs/deepseek-v3/deepseek-v3-moe-670b-fsdp64-cp4-ep64-grpo.toml
+++ b/configs/deepseek-v3/deepseek-v3-moe-670b-fsdp64-cp4-ep64-grpo.toml
@@ -1,0 +1,85 @@
+redis = "12800"
+
+[train]
+resume = false
+epoch = 10
+output_dir = "./outputs/deepseek-v3-fsdp8-r-tp1-grpo"
+epsilon = 1e-6
+optm_name = "AdamW"
+optm_lr = 2e-6
+optm_impl = "foreach"
+optm_weight_decay = 1.0
+optm_betas = [ 0.9, 0.95,]
+optm_warmup_steps = 20
+optm_grad_norm_clip = 0.0
+async_tp_enabled = false
+compile = false
+param_dtype = "bfloat16"
+fsdp_reduce_dtype = "float32"
+fsdp_offload = false
+fsdp_reshard_after_forward = "default"
+train_batch_per_replica = 128
+sync_weight_interval = 1
+
+[rollout]
+gpu_memory_utilization = 0.9
+enable_chunked_prefill = false
+n_generation = 8
+batch_size = 8
+quantization = "none"
+max_response_length = 128
+
+[rollout.sampling_config]
+temperature = 0.6
+top_p = 0.95
+top_k = 50
+repetition_penalty = 1.05
+
+[policy]
+model_name_or_path = "/lustre/fsw/portfolios/sw/users/yufhuang/cache/deepseek-v3/dcp_hf"
+model_max_length = 4096
+model_gradient_checkpointing = true
+
+[logging]
+logger = ['console', 'wandb']
+project_name = "cosmos_rl"
+experiment_name = "deepseek_v3_grpo"
+
+[train.train_policy]
+type = "grpo"
+dataset.name = "openai/gsm8k"
+dataset.subset = "main"
+dataset.split = "train"
+prompt_column_name = "question"
+response_column_name = "answer"
+reward_function = "gsm8k"
+enable_dataset_cache = false
+temperature = 0.9
+epsilon_low = 0.2
+epsilon_high = 0.2
+kl_beta = 0.0
+mu_iterations = 1
+mini_batch = 1
+
+[train.ckpt]
+enable_checkpoint = true
+save_freq = 50
+save_mode = "async"
+
+[rollout.parallelism]
+n_init_replicas = 1
+tp_size = 32
+pp_size = 1
+dp_replicate_size = 1
+cp_size = 1
+dp_shard_size = 1
+
+[policy.parallelism]
+n_init_replicas = 1
+tp_size = 1
+cp_size = 4
+ep_size = 64
+dp_shard_size = 64
+pp_size = 1
+dp_replicate_size = 1
+cp_rotate_method = "allgather"

--- a/cosmos_rl/dispatcher/data/packer/deepseek_data_packer.py
+++ b/cosmos_rl/dispatcher/data/packer/deepseek_data_packer.py
@@ -33,6 +33,11 @@ class DeepSeek_DataPacker(DecoderOnlyLLMDataPacker):
         super().setup(config, tokenizer, *args, **kwargs)
         self.seq_len = config.policy.model_max_length
 
+    def policy_compute_max_len(
+        self, processed_samples: List[DecoderOnlyLLMDataPacker.RLPolicyInput]
+    ) -> int:
+        return max(self.seq_len, max([len(x.input_ids) for x in processed_samples]))
+
     def policy_collate_fn(
         self,
         processed_samples: List[DecoderOnlyLLMDataPacker.RLPolicyInput],

--- a/cosmos_rl/policy/model/deepseek_v3/__init__.py
+++ b/cosmos_rl/policy/model/deepseek_v3/__init__.py
@@ -400,7 +400,7 @@ class DeepseekV3MoEModel(BaseModel):
 
             logger.info("Creating storage reader...")
             fs_storage_reader = torch.distributed.checkpoint.FileSystemReader(
-                dcp_checkpoint_path
+                model_name_or_path
             )
             logger.info("Loading checkpoint ...")
             torch.distributed.checkpoint.load(

--- a/cosmos_rl/policy/model/deepseek_v3/grpo_launcher.py
+++ b/cosmos_rl/policy/model/deepseek_v3/grpo_launcher.py
@@ -1,0 +1,135 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from typing import Any
+from torch.utils.data import Dataset, ConcatDataset
+from datasets import load_dataset
+from cosmos_rl.launcher.worker_entry import main as launch_worker
+from cosmos_rl.policy.config import Config as CosmosConfig
+from transformers import AutoTokenizer
+from cosmos_rl.utils.logging import logger
+
+
+class DeepSeekV3GRPODataset(Dataset):
+    def setup(self, config: CosmosConfig, tokenizer: AutoTokenizer, *args, **kwargs):
+        """
+        This method is optional and get called by launcher after being mounted
+        `config`: config;
+        `tokenizer`: tokenizer;
+        """
+        self.config = config
+        self.tokenizer = tokenizer
+        self.dataset = load_dataset(
+            config.train.train_policy.dataset.name,
+            config.train.train_policy.dataset.subset,
+        )
+        if config.train.train_policy.dataset.split:
+            if isinstance(config.train.train_policy.dataset.split, list):
+                dataset_list = []
+                for split_name in config.train.train_policy.dataset.split:
+                    dataset_list.append(self.dataset[split_name])
+                self.dataset = ConcatDataset(dataset_list)
+            else:
+                assert isinstance(config.train.train_policy.dataset.split, str)
+                self.dataset = self.dataset[config.train.train_policy.dataset.split]
+
+    def __len__(self):
+        logger.info(f"Length of the dataset: {len(self.dataset)}")
+        return len(self.dataset)
+
+    def __getitem__(self, idx: int) -> tuple[str, str]:
+        """
+        For DecoderOnlyLLMDataPacker, it should either return:
+        - raw text prompt to be converted into input_ids by both rollout and policy models;
+        - conversation format:
+        ```
+        [
+            {
+                "role": "user",
+                "content": f"{question} Let\'s think step by step and output the final answer after \"####\".",
+            }
+        ]
+        ```
+        """
+        assert hasattr(
+            self, "tokenizer"
+        ), "`self.tokenizer` should be set by the launcher"
+        question = self.dataset[idx]["question"]
+        assert isinstance(question, str), "Question should be a string"
+        # Convert to templated prompt
+        conversation = [
+            {
+                "role": "user",
+                "content": f'{question} Let\'s think step by step and output the final answer after "####".',
+            }
+        ]
+        prompt = self.tokenizer.apply_chat_template(
+            conversation,
+            tokenize=False,
+            add_generation_prompt=True,
+        )
+        return prompt
+
+    def get_reference_answer(self, idx: int) -> Any:
+        """
+        This is mandatory for GRPO to get a reference answer for reward computation.
+        """
+        answer = self.dataset[idx]["answer"]
+        return answer
+
+
+class DeepSeekV3GRPOValDataset(DeepSeekV3GRPODataset):
+    """
+    This is a validation dataset for DeepSeekV3, which is used to evaluate the performance of the model.
+    It should be used in the launcher to evaluate the model during training.
+    """
+
+    def setup(self, config: CosmosConfig, tokenizer: AutoTokenizer, *args, **kwargs):
+        if not config.train.enable_validation:
+            logger.warning(
+                "Validation is not enabled in the config. Skipping setup for GSM8kValDataset."
+            )
+            return
+
+        self.config = config
+        self.tokenizer = tokenizer
+
+        self.dataset = load_dataset(
+            config.validation.dataset.name, config.validation.dataset.subset
+        )
+        if config.validation.dataset.split:
+            if isinstance(config.validation.dataset.split, list):
+                dataset_list = []
+                for split_name in config.validation.dataset.split:
+                    dataset_list.append(self.dataset[split_name])
+                self.dataset = ConcatDataset(dataset_list)
+            else:
+                assert isinstance(config.validation.dataset.split, str)
+                self.dataset = self.dataset[config.validation.dataset.split]
+
+
+if __name__ == "__main__":
+
+    def get_dataset(config: CosmosConfig) -> Dataset:
+        return DeepSeekV3GRPODataset()
+
+    def get_val_dataset(config: CosmosConfig) -> Dataset:
+        return DeepSeekV3GRPOValDataset()
+
+    launch_worker(
+        dataset=get_dataset,
+        val_dataset=get_val_dataset,
+    )

--- a/cosmos_rl/rollout/vllm_rollout/vllm_rollout.py
+++ b/cosmos_rl/rollout/vllm_rollout/vllm_rollout.py
@@ -112,7 +112,7 @@ class vLLMRollout(RolloutBase):
             disable_mm_preprocessor_cache = False
 
             # Check if the model has MoE
-            moe_model_type = {"qwen3_moe"}
+            moe_model_type = {"qwen3_moe", "deepseek_v3"}
             multimodal_type = {"qwen2_5_vl"}
 
             model_type = self.model_config.model_type


### PR DESCRIPTION
This PR upstreams the changes needed for GRPO experiments for Deepseek V3 LLM.

To run the model in CW-DFW cluster, I run the following command:

```
export CONTAINER_IMAGE_IN=/lustre/fsw/portfolios/sw/users/boryiings/images/cosmos/img4_echo_pt27_vllm_cosmos_rl.sqsh; python tools/slurm/dispatch_job.py --config-path configs/deepseek-v3/deepseek-v3-moe-670b-fsdp64-cp4-ep64-grpo.toml --output-root-path /home/heslami/lustre/logs --cosmos-container $CONTAINER_IMAGE_IN --ngpu-per-node 8 --repo-root-path $(pwd -P .) cosmos_rl/policy/model/deepseek_v3/grpo_launcher.py
```