### PR TITLE
Support of passing custom arguments to custom dataset script.

### DIFF
--- a/cosmos_rl/dispatcher/data/packer/__init__.py
+++ b/cosmos_rl/dispatcher/data/packer/__init__.py
@@ -17,10 +17,12 @@ from .base import DataPacker
 from .decoder_only_llm_data_packer import DecoderOnlyLLMDataPacker
 from .qwen2_5_vlm_data_packer import Qwen2_5_VLM_DataPacker
 from .hf_vlm_data_packer import HFVLMDataPacker
+from .base import worker_entry_parser
 
 __all__ = [
     "DataPacker",
     "DecoderOnlyLLMDataPacker",
     "Qwen2_5_VLM_DataPacker",
     "HFVLMDataPacker",
+    "worker_entry_parser",
 ]

--- a/cosmos_rl/dispatcher/data/packer/base.py
+++ b/cosmos_rl/dispatcher/data/packer/base.py
@@ -18,6 +18,32 @@ from typing import Any, List, Dict, Type, Union
 from transformers import AutoTokenizer
 from cosmos_rl.policy.config import Config
 
+from argparse import REMAINDER
+import argparse
+
+def worker_entry_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Run the replica entrypoint.")
+    parser.add_argument(
+        "--port", type=int, default=8000, help="Port to run the web panel on."
+    )
+    parser.add_argument(
+        "--redis-port", type=int, default=12800, help="Port to run the web panel on."
+    )
+    parser.add_argument(
+        "--config",
+        type=str,
+        default=None,
+        required=True,
+        help="Path to TOML configuration file to load.",
+    )
+
+    parser.add_argument(
+        "--redis-logfile-path",
+        type=str,
+        default="/tmp/redis.log",
+        help="The redis server log file path.",
+    )
+    return parser
 
 class DataPacker(ABC):
     _MODEL_TO_DEFAULT_DATA_PACKER_REGISTRY: Dict[str, Type["DataPacker"]] = {}

--- a/cosmos_rl/dispatcher/data/packer/base.py
+++ b/cosmos_rl/dispatcher/data/packer/base.py
@@ -18,8 +18,8 @@ from typing import Any, List, Dict, Type, Union
 from transformers import AutoTokenizer
 from cosmos_rl.policy.config import Config
 
-from argparse import REMAINDER
 import argparse
+
 
 def worker_entry_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="Run the replica entrypoint.")
@@ -44,6 +44,7 @@ def worker_entry_parser() -> argparse.ArgumentParser:
         help="The redis server log file path.",
     )
     return parser
+
 
 class DataPacker(ABC):
     _MODEL_TO_DEFAULT_DATA_PACKER_REGISTRY: Dict[str, Type["DataPacker"]] = {}

--- a/cosmos_rl/dispatcher/run_web_panel.py
+++ b/cosmos_rl/dispatcher/run_web_panel.py
@@ -75,7 +75,7 @@ from cosmos_rl.utils.api_suffix import (
     COSMOS_API_ROLLOUT_SHARD_RECV_INSTS_SUFFIX,
     COSMOS_API_GET_TRAINABLE_PARAMS_SUFFIX,
 )
-from cosmos_rl.dispatcher.data.packer.base import DataPacker
+from cosmos_rl.dispatcher.data.packer.base import DataPacker, worker_entry_parser
 from fastapi.responses import Response
 from fastapi import Request
 
