### PR TITLE
[Fix] Deepseek V3 GRPO bug fix

### DIFF
--- a/cosmos_rl/rollout/vllm_rollout/vllm_rollout.py
+++ b/cosmos_rl/rollout/vllm_rollout/vllm_rollout.py
@@ -107,7 +107,8 @@ class vLLMRollout(RolloutBase):
             disable_mm_preprocessor_cache = False
 
             # Check if the model has MoE
-            moe_model_type = {"qwen3_moe", "deepseek_v3"}
+            # Note: even though deepseek_v3 is MoE, EP in rollout is not supported for it yet
+            moe_model_type = {"qwen3_moe"}
             multimodal_type = {"qwen2_5_vl"}
 
             model_type = self.model_config.model_type

--- a/cosmos_rl/utils/parallelism_map.py
+++ b/cosmos_rl/utils/parallelism_map.py
@@ -98,7 +98,9 @@ def slice_tensor_with_strategy(
     """
 
     view = tensor
-    assert view.shape[idx] % tensor_split_strategy.total_size == 0
+    assert (
+        view.shape[idx] % tensor_split_strategy.total_size == 0
+    ), f"Tensor shape {view.shape} on dim {idx} must be divisible by {tensor_split_strategy.total_size}"
     start = (
         view.shape[idx]
         // tensor_split_strategy.total_size


### PR DESCRIPTION
Currently Deepseek V3 runs hit [this](https://github.com/nvidia-cosmos/cosmos-rl/blob/main/cosmos_rl/utils/parallelism_map.py#L101) assertion issue when running GRPO when using EP. However, for deepseek model, given the mix of dense/MoE layers, EP is not supported in rollout. In other words, rollout assumes that the tensor being constructed in the full tensor.

This PR removes `deepseek_v3` model from the list of MoE models in rollout to get around the issue.

As part of the investigation, I also noticed part of the logic in weight mapper is not used and can be removed to avoid confusion.
