### PR TITLE
feat: Support epoch level save frequency by `save_freq_in_epoch`

### DIFF
--- a/cosmos_rl/dispatcher/command.py
+++ b/cosmos_rl/dispatcher/command.py
@@ -371,6 +371,8 @@ class DataFetchCommand(Command):
         global_step: int,
         total_steps: int,
         remain_samples_num: int,
+        # For save checkpoint
+        do_save: bool = False,
         # For profiling
         do_profile: Optional[bool] = None,
         active_steps: Optional[int] = None,
@@ -390,6 +392,8 @@ class DataFetchCommand(Command):
         self.total_steps = total_steps
         self.remain_samples_num = remain_samples_num
 
+        self.do_save = do_save
+
         # Profling config
         self.do_profile = do_profile
         self.active_steps = active_steps
@@ -404,6 +408,8 @@ class DataFetchCommand(Command):
     global_step: Optional[int]
     total_steps: Optional[int]
     remain_samples_num: int
+
+    do_save: bool
 
     do_profile: bool
     active_steps: int
@@ -421,6 +427,7 @@ class DataFetchCommand(Command):
         global_step: Optional[int],
         total_steps: Optional[int],
         remain_samples_num: int,
+        do_save: bool,
         redis_handler: RedisStreamHandler,
     ):
         cmd = cls(
@@ -429,6 +436,7 @@ class DataFetchCommand(Command):
             global_step,
             total_steps,
             remain_samples_num,
+            do_save,
             replica.sub_profiler_config.do_profile,
             replica.sub_profiler_config.active_steps,
             replica.sub_profiler_config.rank_filter,

--- a/cosmos_rl/dispatcher/controller.py
+++ b/cosmos_rl/dispatcher/controller.py
@@ -344,6 +344,9 @@ class Controller:
             config,
             self.redis_controller,
             remain_samples_num=remain_samples_num,
+            samples_per_epoch=len(self.dataset.train_set) * config.rollout.n_generation
+            if self.is_rl
+            else 0,
             tokenizer=self.tokenizer,
             val_dataloader=val_dataloader,
             current_step=self.ckpt_extra_info.get("step", 0),

--- a/cosmos_rl/policy/config/__init__.py
+++ b/cosmos_rl/policy/config/__init__.py
@@ -152,6 +152,10 @@ class CheckpointConfig(BaseModel):
     save_freq: int = Field(
         default=20, description="Checkpoint save frequency for training steps"
     )
+    save_freq_in_epoch: int = Field(
+        default=0,
+        description="Checkpoint save frequency for training epochs. Default to 0 (disabled).",
+    )
     save_mode: str = Field(
         default="async",
         description="Checkpoint save mode for training steps",
@@ -203,8 +207,10 @@ class CheckpointConfig(BaseModel):
             raise ValueError(
                 f"Invalid save_mode: {self.save_mode}. Must be one of ['async', 'sync']"
             )
-        if self.save_freq <= 0:
-            raise ValueError(f"save_freq must be greater than 0, got {self.save_freq}")
+        if self.save_freq_in_epoch <= 0 and self.save_freq <= 0:
+            raise ValueError(
+                f"save_freq must be greater than 0 when save_freq_in_epoch disabled, got {self.save_freq}"
+            )
         return self
 
 

--- a/cosmos_rl/policy/trainer/grpo_trainer.py
+++ b/cosmos_rl/policy/trainer/grpo_trainer.py
@@ -964,6 +964,7 @@ class GRPOTrainer(Trainer):
                 current_step=command.global_step,
                 total_steps=command.total_steps,
                 remain_samples_num=command.remain_samples_num,
+                do_save_checkpoint=command.do_save,
             )
         else:
             report_data = {}
@@ -1239,7 +1240,11 @@ class GRPOTrainer(Trainer):
             return False, 0.0
 
     def train(
-        self, current_step: int, total_steps: int, remain_samples_num: int
+        self,
+        current_step: int,
+        total_steps: int,
+        remain_samples_num: int,
+        do_save_checkpoint: bool = False,
     ) -> Dict[str, Any]:
         pp_last_stage = (
             self.parallel_dims.pp_coord[0] == self.parallel_dims.pp_coord[1] - 1
@@ -1754,16 +1759,7 @@ class GRPOTrainer(Trainer):
                     for k, v in mfu.items():
                         report_data[f"train/{k}"] = v
         # checkpointing
-        if self.is_master_replica and (
-            (
-                self.config.train.ckpt.enable_checkpoint
-                and current_step % self.config.train.ckpt.save_freq == 0
-                and current_step > 0
-            )
-            or (
-                self.config.train.ckpt.enable_checkpoint and current_step == total_steps
-            )
-        ):
+        if self.is_master_replica and (do_save_checkpoint):
             if self.config.train.ckpt.export_safetensors:
                 logger.info(
                     f"[Policy] Saving huggingface checkpoint at step {current_step} to {self.config.train.output_dir}..."


### PR DESCRIPTION
Considering:
- The replica number changing in dynamic scaling which makes the steps needed for one epoch varying;
- The concurrent control may be needed to save checkpoint at both step level and epoch level.
So, we don't modify the save frequency in steps as a newly calculated step interval from the epochs. We rather add a new control besides the step level to exactly match the epoch level save frequency in the controller.
Both sft and rl are supported.
`save_freq_in_epoch` in` config.train.ckpt` can be used to specify the frequency at epoch level for saving checkpoints.