@@ -633,32 +633,9 @@ def main(
         return
 
     if args is None:
-        # This means we should parse the args manually
-        parser = argparse.ArgumentParser(
-            description="Run the web panel for the dispatcher."
-        )
-        parser.add_argument(
-            "--port", type=int, default=8000, help="Port to run the web panel on."
-        )
-        parser.add_argument(
-            "--redis-port",
-            type=int,
-            default=12800,
-            help="Port to run the web panel on.",
-        )
-        parser.add_argument(
-            "--config",
-            type=str,
-            default=None,
-            required=True,
-            help="Path to TOML configuration file to load.",
-        )
-        parser.add_argument(
-            "--redis-logfile-path",
-            type=str,
-            default="/tmp/redis.log",
-            help="The redis server log file path.",
-        )
+        # This means that args are not parsed in dataset entry script
+        # So we need to parse the args manually
+        parser = worker_entry_parser()
         try:
             args = parser.parse_args()
         except SystemExit as e:

--- a/cosmos_rl/dispatcher/run_web_panel.py
+++ b/cosmos_rl/dispatcher/run_web_panel.py
@@ -426,9 +426,9 @@ async def validation_report(request: ValidationReportRequest):
 async def put_rollout_group(rollout: RolloutRequest):
     try:
         if rollout.is_end:
-            assert (
-                len(rollout.prompt_idxs) == 0
-            ), "Prompt idxs should be empty if is_end is True"
+            assert len(rollout.prompt_idxs) == 0, (
+                "Prompt idxs should be empty if is_end is True"
+            )
             logger.info(
                 f"[Controller] Received rollout end signal from {rollout.src_replica_name}"
             )
@@ -518,9 +518,9 @@ async def put_rollout_group(rollout: RolloutRequest):
                     )
                 )
                 for shared_prefix, rollout_indices in shared_prefix_groups.items():
-                    assert (
-                        len(rollout_indices) > 1
-                    ), "Shared prefix group should not be empty"
+                    assert len(rollout_indices) > 1, (
+                        "Shared prefix group should not be empty"
+                    )
                     # Check if the shared prefix holds different rewards
                     rewards = [rollouts_group[i].reward for i in rollout_indices]
                     if len(set(rewards)) > 1:
@@ -641,7 +641,10 @@ def main(
             "--port", type=int, default=8000, help="Port to run the web panel on."
         )
         parser.add_argument(
-            "--redis-port", type=int, default=12800, help="Port to run the web panel on."
+            "--redis-port",
+            type=int,
+            default=12800,
+            help="Port to run the web panel on.",
         )
         parser.add_argument(
             "--config",
@@ -656,13 +659,17 @@ def main(
             default="/tmp/redis.log",
             help="The redis server log file path.",
         )
-        args = parser.parse_args()
+        try:
+            args = parser.parse_args()
+        except SystemExit as e:
+            logger.error(
+                "Error when parsing args. Did you use custom arguments in your script? If so, please check your custom script and pass `args` to this main function."
+            )
+            raise e
 
     # Load config from file if provided
     loaded_config = None
-    assert os.path.exists(
-        args.config
-    ), f"Config file {args.config} does not exist."
+    assert os.path.exists(args.config), f"Config file {args.config} does not exist."
 
     try:
         logger.info(f"Attempting to load configuration from {args.config}")
@@ -686,9 +693,9 @@ def main(
                 )
 
         if data_packer is not None:
-            assert isinstance(
-                data_packer, DataPacker
-            ), "data_packer should be a DataPacker instance"
+            assert isinstance(data_packer, DataPacker), (
+                "data_packer should be a DataPacker instance"
+            )
         controller.setup(
             loaded_config,
             redis_port=args.redis_port,

--- a/cosmos_rl/dispatcher/run_web_panel.py
+++ b/cosmos_rl/dispatcher/run_web_panel.py
@@ -426,9 +426,9 @@ async def validation_report(request: ValidationReportRequest):
 async def put_rollout_group(rollout: RolloutRequest):
     try:
         if rollout.is_end:
-            assert len(rollout.prompt_idxs) == 0, (
-                "Prompt idxs should be empty if is_end is True"
-            )
+            assert (
+                len(rollout.prompt_idxs) == 0
+            ), "Prompt idxs should be empty if is_end is True"
             logger.info(
                 f"[Controller] Received rollout end signal from {rollout.src_replica_name}"
             )
@@ -518,9 +518,9 @@ async def put_rollout_group(rollout: RolloutRequest):
                     )
                 )
                 for shared_prefix, rollout_indices in shared_prefix_groups.items():
-                    assert len(rollout_indices) > 1, (
-                        "Shared prefix group should not be empty"
-                    )
+                    assert (
+                        len(rollout_indices) > 1
+                    ), "Shared prefix group should not be empty"
                     # Check if the shared prefix holds different rewards
                     rewards = [rollouts_group[i].reward for i in rollout_indices]
                     if len(set(rewards)) > 1:
@@ -693,9 +693,9 @@ def main(
                 )
 
         if data_packer is not None:
-            assert isinstance(data_packer, DataPacker), (
-                "data_packer should be a DataPacker instance"
-            )
+            assert isinstance(
+                data_packer, DataPacker
+            ), "data_packer should be a DataPacker instance"
         controller.setup(
             loaded_config,
             redis_port=args.redis_port,

--- a/cosmos_rl/dispatcher/run_web_panel.py
+++ b/cosmos_rl/dispatcher/run_web_panel.py
@@ -604,6 +604,7 @@ def main(
     val_reward_fns: Optional[List[Callable]] = None,
     val_data_packer: Optional[DataPacker] = None,
     custom_logger_fns: Optional[List[Callable]] = None,
+    args: Optional[argparse.Namespace] = None,
     **kwargs,
 ):
     if kwargs:
@@ -631,39 +632,41 @@ def main(
             run_rollout()
         return
 
-    parser = argparse.ArgumentParser(
-        description="Run the web panel for the dispatcher."
-    )
-    parser.add_argument(
-        "--port", type=int, default=8000, help="Port to run the web panel on."
-    )
-    parser.add_argument(
-        "--redis-port", type=int, default=12800, help="Port to run the web panel on."
-    )
-    parser.add_argument(
-        "--config-file",
-        type=str,
-        default=None,
-        required=True,
-        help="Path to TOML configuration file to load.",
-    )
-    parser.add_argument(
-        "--redis-logfile-path",
-        type=str,
-        default="/tmp/redis.log",
-        help="The redis server log file path.",
-    )
-    args = parser.parse_args()
+    if args is None:
+        # This means we should parse the args manually
+        parser = argparse.ArgumentParser(
+            description="Run the web panel for the dispatcher."
+        )
+        parser.add_argument(
+            "--port", type=int, default=8000, help="Port to run the web panel on."
+        )
+        parser.add_argument(
+            "--redis-port", type=int, default=12800, help="Port to run the web panel on."
+        )
+        parser.add_argument(
+            "--config",
+            type=str,
+            default=None,
+            required=True,
+            help="Path to TOML configuration file to load.",
+        )
+        parser.add_argument(
+            "--redis-logfile-path",
+            type=str,
+            default="/tmp/redis.log",
+            help="The redis server log file path.",
+        )
+        args = parser.parse_args()
 
     # Load config from file if provided
     loaded_config = None
     assert os.path.exists(
-        args.config_file
-    ), f"Config file {args.config_file} does not exist."
+        args.config
+    ), f"Config file {args.config} does not exist."
 
     try:
-        logger.info(f"Attempting to load configuration from {args.config_file}")
-        with open(args.config_file, "r") as f:
+        logger.info(f"Attempting to load configuration from {args.config}")
+        with open(args.config, "r") as f:
             config_dict = toml.load(f)
 
         # Ensure CosmosConfig is available (it's imported at the top now)
@@ -698,12 +701,12 @@ def main(
             val_data_packer=val_data_packer,
             custom_logger_fns=custom_logger_fns,
         )
-        logger.info(f"Successfully loaded configuration from {args.config_file}")
+        logger.info(f"Successfully loaded configuration from {args.config}")
     except FileNotFoundError:
-        raise FileNotFoundError(f"Config file not found: {args.config_file}")
+        raise FileNotFoundError(f"Config file not found: {args.config}")
     except Exception as e:
         raise RuntimeError(
-            f"Failed to load or parse config file {args.config_file}: {e}.",
+            f"Failed to load or parse config file {args.config}: {e}.",
             exc_info=True,
         )
 

--- a/cosmos_rl/launcher/launch_all.py
+++ b/cosmos_rl/launcher/launch_all.py
@@ -78,7 +78,7 @@ def wait_for_url_ready(url: str, process: Optional[subprocess.Popen] = None):
                         sys.exit(1)
                     else:
                         logger.error(
-                            f"Process {process.pid} exited with code {process.returncode} as soon as launched. Exiting."
+                            f"Process {process.pid} exited as soon as launched. Exiting."
                         )
                         sys.exit(1)
             sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)

--- a/cosmos_rl/launcher/launch_all.py
+++ b/cosmos_rl/launcher/launch_all.py
@@ -23,6 +23,7 @@ import time
 import os
 import re
 import argparse
+from argparse import REMAINDER
 from typing import List, Dict, Optional, Any, Callable
 import toml
 import tempfile
@@ -77,7 +78,7 @@ def wait_for_url_ready(url: str, process: Optional[subprocess.Popen] = None):
                         sys.exit(1)
                     else:
                         logger.error(
-                            f"Process {process.pid} exited as soon as launched. Exiting."
+                            f"Process {process.pid} exited with code {process.returncode} as soon as launched. Exiting."
                         )
                         sys.exit(1)
             sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
@@ -280,13 +281,6 @@ def parse_args():
     )
 
     parser.add_argument(
-        "script",
-        nargs="?",  # “?” means 0 or 1 occurrences
-        default=None,
-        help="A user script which can be provided for custom dataset, reward functions, and model registration.",
-    )
-
-    parser.add_argument(
         "--lepton-mode",
         action="store_true",
         default=False,
@@ -429,6 +423,17 @@ def parse_args():
         help="Reservation ID for dedicated node groups",
     )
 
+    # Positional arguments
+
+    parser.add_argument(
+        "script",
+        nargs="?",  # “?” means 0 or 1 occurrences
+        default=None,
+        help="A user script which can be provided for custom dataset, reward functions, and model registration.",
+    )
+
+    parser.add_argument("script_args", nargs=REMAINDER)
+
     args = parser.parse_args()
 
     # Validate Lepton mode arguments
@@ -474,6 +479,7 @@ def replica_placement(
     script: Optional[str] = None,
     backend: str = "vllm",
     config_path: Optional[str] = None,
+    script_args: Optional[List[Any]] = None,
 ) -> List[List[str]]:
     commands = []
     gpu_devices = []
@@ -516,6 +522,9 @@ def replica_placement(
                         rdzv_ip = get_worker_ip(global_worker_idx)
                 else:
                     commands[-1] += f" --rdzv-endpoint {rdzv_ip}:{rdzv_port}"
+
+                if script_args is not None:
+                    commands[-1] += f" {' '.join(script_args)}"
 
                 control_urls.append(control_url)
                 output_files.append(
@@ -562,6 +571,8 @@ def replica_placement(
             )
             if script is not None:
                 commands[-1] += f" --script {script}"
+            if script_args is not None:
+                commands[-1] += f" {' '.join(script_args)}"
             control_urls.append(control_url)
             output_files.append(
                 os.path.join(output_dir, f"policy_{i}.log")
@@ -609,6 +620,9 @@ def replica_placement(
                 else:
                     commands[-1] += f" --rdzv-endpoint {rdzv_ip}:{rdzv_port}"
 
+                if script_args is not None:
+                    commands[-1] += f" {' '.join(script_args)}"
+
                 control_urls.append(control_url)
                 output_files.append(
                     os.path.join(output_dir, f"rollout_{i}.log")
@@ -652,6 +666,10 @@ def replica_placement(
             )
             if script is not None:
                 commands[-1] += f" --script {script}"
+
+            if script_args is not None:
+                commands[-1] += f" {' '.join(script_args)}"
+
             control_urls.append(control_url)
             output_files.append(
                 os.path.join(output_dir, f"rollout_{i}.log")
@@ -1175,7 +1193,9 @@ cosmos-rl --config config.toml"""
         controller_cmd = f"{controller_script} --config {tmpfile_toml}"
         controller_cmd += f" --port {port}"
         if script:
-            controller_cmd += f" {script}"
+            controller_cmd += f" --script {script}"
+        if args.script_args is not None:
+            controller_cmd += f" {' '.join(args.script_args)}"
         control_url = f"localhost:{port}"
 
     def get_lepton_ip(worker_idx: int) -> str:
@@ -1231,6 +1251,7 @@ cosmos-rl --config config.toml"""
         script=script,
         backend=backend,
         config_path=tmpfile_toml,
+        script_args=args.script_args,
     )
 
     num_workers = len(global_launch_settings)

--- a/cosmos_rl/launcher/launch_controller.sh
+++ b/cosmos_rl/launcher/launch_controller.sh
@@ -4,6 +4,7 @@ PORT=""
 CONFIG_FILE=""
 LOG_FILE=""
 SCRIPT="cosmos_rl.dispatcher.run_web_panel"
+SCRIPT_ARGS=()
 
 show_help() {
   echo "Usage: $0 [options]"
@@ -14,6 +15,7 @@ show_help() {
   echo "  --log <file>        Specify the redis log file"
   echo "  --help              Show this help message and exit"
   echo "  <script>            Specify the script to run"
+  echo "  <script_args>      Specify the script arguments"
 }
 
 while [[ $# -gt 0 ]]; do
@@ -30,13 +32,17 @@ while [[ $# -gt 0 ]]; do
       LOG_FILE="$2"
       shift 2
       ;;
+    --script)
+      SCRIPT="$2"
+      echo "Using script: $SCRIPT"
+      shift 2
+      ;;
     --help)
       show_help
       exit 0
       ;;
     *)
-      SCRIPT="$1"
-      echo "Using script: $SCRIPT"
+      SCRIPT_ARGS+=("$1")
       shift
       ;;
   esac
@@ -60,7 +66,11 @@ if [[ -n "$LOG_FILE" ]]; then
   CMD+=" --redis-logfile-path $LOG_FILE"
 fi
 
-echo "${CMD}"
+if [[ -n "$SCRIPT_ARGS" ]]; then
+  CMD+=" ${SCRIPT_ARGS[@]}"
+fi
+
+echo "Controller CMD: ${CMD}"
 
 export COSMOS_ROLE="Controller"
 $CMD

--- a/cosmos_rl/launcher/launch_replica.sh
+++ b/cosmos_rl/launcher/launch_replica.sh
@@ -7,6 +7,7 @@ LOG_RANKS=""
 TYPE=""
 RDZV_ENDPOINT="localhost:0"
 SCRIPT=""
+SCRIPT_ARGS=()
 CONFIG=""
 BACKEND="vllm"
 
@@ -77,9 +78,8 @@ while [[ $# -gt 0 ]]; do
     exit 0
     ;;
   *)
-    echo "Unknown option: $1"
-    print_help
-    exit 1
+    SCRIPT_ARGS+=("$1")
+    shift
     ;;
   esac
 done
@@ -185,9 +185,15 @@ if [ -n "$SCRIPT" ]; then
     LAUNCH_CMD+=(
       -m "$SCRIPT"
     )
+    LAUNCH_CMD+=(
+      "${SCRIPT_ARGS[@]}"
+    )
   else
     LAUNCH_CMD+=(
       "$SCRIPT"
+    )
+    LAUNCH_CMD+=(
+      "${SCRIPT_ARGS[@]}"
     )
   fi
 else

--- a/cosmos_rl/launcher/worker_entry.py
+++ b/cosmos_rl/launcher/worker_entry.py
@@ -6,6 +6,7 @@ from cosmos_rl.policy.config import Config as CosmosConfig
 from torch.utils.data import Dataset
 import argparse
 
+
 def main(
     dataset: Optional[Union[Dataset, Callable[[CosmosConfig], Dataset]]] = None,
     data_packer: Optional[DataPacker] = None,

--- a/cosmos_rl/launcher/worker_entry.py
+++ b/cosmos_rl/launcher/worker_entry.py
@@ -4,7 +4,7 @@ from cosmos_rl.dispatcher.data.packer.base import DataPacker
 from cosmos_rl.utils.logging import logger
 from cosmos_rl.policy.config import Config as CosmosConfig
 from torch.utils.data import Dataset
-
+import argparse
 
 def main(
     dataset: Optional[Union[Dataset, Callable[[CosmosConfig], Dataset]]] = None,
@@ -14,7 +14,7 @@ def main(
     val_reward_fns: Optional[List[Callable]] = None,
     val_data_packer: Optional[DataPacker] = None,
     custom_logger_fns: Optional[List[Callable]] = None,
-    *args,
+    args: Optional[argparse.Namespace] = None,
     **kwargs,
 ):
     if kwargs:
@@ -33,6 +33,7 @@ def main(
             val_reward_fns=val_reward_fns,
             val_data_packer=val_data_packer,
             custom_logger_fns=custom_logger_fns,
+            args=args,
         )
     elif role == "Policy":
         from cosmos_rl.policy.train import main as policy_main

--- a/cosmos_rl/tools/dataset/gsm8k_grpo.py
+++ b/cosmos_rl/tools/dataset/gsm8k_grpo.py
@@ -227,7 +227,6 @@ class GSM8kDataPacker(DataPacker):
 
 
 if __name__ == "__main__":
-
     def get_dataset(config: CosmosConfig) -> Dataset:
         return GSM8kDataset()
 

--- a/cosmos_rl/tools/dataset/gsm8k_grpo.py
+++ b/cosmos_rl/tools/dataset/gsm8k_grpo.py
@@ -227,6 +227,7 @@ class GSM8kDataPacker(DataPacker):
 
 
 if __name__ == "__main__":
+
     def get_dataset(config: CosmosConfig) -> Dataset:
         return GSM8kDataset()
 

--- a/tests/custom_dataset/custom_gsm8k_grpo.py
+++ b/tests/custom_dataset/custom_gsm8k_grpo.py
@@ -10,7 +10,6 @@ from cosmos_rl.tools.dataset.gsm8k_grpo import (
 from cosmos_rl.utils.logging import logger
 from cosmos_rl.policy.config import Config as CosmosConfig
 from torch.utils.data import Dataset
-import sys
 
 
 class MinimalGSM8kDataset(GSM8kDataset):
@@ -41,9 +40,9 @@ if __name__ == "__main__":
         args = parser.parse_args()
         assert args.x_arg == "cosmos_rl"
         assert args.foo == "cosmos"
-    except Exception as e:
-        logger.error(f"Error parsing arguments: {e}")
-        sys.exit(1)
+    except SystemExit as e:
+        logger.error("Error parsing arguments.")
+        raise e
 
     def get_dataset(config: CosmosConfig) -> Dataset:
         return MinimalGSM8kDataset()

--- a/tests/custom_dataset/custom_gsm8k_grpo.py
+++ b/tests/custom_dataset/custom_gsm8k_grpo.py
@@ -1,11 +1,24 @@
 from cosmos_rl.dispatcher.data.packer import worker_entry_parser
+from cosmos_rl.launcher.worker_entry import main as launch_worker
+from cosmos_rl.tools.dataset.gsm8k_grpo import GSM8kDataset, GSM8kValDataset, custom_reward_fn, custom_logger_fn, GSM8kDataPacker
 from cosmos_rl.utils.logging import logger
+from cosmos_rl.policy.config import Config as CosmosConfig
+from torch.utils.data import Dataset
 import sys
+
+
+class MinimalGSM8kDataset(GSM8kDataset):
+    def __len__(self):
+        return 8
+
+class MinimalGSM8kValDataset(GSM8kValDataset):
+    def __len__(self):
+        return 8
 
 if __name__ == "__main__":
     parser = worker_entry_parser()
 
-    # add custom arguments here
+    # Users can add custom arguments here
     parser.add_argument("--foo", type=str, default="bar", help="The custom optional argument name.")
     parser.add_argument(
         "x_arg",
@@ -13,12 +26,27 @@ if __name__ == "__main__":
         default=None,
         help="The custom positional argument name.",
     )
+
     try:
         args = parser.parse_args()
-        logger.info(f"LMS: args: {args}")
-        # assert args.x_arg == "cosmos_rl"
-        # assert args.foo == "cosmos"
+        assert args.x_arg == "cosmos_rl"
+        assert args.foo == "cosmos"
     except Exception as e:
         logger.error(f"Error parsing arguments: {e}")
         sys.exit(1)
-    sys.exit(0)
+
+    def get_dataset(config: CosmosConfig) -> Dataset:
+        return MinimalGSM8kDataset()
+
+    def get_val_dataset(config: CosmosConfig) -> Dataset:
+        return MinimalGSM8kValDataset()
+
+    launch_worker(
+        dataset=get_dataset,
+        val_dataset=get_val_dataset,
+        reward_fns=[custom_reward_fn],
+        data_packer=GSM8kDataPacker(),
+        val_data_packer=GSM8kDataPacker(),
+        custom_logger_fns=[custom_logger_fn],
+        args=args, # Note: args must be passed if you want to use custom arguments
+    )

--- a/tests/custom_dataset/custom_gsm8k_grpo.py
+++ b/tests/custom_dataset/custom_gsm8k_grpo.py
@@ -1,6 +1,12 @@
 from cosmos_rl.dispatcher.data.packer import worker_entry_parser
 from cosmos_rl.launcher.worker_entry import main as launch_worker
-from cosmos_rl.tools.dataset.gsm8k_grpo import GSM8kDataset, GSM8kValDataset, custom_reward_fn, custom_logger_fn, GSM8kDataPacker
+from cosmos_rl.tools.dataset.gsm8k_grpo import (
+    GSM8kDataset,
+    GSM8kValDataset,
+    custom_reward_fn,
+    custom_logger_fn,
+    GSM8kDataPacker,
+)
 from cosmos_rl.utils.logging import logger
 from cosmos_rl.policy.config import Config as CosmosConfig
 from torch.utils.data import Dataset
@@ -11,15 +17,19 @@ class MinimalGSM8kDataset(GSM8kDataset):
     def __len__(self):
         return 8
 
+
 class MinimalGSM8kValDataset(GSM8kValDataset):
     def __len__(self):
         return 8
+
 
 if __name__ == "__main__":
     parser = worker_entry_parser()
 
     # Users can add custom arguments here
-    parser.add_argument("--foo", type=str, default="bar", help="The custom optional argument name.")
+    parser.add_argument(
+        "--foo", type=str, default="bar", help="The custom optional argument name."
+    )
     parser.add_argument(
         "x_arg",
         type=str,
@@ -48,5 +58,5 @@ if __name__ == "__main__":
         data_packer=GSM8kDataPacker(),
         val_data_packer=GSM8kDataPacker(),
         custom_logger_fns=[custom_logger_fn],
-        args=args, # Note: args must be passed if you want to use custom arguments
+        args=args,  # Note: args must be passed if you want to use custom arguments
     )

--- a/tests/custom_dataset/custom_gsm8k_grpo.py
+++ b/tests/custom_dataset/custom_gsm8k_grpo.py
@@ -1,0 +1,24 @@
+from cosmos_rl.dispatcher.data.packer import worker_entry_parser
+from cosmos_rl.utils.logging import logger
+import sys
+
+if __name__ == "__main__":
+    parser = worker_entry_parser()
+
+    # add custom arguments here
+    parser.add_argument("--foo", type=str, default="bar", help="The custom optional argument name.")
+    parser.add_argument(
+        "x_arg",
+        type=str,
+        default=None,
+        help="The custom positional argument name.",
+    )
+    try:
+        args = parser.parse_args()
+        logger.info(f"LMS: args: {args}")
+        # assert args.x_arg == "cosmos_rl"
+        # assert args.foo == "cosmos"
+    except Exception as e:
+        logger.error(f"Error parsing arguments: {e}")
+        sys.exit(1)
+    sys.exit(0)

--- a/tests/test_custom_args.py
+++ b/tests/test_custom_args.py
@@ -80,21 +80,27 @@ dp_replicate_size = 1
 
 """
 
+
 class TestCustomArgs(unittest.TestCase):
     def test_custom_args(self):
         # save the config file to a temp file
-        with tempfile.NamedTemporaryFile(mode="w+", suffix=".toml", delete=False) as tmpfile:
+        with tempfile.NamedTemporaryFile(
+            mode="w+", suffix=".toml", delete=False
+        ) as tmpfile:
             tmpfile.write(config_content)
             tmpfile_toml = tmpfile.name
 
         current_dir = os.path.dirname(os.path.abspath(__file__))
         config_file = f"{tmpfile_toml}"
-        custom_dataset_script = os.path.join(current_dir, "custom_dataset/custom_gsm8k_grpo.py")
+        custom_dataset_script = os.path.join(
+            current_dir, "custom_dataset/custom_gsm8k_grpo.py"
+        )
         cmd = f"cosmos-rl --config {config_file} {custom_dataset_script} --foo cosmos cosmos_rl"
         process = subprocess.Popen(cmd, shell=True)
 
         process.wait()
         self.assertEqual(process.returncode, 0)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_custom_args.py
+++ b/tests/test_custom_args.py
@@ -1,11 +1,94 @@
 import os
 import unittest
 import subprocess
+import tempfile
+
+config_content = """
+redis = "12808"
+
+[train]
+resume = false
+epoch = 1
+output_dir = "./outputs/qwen2-5-3b-p-fsdp1-tp1-r-tp1-pp1-grpo"
+epsilon = 1e-6
+optm_name = "AdamW"
+optm_lr = 1e-6
+optm_impl = "fused"
+optm_weight_decay = 0.01
+optm_betas = [ 0.9, 0.999,]
+optm_warmup_steps = 20
+optm_grad_norm_clip = 1.0
+async_tp_enabled = false
+compile = false
+param_dtype = "bfloat16"
+fsdp_reduce_dtype = "float32"
+fsdp_offload = false
+fsdp_reshard_after_forward = "default"
+train_batch_per_replica = 32
+sync_weight_interval = 1
+
+[rollout]
+gpu_memory_utilization = 0.7
+enable_chunked_prefill = false
+max_response_length = 2048
+n_generation = 16
+batch_size = 4
+quantization = "none"
+
+
+[policy]
+model_name_or_path = "Qwen/Qwen2.5-3B-Instruct"
+model_max_length = 4096
+model_gradient_checkpointing = false
+
+[logging]
+logger = ['console', 'wandb']
+project_name = "cosmos_rl"
+experiment_name = "None"
+
+[train.train_policy]
+type = "grpo"
+dataset.name = "JiaxinTsao/math_examples"
+prompt_column_name = "prompt"
+response_column_name = "result"
+dataset.split = "train"
+reward_function = "boxed_math"
+temperature = 0.9
+epsilon_low = 0.2
+epsilon_high = 0.2
+kl_beta = 0.0
+mu_iterations = 1
+min_filter_prefix_tokens = 1
+
+[train.ckpt]
+enable_checkpoint = false
+save_freq = 20
+save_mode = "async"
+
+[rollout.parallelism]
+n_init_replicas = 1
+tp_size = 1
+pp_size = 1
+
+[policy.parallelism]
+n_init_replicas = 1
+tp_size = 1
+cp_size = 1
+dp_shard_size = 1
+pp_size = 1
+dp_replicate_size = 1
+
+"""
 
 class TestCustomArgs(unittest.TestCase):
     def test_custom_args(self):
+        # save the config file to a temp file
+        with tempfile.NamedTemporaryFile(mode="w+", suffix=".toml", delete=False) as tmpfile:
+            tmpfile.write(config_content)
+            tmpfile_toml = tmpfile.name
+
         current_dir = os.path.dirname(os.path.abspath(__file__))
-        config_file = os.path.join(current_dir, "../configs/qwen2-5/qwen2-5-3b-p-fsdp1-tp1-r-tp1-pp1-grpo.toml")
+        config_file = f"{tmpfile_toml}"
         custom_dataset_script = os.path.join(current_dir, "custom_dataset/custom_gsm8k_grpo.py")
         cmd = f"cosmos-rl --config {config_file} {custom_dataset_script} --foo cosmos cosmos_rl"
         process = subprocess.Popen(cmd, shell=True)

--- a/tests/test_custom_args.py
+++ b/tests/test_custom_args.py
@@ -1,0 +1,17 @@
+import os
+import unittest
+import subprocess
+
+class TestCustomArgs(unittest.TestCase):
+    def test_custom_args(self):
+        current_dir = os.path.dirname(os.path.abspath(__file__))
+        config_file = os.path.join(current_dir, "../configs/qwen2-5/qwen2-5-3b-p-fsdp1-tp1-r-tp1-pp1-grpo.toml")
+        custom_dataset_script = os.path.join(current_dir, "custom_dataset/custom_gsm8k_grpo.py")
+        cmd = f"cosmos-rl --config {config_file} {custom_dataset_script} --foo cosmos cosmos_rl"
+        process = subprocess.Popen(cmd, shell=True)
+
+        process.wait()
+        self.assertEqual(process.returncode, 0)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Users could pass custom arguments to customized dataset script like:
```
cosmos-rl --config ./configs/qwen2-5/qwen2-5-3b-p-fsdp1-tp1-r-tp1-pp1-grpo.toml ./tests/custom_dataset/custom_gsm8k_grpo.py --foo cosmos cosmos_rl
```

`--foo cosmos cosmos_rl` will be forwarded to the `custom_gsm8k_grpo.py` and users must handle them manually.

To achieve this, users must add customized argument to `worker_entry_parser`. Then they can do some customized things inside the entry script.