### PR TITLE
Implementation of DeepEP for Qwen3

### DIFF
--- a/cosmos_rl/policy/kernel/mlp.py
+++ b/cosmos_rl/policy/kernel/mlp.py
@@ -1,0 +1,39 @@
+import torch
+from torch import nn
+import torch.nn.functional as F
+
+
+class MLP(nn.Module):
+    """
+    Multi-Layer Perceptron (MLP) used as a feed-forward layer.
+
+    Attributes:
+        gate_proj (nn.Module): Linear layer for input-to-hidden transformation.
+        down_proj (nn.Module): Linear layer for hidden-to-output transformation.
+        up_proj (nn.Module): Additional linear layer for feature transformation.
+    """
+
+    def __init__(self, dim: int, inter_dim: int):
+        """
+        Initializes the MLP layer.
+
+        Args:
+            dim (int): Input and output dimensionality.
+            inter_dim (int): Hidden layer dimensionality.
+        """
+        super().__init__()
+        self.gate_proj = nn.Linear(dim, inter_dim, bias=False)
+        self.down_proj = nn.Linear(inter_dim, dim, bias=False)
+        self.up_proj = nn.Linear(dim, inter_dim, bias=False)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """
+        Forward pass for the MLP layer.
+
+        Args:
+            x (torch.Tensor): Input tensor.
+
+        Returns:
+            torch.Tensor: Output tensor after MLP computation.
+        """
+        return self.down_proj(F.silu(self.gate_proj(x)) * self.up_proj(x))

--- a/cosmos_rl/policy/kernel/moe/moe.py
+++ b/cosmos_rl/policy/kernel/moe/moe.py
@@ -13,18 +13,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from dataclasses import dataclass
 from typing import Optional, Tuple
 
 import torch
+import torch.distributed as dist
 import torch.nn as nn
 import torch.nn.functional as F
 
-try:
-    from torch.distributed.device_mesh import DeviceMesh
-    from torch.distributed.tensor import DTensor, Partial, Replicate, Shard
-except ImportError:
-    print("torch.distributed.tensor is not available. DeepSeek model will not work.")
+from torch.distributed.device_mesh import DeviceMesh
+from torch.distributed.tensor import DTensor, Partial, Shard
+import torch.distributed._symmetric_memory as symm_mem
 
 try:
     from grouped_gemm import ops
@@ -34,69 +32,14 @@ except ImportError:
         "pip install git+https://github.com/fanshiqing/grouped_gemm@v1.1.4"
     )
 
-from cosmos_rl.policy.kernel.megatron_moe.moe_utils import (
-    WeightedSwiGLUFunction,
-)
+from cosmos_rl.policy.kernel.moe.indices import generate_permute_indices
+from cosmos_rl.policy.kernel.moe.grouped_gemm import group_gemm_imp
+from cosmos_rl.policy.kernel.megatron_moe.moe_utils import WeightedSwiGLUFunction
 from cosmos_rl.policy.kernel.megatron_moe.token_dispatcher import (
     MoEConfig,
     MoEFlexTokenDispatcher,
 )
-
-_shared_experts_stream: Optional[torch.cuda.Stream] = None
-
-
-@dataclass
-class MoEArgs:
-    n_routed_experts: int
-    n_shared_experts: int
-    n_activated_experts: int
-    n_expert_groups: int
-    n_limited_groups: int
-    train_gate: bool
-    gate_bias_update_factor: float
-    aux_loss_coeff: float
-    score_func: str
-    route_scale: float
-    dim: int
-    moe_inter_dim: int
-    enable_deepep: bool = False
-    fake_balanced_gate: bool = False
-
-
-class MLP(nn.Module):
-    """
-    Multi-Layer Perceptron (MLP) used as a feed-forward layer.
-
-    Attributes:
-        gate_proj (nn.Module): Linear layer for input-to-hidden transformation.
-        down_proj (nn.Module): Linear layer for hidden-to-output transformation.
-        up_proj (nn.Module): Additional linear layer for feature transformation.
-    """
-
-    def __init__(self, dim: int, inter_dim: int, use_tp: bool = True):
-        """
-        Initializes the MLP layer.
-
-        Args:
-            dim (int): Input and output dimensionality.
-            inter_dim (int): Hidden layer dimensionality.
-        """
-        super().__init__()
-        self.gate_proj = nn.Linear(dim, inter_dim, bias=False)
-        self.down_proj = nn.Linear(inter_dim, dim, bias=False)
-        self.up_proj = nn.Linear(dim, inter_dim, bias=False)
-
-    def forward(self, x: torch.Tensor) -> torch.Tensor:
-        """
-        Forward pass for the MLP layer.
-
-        Args:
-            x (torch.Tensor): Input tensor.
-
-        Returns:
-            torch.Tensor: Output tensor after MLP computation.
-        """
-        return self.down_proj(F.silu(self.gate_proj(x)) * self.up_proj(x))
+from cosmos_rl.policy.kernel.symm_mem_recipes import OnDeviceAllToAllV
 
 
 class GroupedExperts(nn.Module):
@@ -113,25 +56,35 @@ class GroupedExperts(nn.Module):
         down_projs (nn.Parameter): Linear layer for hidden-to-output transformation.
     """
 
-    def __init__(self, args: MoEArgs):
+    def __init__(
+        self,
+        dim: int,
+        inter_dim: int,
+        n_routed_experts: int,
+    ):
         """
         Initializes the GroupedExperts module.
 
         Args:
-            args (MoEArgs): Model arguments containing the number of routed experts,
-                model and intermediate dimension parameters.
+            dim (int): Dimension of the model.
+            inter_dim (int): Intermediate dimension of the feed-forward layers.
+            n_routed_experts (int): Total number of experts in the MoE.
         """
         super().__init__()
-        self.n_routed_experts = args.n_routed_experts
-        self.gate_projs = nn.Parameter(
-            torch.empty(args.n_routed_experts, args.moe_inter_dim, args.dim)
-        )
-        self.up_projs = nn.Parameter(
-            torch.empty(args.n_routed_experts, args.moe_inter_dim, args.dim)
-        )
-        self.down_projs = nn.Parameter(
-            torch.empty(args.n_routed_experts, args.dim, args.moe_inter_dim)
-        )
+        self.n_routed_experts = n_routed_experts
+        self.gate_projs = nn.Parameter(torch.empty(n_routed_experts, inter_dim, dim))
+        self.up_projs = nn.Parameter(torch.empty(n_routed_experts, inter_dim, dim))
+        self.down_projs = nn.Parameter(torch.empty(n_routed_experts, dim, inter_dim))
+
+    def setup_mesh(self, ep_mesh: DeviceMesh) -> None:
+        assert ep_mesh is not None, "ep_mesh must be provided for MoE"
+        assert ep_mesh.ndim == 1, "We only support 1D mesh for MoE"
+        self.ep_mesh = ep_mesh
+        self.ep_size = ep_mesh.size()
+        self.ep_rank = ep_mesh.get_local_rank()
+        assert (
+            self.n_routed_experts % self.ep_size == 0
+        ), f"Number of experts must be divisible by ep_size (ep_size={self.ep_size})"
 
     def forward(
         self,
@@ -156,41 +109,30 @@ class GroupedExperts(nn.Module):
             torch.Tensor: Output tensor after expert computation.
                 Shape is [num_tokens, model_dim]
         """
-        assert not isinstance(x, DTensor)
-
-        if isinstance(self.gate_projs, DTensor):
-            ep_mesh = self.gate_projs.device_mesh
-            assert ep_mesh is not None
-            assert ep_mesh.ndim == 1, "We only support 1D mesh for MoE"
-            ep_size = ep_mesh.size()
-            ep_rank = ep_mesh.get_local_rank()
-        else:
-            ep_mesh = None
-            ep_size = 1
-            ep_rank = 0
-
-        assert (
-            self.n_routed_experts % ep_size == 0
-        ), f"Number of experts must be divisible by ep_size (ep_size={ep_size})"
+        if not hasattr(self, "ep_mesh"):
+            # Default expert parallelism parameters if EP is not enabled.
+            self.ep_mesh = None
+            self.ep_size = 1
+            self.ep_rank = 0
 
         # Replicate the tensor to all experts. This is sub-optimal but is
         # used by this implementation for correctness.
-        if ep_size > 1:
+        if self.ep_size > 1:
             x = DTensor.from_local(
-                x, device_mesh=ep_mesh, placements=[Shard(0)]
+                x, device_mesh=self.ep_mesh, placements=[Shard(0)]
             ).full_tensor()
             weights = DTensor.from_local(
-                weights, device_mesh=ep_mesh, placements=[Shard(0)]
+                weights, device_mesh=self.ep_mesh, placements=[Shard(0)]
             ).full_tensor()
             indices = DTensor.from_local(
-                indices, device_mesh=ep_mesh, placements=[Shard(0)]
+                indices, device_mesh=self.ep_mesh, placements=[Shard(0)]
             ).full_tensor()
             token_mask = DTensor.from_local(
-                token_mask, device_mesh=ep_mesh, placements=[Shard(0)]
+                token_mask, device_mesh=self.ep_mesh, placements=[Shard(0)]
             ).full_tensor()
 
-        n_local_experts = self.n_routed_experts // ep_size
-        experts_start_idx = ep_rank * n_local_experts
+        n_local_experts = self.n_routed_experts // self.ep_size
+        experts_start_idx = self.ep_rank * n_local_experts
         experts_end_idx = experts_start_idx + n_local_experts
 
         def get_local_proj(proj, expert_id):
@@ -232,8 +174,8 @@ class GroupedExperts(nn.Module):
             )
             y[0] += expert_out
 
-        if ep_size > 1:
-            y = DTensor.from_local(y, device_mesh=ep_mesh, placements=[Partial()])
+        if self.ep_size > 1:
+            y = DTensor.from_local(y, device_mesh=self.ep_mesh, placements=[Partial()])
             y = y.redistribute(placements=[Shard(0)]).to_local()
 
         return y
@@ -253,38 +195,47 @@ class GroupedExpertsDeepEP(nn.Module):
         down_projs (nn.Parameter): Linear layer for hidden-to-output transformation.
     """
 
-    def __init__(self, args: MoEArgs):
+    def __init__(
+        self,
+        dim: int,
+        inter_dim: int,
+        n_routed_experts: int,
+        n_activated_experts: int,
+    ):
         """
         Initializes the GroupedExperts module.
 
         Args:
-            args (MoEArgs): Model arguments containing the number of routed experts,
-                model and intermediate dimension parameters.
+            dim (int): Dimension of the model.
+            inter_dim (int): Intermediate dimension of the feed-forward layers.
+            n_routed_experts (int): Total number of experts in the MoE.
+            n_activated_experts (int): Number of activated experts in the MoE.
         """
         super().__init__()
+        self.n_activated_experts = n_activated_experts
+        self.n_routed_experts = n_routed_experts
 
         self.gate_and_up_projs = nn.Parameter(
-            torch.empty(args.n_routed_experts, args.dim, args.moe_inter_dim * 2)
+            torch.empty(n_routed_experts, inter_dim * 2, dim)
         )
-        self.down_projs = nn.Parameter(
-            torch.empty(args.n_routed_experts, args.moe_inter_dim, args.dim)
-        )
-        self.args = args
+        self.down_projs = nn.Parameter(torch.empty(n_routed_experts, dim, inter_dim))
 
     def init_token_dispatcher(self, ep_mesh: DeviceMesh):
+        assert ep_mesh is not None
         self.ep_size = ep_mesh.size()
         self.ep_rank = ep_mesh.get_local_rank()
 
-        # TODO: merge with MoEArgs
+        assert (
+            self.n_routed_experts % self.ep_size == 0
+        ), f"Number of experts must be divisible by ep_size (ep_size={self.ep_size})"
+
         config = MoEConfig(
-            moe_router_topk=self.args.n_activated_experts,
-            num_moe_experts=self.args.n_routed_experts,
+            moe_router_topk=self.n_activated_experts,
+            num_moe_experts=self.n_routed_experts,
             moe_permute_fusion=True,
         )
 
-        self.n_routed_experts = self.args.n_routed_experts
-
-        num_local_experts = self.args.n_routed_experts // self.ep_size
+        num_local_experts = self.n_routed_experts // self.ep_size
 
         local_expert_indices_offset = self.ep_rank * num_local_experts
         local_expert_indices = [
@@ -323,10 +274,6 @@ class GroupedExpertsDeepEP(nn.Module):
         """
         assert not isinstance(x, DTensor)
 
-        assert (
-            self.n_routed_experts % self.ep_size == 0
-        ), f"Number of experts must be divisible by ep_size (ep_size={self.ep_size})"
-
         indices = indices.masked_fill(~token_mask.unsqueeze(-1), -1)
 
         (permuted_local_hidden_states, tokens_per_expert, permuted_probs) = (
@@ -344,20 +291,281 @@ class GroupedExpertsDeepEP(nn.Module):
                 permuted_local_hidden_states,
                 self.gate_and_up_projs.to_local(),
                 tokens_per_expert,
-                trans_b=False,
+                trans_b=True,
             )
             output1_ = WeightedSwiGLUFunction.apply(output1, permuted_probs, False)
             output2 = ops.gmm(
-                output1_, self.down_projs.to_local(), tokens_per_expert, trans_b=False
+                output1_,
+                self.down_projs.to_local(),
+                tokens_per_expert,
+                trans_b=True,
             )
         else:
-            output1 = torch.matmul(x[0] * 0, self.gate_and_up_projs.to_local()[0])
+            gate_and_up_projs = (self.gate_and_up_projs.to_local()[0]).t()
+            down_projs = (self.down_projs.to_local()[0]).t()
+            output1 = torch.matmul(x[0] * 0, gate_and_up_projs)
             output1_ = WeightedSwiGLUFunction.apply(output1, permuted_probs, False)
-            output2 = torch.matmul(output1_, self.down_projs.to_local()[0])
+            output2 = torch.matmul(output1_, down_projs)
 
         y = self.token_dispatcher.token_unpermutation(output2)
 
         return y
+
+
+def setup_symm_mem(
+    max_batch_tokens: int,
+    model_dim: int,
+    dtype: torch.dtype,
+    device: torch.device,
+) -> None:
+    # Basically, max_seq_len * 2 is enough for all-to-all-v communication.
+    overflow = 2
+
+    OnDeviceAllToAllV.max_output_len = max_batch_tokens * overflow
+
+    # Init MoE kernel related buffers
+    if GroupedExpertsSymmMem.token_send_buf is None:
+        # Input buffer for DP-to-EP shuffle
+        GroupedExpertsSymmMem.token_send_buf = symm_mem.empty(
+            max_batch_tokens,
+            model_dim,  # hidden dim
+            dtype=dtype,
+            device=device,
+        )
+        GroupedExpertsSymmMem.token_send_buf.zero_()
+
+        # Input buffer for EP-to-DP shuffle
+        GroupedExpertsSymmMem.token_gather_buf = symm_mem.empty(
+            max_batch_tokens * overflow,
+            model_dim,  # hidden dim
+            dtype=dtype,
+            device=device,
+        )
+        GroupedExpertsSymmMem.token_gather_buf.zero_()
+
+
+class GroupedExpertsSymmMem(nn.Module):
+    """
+    FeedForward module, support hybrid parallelism including:
+    - TP: Shard the experts row/col-wisely across TP groups
+    - EP: split the experts into groups, located on EP groups
+    - FSDP: Shard the weights across FSDP groups
+
+    Args:
+        dim (int): Input dimension.
+        inter_dim (int): Intermediate dimension.
+        model_args (Qwen3MoeArgs): Model configuration arguments.
+    """
+
+    token_send_buf: Optional[torch.Tensor] = None
+    token_gather_buf: Optional[torch.Tensor] = None
+
+    def __init__(
+        self,
+        dim: int,
+        inter_dim: int,
+        n_routed_experts: int,
+    ):
+        super().__init__()
+        self.total_experts = n_routed_experts
+        self.local_experts = n_routed_experts
+        self.gate_projs = nn.Parameter(torch.empty(self.local_experts, inter_dim, dim))
+        self.up_projs = nn.Parameter(torch.empty(self.local_experts, inter_dim, dim))
+        self.down_projs = nn.Parameter(torch.empty(self.local_experts, dim, inter_dim))
+        self.act_fn = F.silu
+
+        self.group_gemm_imp = group_gemm_imp()
+
+    def _sort_tokens(self, x, topk_ids, topk_weights):
+        # This part sorts the token indices so that tokens routed to the
+        # same expert reside consecutively. An implication is that tokens
+        # to the same "expert group" (i.e., device) are also consecutive.
+        # Since this is an "artificial" index creation (final outcome being
+        # `idxs`), we don't need gradients here.
+
+        del topk_weights
+
+        with torch.no_grad():
+            # [seq_len, n_routed_experts]
+            expert_counts = topk_ids.new_zeros((topk_ids.shape[0], self.total_experts))
+            # Fill 1 to the selected experts
+            expert_counts.scatter_(1, topk_ids, 1)
+            tokens_per_expert = expert_counts.sum(dim=0)
+            # Token indices for each expert
+            token_indices = topk_ids.view(-1).argsort()
+
+        sorted_tokens = x[token_indices // topk_ids.shape[1]]
+
+        return (sorted_tokens, token_indices, tokens_per_expert)
+
+    def _get_send_buf(self):
+        # [Why detach?] During a first forward-backward step, the buffer would
+        # be included in a computational graph. In a second step, autograd will
+        # return an error saying "Trying to backward through the graph a second
+        # time (or directly access saved tensors more than once)". This is
+        # because the buffer is still in the graph, and autograd is trying to
+        # backward through the graph a second time. To avoid this, we detach the
+        # buffer from the graph. `detach()` returns a new tensor, which shares
+        # the same storage with the original one.
+        self.token_send_buf.grad = None
+        return self.token_send_buf.detach()
+
+    def _get_gather_buf(self):
+        # See [Why detach?] in `_get_send_buf`
+        self.token_gather_buf.grad = None
+        return self.token_gather_buf.detach()
+
+    def _moe_on_device(self, x, topk_ids, topk_weight):
+        """
+        x: [batch * local_seq_len, dim]
+        topk_ids: [batch * local_seq_len, topk]
+        topk_weight: [batch * local_seq_len, topk]
+
+        sorted_tokens: [batch * local_seq_len * topk, dim]
+        token_indices: [batch * local_seq_len * topk]
+        tokens_per_expert: [n_experts]
+        """
+        (
+            sorted_tokens,
+            token_indices,
+            tokens_per_expert,
+        ) = self._sort_tokens(x, topk_ids, topk_weight)
+        # keep the seqlen dimension for later use without holding onto the sorted tokens
+        seqlen_sorted_tokens = sorted_tokens.shape[0]
+
+        # Sum the tokens over local experts, then we get tokens per EP rank,
+        # which is the input splits
+        with torch.no_grad():
+            # tokens_per_expert: [n_experts, 1]
+            # tokens_per_expert_group: [n_experts, 1]
+            tokens_per_expert_group = tokens_per_expert.new_empty(
+                tokens_per_expert.shape[0]
+            )
+            # For TP/EP mode, the input is sequencely parallelized
+            # So each EP group will have distinct, but the same number of tokens
+            # After this collective, tokens_per_expert_group is still of shape [n_experts, 1]
+
+            # Let's say we are on EP rank 0:
+            # recv: [(e0, e1, e2 ...), (e0, e1, e2 ...), ...], totally `n_experts` elements
+            #        ----------------: tokens from EP group 0 to EP group 0
+            #                          ----------------: tokens from EP group 1 to EP group 0
+            #                          ...
+            # So we can just concat
+            dist.all_to_all_single(
+                tokens_per_expert_group,
+                tokens_per_expert,
+                group=self.ep_group,
+                async_op=False,
+            )
+            input_splits = tokens_per_expert.view(self.ep_size, -1).sum(dim=1)
+        # Move input to the `token_send_buf` symm mem
+        token_send_buf = self._get_send_buf()
+        token_send_buf[: token_indices.shape[0]].copy_(sorted_tokens)
+        # Note: `out=` avoids copy, but it is not differentiable
+        # torch.index_select(x, 0, idxs // topk_ids.shape[1], out=token_send_buf[: idxs.shape[0]])
+
+        # Reference:
+        #   1. [TorchTitan](https://github.com/pytorch/torchtitan/blob/main/torchtitan/experiments/deepseek_v3/symm_mem_recipes/triton_on_device_all_to_all_v.py)
+        #   2. [Symm-mem-recipes](https://github.com/yifuwang/symm-mem-recipes)
+        token_gather_buf, output_splits = OnDeviceAllToAllV.apply(
+            token_send_buf,
+            input_splits,
+            self.ep_group,
+        )
+
+        # We need to permute the received tokens so that tokens for the same expert are contiguous.
+        # This part prepares a 1D tensor `permuted_indices` for such permutation.
+        # This part doesn't need gradient.
+        with torch.no_grad():
+            ALIGN_SIZE_M = 128
+            permuted_indices, m_sizes, m_offsets = generate_permute_indices(
+                tokens_per_expert_group,
+                self.local_experts,
+                self.ep_size,
+                ALIGN_SIZE_M,
+            )
+        # Permute the received tokens so that tokens for the same expert are contiguous.
+        contig_tokens = token_gather_buf[permuted_indices]
+        # group gemm - handle all three group gemms (up, gate, down for all experts)
+        # print(f"m_sizes: {m_sizes}, m_offsets: {m_offsets}")
+        hidden_outputs = self.group_gemm_imp(
+            contig_tokens,
+            m_sizes,
+            m_offsets,
+            self.gate_projs.to_local(),
+            self.up_projs.to_local(),
+            self.down_projs.to_local(),
+            self.act_fn,
+        )
+
+        # Prepare buffer for tokens processed by experts
+        processed_tokens = self._get_gather_buf()
+
+        # Move into Symmetric Memory for the return shuffle
+        processed_tokens[permuted_indices] = hidden_outputs
+
+        # Now shuffle the tokens back to their original owner, i.e. EP to DP shuffle.
+        # The input/output splits are just a reverse of the previous shuffle.
+        token_return_buf, _ = OnDeviceAllToAllV.apply(
+            processed_tokens,
+            output_splits,
+            self.ep_group,
+        )
+
+        returned_tokens = token_return_buf[:seqlen_sorted_tokens]
+        output_tokens = torch.empty_like(returned_tokens)
+        output_tokens[token_indices] = returned_tokens
+
+        final_out = (
+            output_tokens.view(*topk_ids.shape, -1)
+            .type(topk_weight.dtype)
+            .mul_(topk_weight.unsqueeze(dim=-1))
+            .sum(dim=1)
+            .type(returned_tokens.dtype)
+        )
+
+        return final_out
+
+    def setup_mesh(self, ep_mesh: DeviceMesh) -> None:
+        self.ep_group = ep_mesh.get_group()
+        self.ep_size = ep_mesh.size()
+        assert (
+            self.total_experts % ep_mesh.size() == 0
+        ), "number of experts must be divisible by ep_mesh.size()"
+        self.local_experts = self.total_experts // ep_mesh.size()
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        token_mask: torch.Tensor,
+        weights: torch.Tensor,
+        indices: torch.Tensor,
+    ) -> torch.Tensor:
+        """
+        Forward pass for the grouped experts.
+
+        Args:
+            x (torch.Tensor): Input tensor. Shape is [num_tokens, model_dim].
+            token_mask (torch.Tensor): Boolean mask indicating valid tokens.
+                Shape is [num_tokens].
+            weights (torch.Tensor): Routing weights for the selected experts.
+                Shape is [num_tokens, num_activated_experts].
+            indices (torch.Tensor): Indices of the selected experts.
+                Shape is [num_tokens, num_activated_experts].
+
+        Returns:
+            torch.Tensor: Output tensor after expert computation.
+                Shape is [num_tokens, model_dim]
+        """
+        del token_mask
+        assert hasattr(self, "ep_group"), "EP group is not set."
+        assert hasattr(self, "ep_size"), "EP size is not set."
+        return self._moe_on_device(x, topk_ids=indices, topk_weight=weights)
+
+
+def swiglu(x, gate_proj, down_proj, up_proj):
+    inter = F.silu(F.linear(x, gate_proj)) * F.linear(x, up_proj)
+    return F.linear(inter, down_proj)
 
 
 class FakeBalancedGate(nn.Module):
@@ -367,33 +575,28 @@ class FakeBalancedGate(nn.Module):
     how the load imbalance with real data is impacting end-to-end performance.
     """
 
-    def __init__(self, args: MoEArgs):
+    def __init__(self, n_routed_experts: int, n_activated_experts: int):
         super().__init__()
-        self.dim = args.dim
-        self.n_routed_experts = args.n_routed_experts
-        self.n_activated_experts = args.n_activated_experts
+        self.n_routed_experts = n_routed_experts
+        self.n_activated_experts = n_activated_experts
 
     def forward(
         self,
         x: torch.Tensor,
-        token_mask: torch.Tensor,
-        cp_mesh: Optional[DeviceMesh],
-    ) -> Tuple[torch.Tensor, torch.Tensor, Optional[torch.Tensor]]:
+        *args,
+        **kwargs,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
         """
         Forward pass for the gating mechanism.
 
         Args:
             x (torch.Tensor): Input tensor.
-            token_mask (torch.Tensor): Boolean mask indicating valid tokens.
-            cp_mesh (Optional[DeviceMesh]): Device mesh for context parallel computation.
 
         Returns:
             weights (torch.Tensor): Routing weights for the selected experts.
             indices (torch.Tensor): Indices of the selected experts.
-            aux_loss (Optional[torch.Tensor]): Auxiliary loss for load balancing.
         """
-        del token_mask
-        del cp_mesh
+        del args, kwargs
 
         n_exp = self.n_routed_experts
         a_exp = self.n_activated_experts
@@ -402,392 +605,4 @@ class FakeBalancedGate(nn.Module):
             torch.arange(x.size(0) * a_exp, device=x.device).view(-1, a_exp) % n_exp
         )
 
-        return weights.type_as(x), indices, None
-
-    def update_bias(self) -> None:
-        pass
-
-
-class Gate(nn.Module):
-    """
-    Gating mechanism for routing inputs in a mixture-of-experts (MoE) model.
-
-    Attributes:
-        dim (int): Dimensionality of input features.
-        topk (int): Number of top experts activated for each input.
-        n_groups (int): Number of groups for routing.
-        topk_groups (int): Number of groups to route inputs to.
-        score_func (str): Scoring function ('softmax' or 'sigmoid').
-        route_scale (float): Scaling factor for routing weights.
-        weight (torch.nn.Parameter): Learnable weights for the gate.
-        bias (Optional[torch.nn.Parameter]): Optional bias term for the gate.
-    """
-
-    def __init__(self, args: MoEArgs):
-        """
-        Initializes the Gate module.
-
-        Args:
-            args (MoEArgs): Model arguments containing gating parameters.
-        """
-        super().__init__()
-        self.dim = args.dim
-        self.n_experts = args.n_routed_experts
-        self.topk = args.n_activated_experts
-        self.n_groups = args.n_expert_groups
-        self.topk_groups = args.n_limited_groups
-        self.score_func = args.score_func
-        self.route_scale = args.route_scale
-        self.train_gate = args.train_gate
-        self.bias_update_factor = args.gate_bias_update_factor
-        self.aux_loss_coeff = args.aux_loss_coeff
-
-        if self.bias_update_factor > 0:
-            assert (
-                self.train_gate
-            ), "Require train_gate to be set to True to apply the bias update"
-
-        self.weight = nn.Parameter(
-            torch.empty(args.n_routed_experts, args.dim), requires_grad=self.train_gate
-        )
-        self.e_score_correction_bias = nn.Parameter(
-            torch.empty(args.n_routed_experts), requires_grad=False
-        )
-        self.e_score_correction_bias_master = None
-
-        # Cumulative expert load is a tensor representing the number of tokens
-        # routed to each expert on the current rank, accumulated across gradient
-        # accumulation steps.
-        self._cumulative_expert_load: Optional[torch.Tensor] = None
-
-    def forward(
-        self,
-        x: torch.Tensor,
-        token_mask: torch.Tensor,
-        cp_mesh: Optional[DeviceMesh],
-    ) -> Tuple[torch.Tensor, torch.Tensor, Optional[torch.Tensor]]:
-        """
-        Forward pass for the gating mechanism.
-
-        Args:
-            x (torch.Tensor): Input tensor.
-            token_mask (torch.Tensor): Boolean mask indicating valid tokens.
-            cp_mesh (Optional[DeviceMesh]): Device mesh for context parallel computation.
-
-        Returns:
-            weights (torch.Tensor): Routing weights for the selected experts.
-            indices (torch.Tensor): Indices of the selected experts.
-            aux_loss (Optional[torch.Tensor]): Auxiliary loss for load balancing.
-        """
-        scores = F.linear(x, self.weight)
-
-        if self.score_func == "softmax":
-            scores = scores.softmax(dim=-1, dtype=torch.float32)
-        else:
-            scores = scores.sigmoid()
-        original_scores = scores
-
-        # Add correction bias to balance tokens across gates.
-        if self.e_score_correction_bias is not None:
-            scores = scores + self.e_score_correction_bias
-
-        if self.n_groups > 1:
-            scores = scores.view(x.size(0), self.n_groups, -1)
-            if self.e_score_correction_bias is None:
-                group_scores = scores.amax(dim=-1)
-            else:
-                group_scores = scores.topk(2, dim=-1)[0].sum(dim=-1)
-
-            indices = group_scores.topk(self.topk_groups, dim=-1)[1]
-            mask = torch.zeros_like(scores[..., 0]).scatter_(1, indices, True)
-            scores = (scores * mask.unsqueeze(-1)).flatten(1)
-
-        indices = torch.topk(scores, self.topk, dim=-1)[1]
-        weights = original_scores.gather(1, indices)
-
-        if self.score_func == "sigmoid":
-            weights /= weights.sum(dim=-1, keepdim=True)
-            original_scores /= original_scores.sum(dim=-1, keepdim=True)
-        weights *= self.route_scale
-
-        if self.bias_update_factor > 0 or self.aux_loss_coeff > 0:
-            expert_load = self._compute_expert_load(indices, token_mask)
-
-        if self.bias_update_factor > 0 and self.training:
-            if self._cumulative_expert_load is None:
-                self._cumulative_expert_load = expert_load.detach()
-            else:
-                self._cumulative_expert_load += expert_load.detach()
-
-        aux_loss = None
-        if self.aux_loss_coeff > 0 and self.training:
-            aux_loss = self._compute_aux_loss(
-                original_scores, expert_load, token_mask, cp_mesh
-            )
-
-        return weights.type_as(x), indices, aux_loss
-
-    def update_bias(self) -> None:
-        """
-        Updates the correction bias used in the gate based on the popularity of experts.
-        This function is a NoOp if the gate is not trained.
-
-        To avoid routing collapse, and to promote better load balance of experts,
-        DeepSeek-V3 uses a correction mechanism to adjust the scores of experts using
-        a learned bias parameter. The bias parameter is updated based on the popularity
-        of experts, i.e., the number of tokens routed to each expert. If an expert is
-        more popular than the average, its bias term is decreased, and vice versa.
-        This encourages the model to route tokens to less popular experts, promoting
-        better load balance.
-        """
-        assert (
-            self.train_gate and self.bias_update_factor > 0
-        ), "Gate bias update is disabled"
-
-        assert self.training, "Gate bias update is only supported during training"
-        assert (
-            self._cumulative_expert_load is not None
-        ), "Score correction bias cannot be updated without the current expert load"
-
-        # 1) Compute the expert load across all DP ranks.
-        # Copy the cumulative load into a local variable, and set the stored load to None.
-        expert_load = self._cumulative_expert_load
-        self._cumulative_expert_load = None
-
-        # Place the expert load on the same device mesh as the score correction
-        # bias parameter, and sum across all ranks.
-        if isinstance(self.e_score_correction_bias, DTensor):
-            expert_load = DTensor.from_local(
-                expert_load,
-                device_mesh=self.e_score_correction_bias.device_mesh,
-                placements=[Partial()] * self.e_score_correction_bias.device_mesh.ndim,
-            )
-            expert_load = expert_load.full_tensor()
-
-        # 2) Compute the bias update by comparing the expert load to the average expert load.
-        expert_load = expert_load.float()
-        average_expert_load = expert_load.mean()
-        bias_update = torch.sign(average_expert_load - expert_load)
-
-        if isinstance(self.e_score_correction_bias, DTensor):
-            # Convert the bias update back to a replicated DTensor with the same device
-            # mesh as the score correction bias parameter.
-            bias_update = DTensor.from_local(
-                bias_update,
-                device_mesh=self.e_score_correction_bias.device_mesh,
-                placements=[Replicate()]
-                * self.e_score_correction_bias.device_mesh.ndim,
-            )
-
-            # The score correction bias parameter could be sharded across FSDP
-            # ranks (dim=-1), and/or optionally replicated across DDP ranks (dim=0).
-            # Redistribute the bias update with the same placement.
-            bias_update = bias_update.redistribute(
-                placements=self.e_score_correction_bias.placements
-            )
-
-        # 3) Update the correction bias using the bias update.
-        with torch.no_grad():
-            # Create full precision master weights
-            if self.e_score_correction_bias_master is None:
-                self.e_score_correction_bias_master = (
-                    self.e_score_correction_bias.clone().detach().float()
-                )
-            self.e_score_correction_bias_master += bias_update * self.bias_update_factor
-            self.e_score_correction_bias.copy_(self.e_score_correction_bias_master)
-
-    def _compute_expert_load(
-        self,
-        indices: torch.Tensor,
-        token_mask: torch.Tensor,
-    ) -> torch.Tensor:
-        """
-        Computes the load of each expert based on the selected indices.
-        Args:
-            indices (torch.Tensor): Indices of the selected experts.
-                Shape is [num_tokens, num_activated_experts].
-            token_mask (torch.Tensor): Boolean mask indicating valid tokens.
-                Shape is [num_tokens].
-
-        Returns:
-            torch.Tensor: Load of each expert (number of tokens routed to each expert).
-                Shape is [num_local_experts].
-        """
-        # Create a mask for the experts based on the selected indices.
-        expert_mask = indices.new_zeros((indices.shape[0], self.n_experts))
-        contribution = (
-            token_mask.to(dtype=expert_mask.dtype)
-            .unsqueeze(-1)
-            .expand(-1, indices.shape[1])
-        )
-        expert_mask.scatter_(dim=1, index=indices, src=contribution)
-        return expert_mask.sum(dim=0)
-
-    def _compute_aux_loss(
-        self,
-        original_scores: torch.Tensor,
-        expert_load: torch.Tensor,
-        token_mask: torch.Tensor,
-        cp_mesh: Optional[DeviceMesh],
-    ) -> torch.Tensor:
-        """
-        Computes the auxiliary loss for load balancing.
-
-        **Warning**: Assumes batch size = 1, if batch size > 1, the aux_loss will
-        be computed across multiple sequences.
-
-        Args:
-            original_scores (torch.Tensor): Original scores from the gating mechanism.
-                Shape is [num_tokens, num_experts].
-            expert_load (torch.Tensor): Load of each expert (number of tokens routed to each expert).
-                Shape is [num_experts].
-            token_mask (torch.Tensor): Boolean mask indicating valid tokens.
-                Shape is [num_tokens].
-            cp_mesh (Optional[DeviceMesh]): Device mesh for context parallel computation.
-
-        Returns:
-            torch.Tensor: Auxiliary loss for load balancing.
-                Shape is [].
-        """
-        context_length = token_mask.sum()
-        expert_scores = (original_scores * token_mask.unsqueeze(-1)).sum(dim=0)
-
-        if cp_mesh is not None:
-            context_length = DTensor.from_local(
-                context_length, device_mesh=cp_mesh, placements=[Partial()]
-            ).full_tensor()
-            expert_load = DTensor.from_local(
-                expert_load, device_mesh=cp_mesh, placements=[Partial()]
-            ).full_tensor()
-            expert_scores = DTensor.from_local(
-                expert_scores, device_mesh=cp_mesh, placements=[Partial()]
-            ).full_tensor()
-
-        # Compute f_i (fraction of tokens dispatched to each expert).
-        # If uniform distribution, expert_load will be topk * num_location / n_experts, and f_i will be 1
-        # Maximum value f_i entries happens when expert_load = num_location, the value will be n_experts / topk
-        f_i = (
-            expert_load * self.n_experts / (self.topk * context_length)
-        )  # Normalized fraction, (n_experts)
-
-        # Compute P_i (average routing probability per expert)
-        P_i = expert_scores / context_length  # (n_experts)
-
-        loss = torch.sum(f_i * P_i)
-        return loss
-
-
-def swiglu(x, gate_proj, down_proj, up_proj):
-    inter = F.silu(F.linear(x, gate_proj)) * F.linear(x, up_proj)
-    return F.linear(inter, down_proj)
-
-
-class MoE(nn.Module):
-    """
-    Mixture-of-Experts (MoE) module.
-
-    Attributes:
-        dim (int): Dimensionality of input features.
-        n_routed_experts (int): Total number of experts in the model.
-        n_local_experts (int): Number of experts handled locally in distributed systems.
-        n_activated_experts (int): Number of experts activated for each input.
-        gate (nn.Module): Gating mechanism to route inputs to experts.
-        experts (nn.ModuleList): List of expert modules.
-        shared_experts (nn.Module): Shared experts applied to all inputs.
-    """
-
-    def __init__(self, args: MoEArgs):
-        """
-        Initializes the MoE module.
-
-        Args:
-            args (MoEArgs): Model arguments containing MoE parameters.
-        """
-        super().__init__()
-        self.dim = args.dim
-        self.n_routed_experts = args.n_routed_experts
-        self.n_activated_experts = args.n_activated_experts
-
-        if args.fake_balanced_gate:
-            self.gate = FakeBalancedGate(args)
-        else:
-            self.gate = Gate(args)
-        if args.enable_deepep:
-            self.experts = GroupedExpertsDeepEP(args)
-        else:
-            self.experts = GroupedExperts(args)
-        self.shared_experts = MLP(args.dim, args.n_shared_experts * args.moe_inter_dim)
-
-    def forward(
-        self,
-        x: torch.Tensor,
-        padding_mask: Optional[torch.Tensor] = None,
-        cp_mesh: Optional[DeviceMesh] = None,
-    ) -> tuple[torch.Tensor, Optional[torch.Tensor]]:
-        """
-        Forward pass for the MoE module.
-
-        Args:
-            x (torch.Tensor): Input tensor.
-            padding_mask (Optional[torch.Tensor]): Boolean mask indicating padding positions.
-
-        Returns:
-            torch.Tensor: Output tensor after expert routing and computation.
-            Optional[torch.Tensor]: Auxiliary loss for load balancing (if applicable).
-        """
-        # Reshape the inputs to 2-D since we are just distributing tokens.
-        shape = x.size()
-        x = x.view(-1, self.dim)
-        if padding_mask is not None:
-            token_mask = (~padding_mask).flatten()
-        else:
-            token_mask = torch.ones(x.size(0), dtype=torch.bool, device=x.device)
-
-        weights, indices, aux_loss = self.gate(x, token_mask, cp_mesh)
-
-        # Execute shared experts in a separate stream to overlap compute with the
-        # communication for grouped experts.
-        global _shared_experts_stream
-        if _shared_experts_stream is None:
-            _shared_experts_stream = torch.cuda.Stream()
-
-        _shared_experts_stream.wait_stream(torch.cuda.current_stream())
-        with torch.cuda.stream(_shared_experts_stream):
-            z = self.shared_experts(x)
-
-        y = self.experts(x, token_mask, weights, indices)
-
-        # Wait for the shared experts stream to complete all operations before
-        # adding together the outputs of grouped experts and shared experts.
-        torch.cuda.current_stream().wait_stream(_shared_experts_stream)
-
-        # Reshape the outputs back to 3-D.
-        return (y + z).view(shape), aux_loss
-
-    def init_weights(self) -> None:
-        self.apply(_init_weights)
-
-
-def _init_weights(module):
-    std = 0.02
-
-    def to_local(tensor):
-        if isinstance(tensor, DTensor):
-            return tensor.to_local()
-        else:
-            return tensor
-
-    if isinstance(module, Gate):
-        to_local(module.weight).normal_(mean=0.0, std=std)
-        to_local(module.e_score_correction_bias).zero_()
-    elif isinstance(module, GroupedExperts):
-        to_local(module.gate_projs).normal_(mean=0.0, std=std)
-        to_local(module.up_projs).normal_(mean=0.0, std=std)
-        to_local(module.down_projs).normal_(mean=0.0, std=std)
-    elif isinstance(module, GroupedExpertsDeepEP):
-        to_local(module.gate_and_up_projs).normal_(mean=0.0, std=std)
-        to_local(module.down_projs).normal_(mean=0.0, std=std)
-    elif isinstance(module, MLP):
-        to_local(module.gate_proj.weight).normal_(mean=0.0, std=std)
-        to_local(module.down_proj.weight).normal_(mean=0.0, std=std)
-        to_local(module.up_proj.weight).normal_(mean=0.0, std=std)
+        return weights.type_as(x), indices

--- a/cosmos_rl/policy/model/deepseek_v3/deepseekv3_mapped.py
+++ b/cosmos_rl/policy/model/deepseek_v3/deepseekv3_mapped.py
@@ -21,17 +21,10 @@ import torch
 import torch.nn.functional as F
 from torch import nn
 
-try:
-    from transformer_engine.pytorch.attention import DotProductAttention
-    from transformer_engine.pytorch.module.rmsnorm import RMSNorm as _RMSNorm
-except ImportError:
-    print("transformer_engine.pytorch is not available. DeepSeek model will not work.")
+from transformer_engine.pytorch.attention import DotProductAttention
+from transformer_engine.pytorch.module.rmsnorm import RMSNorm as _RMSNorm
 
-    class _RMSNorm:
-        pass
-
-
-from cosmos_rl.policy.kernel.moe.moe import MoE
+from cosmos_rl.policy.model.deepseek_v3.moe import MoE
 
 
 @dataclass

--- a/cosmos_rl/policy/model/deepseek_v3/moe.py
+++ b/cosmos_rl/policy/model/deepseek_v3/moe.py
@@ -1,0 +1,427 @@
+from dataclasses import dataclass
+import torch
+from torch import nn
+import torch.nn.functional as F
+from typing import Optional, Tuple
+
+from torch.distributed.tensor import DTensor, DeviceMesh, Replicate, Partial
+
+from cosmos_rl.policy.kernel.mlp import MLP
+from cosmos_rl.policy.kernel.moe.moe import (
+    FakeBalancedGate,
+    GroupedExperts,
+    GroupedExpertsDeepEP,
+)
+
+
+_shared_experts_stream: Optional[torch.cuda.Stream] = None
+
+
+@dataclass
+class MoEArgs:
+    n_routed_experts: int
+    n_shared_experts: int
+    n_activated_experts: int
+    n_expert_groups: int
+    n_limited_groups: int
+    train_gate: bool
+    gate_bias_update_factor: float
+    aux_loss_coeff: float
+    score_func: str
+    route_scale: float
+    dim: int
+    moe_inter_dim: int
+    enable_deepep: bool = False
+    fake_balanced_gate: bool = False
+
+
+class Gate(nn.Module):
+    """
+    Gating mechanism for routing inputs in a mixture-of-experts (MoE) model.
+
+    Attributes:
+        dim (int): Dimensionality of input features.
+        topk (int): Number of top experts activated for each input.
+        n_groups (int): Number of groups for routing.
+        topk_groups (int): Number of groups to route inputs to.
+        score_func (str): Scoring function ('softmax' or 'sigmoid').
+        route_scale (float): Scaling factor for routing weights.
+        weight (torch.nn.Parameter): Learnable weights for the gate.
+        bias (Optional[torch.nn.Parameter]): Optional bias term for the gate.
+    """
+
+    def __init__(self, args: MoEArgs):
+        """
+        Initializes the Gate module.
+
+        Args:
+            args (MoEArgs): Model arguments containing gating parameters.
+        """
+        super().__init__()
+        self.dim = args.dim
+        self.n_experts = args.n_routed_experts
+        self.topk = args.n_activated_experts
+        self.n_groups = args.n_expert_groups
+        self.topk_groups = args.n_limited_groups
+        self.score_func = args.score_func
+        self.route_scale = args.route_scale
+        self.train_gate = args.train_gate
+        self.bias_update_factor = args.gate_bias_update_factor
+        self.aux_loss_coeff = args.aux_loss_coeff
+
+        if self.bias_update_factor > 0:
+            assert (
+                self.train_gate
+            ), "Require train_gate to be set to True to apply the bias update"
+
+        self.weight = nn.Parameter(
+            torch.empty(args.n_routed_experts, args.dim), requires_grad=self.train_gate
+        )
+        self.e_score_correction_bias = nn.Parameter(
+            torch.empty(args.n_routed_experts), requires_grad=False
+        )
+        self.e_score_correction_bias_master = None
+
+        # Cumulative expert load is a tensor representing the number of tokens
+        # routed to each expert on the current rank, accumulated across gradient
+        # accumulation steps.
+        self._cumulative_expert_load: Optional[torch.Tensor] = None
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        token_mask: torch.Tensor,
+        cp_mesh: Optional[DeviceMesh],
+    ) -> Tuple[torch.Tensor, torch.Tensor, Optional[torch.Tensor]]:
+        """
+        Forward pass for the gating mechanism.
+
+        Args:
+            x (torch.Tensor): Input tensor.
+            token_mask (torch.Tensor): Boolean mask indicating valid tokens.
+            cp_mesh (Optional[DeviceMesh]): Device mesh for context parallel computation.
+
+        Returns:
+            weights (torch.Tensor): Routing weights for the selected experts.
+            indices (torch.Tensor): Indices of the selected experts.
+            aux_loss (Optional[torch.Tensor]): Auxiliary loss for load balancing.
+        """
+        scores = F.linear(x, self.weight)
+
+        if self.score_func == "softmax":
+            scores = scores.softmax(dim=-1, dtype=torch.float32)
+        else:
+            scores = scores.sigmoid()
+        original_scores = scores
+
+        # Add correction bias to balance tokens across gates.
+        if self.e_score_correction_bias is not None:
+            scores = scores + self.e_score_correction_bias
+
+        if self.n_groups > 1:
+            scores = scores.view(x.size(0), self.n_groups, -1)
+            if self.e_score_correction_bias is None:
+                group_scores = scores.amax(dim=-1)
+            else:
+                group_scores = scores.topk(2, dim=-1)[0].sum(dim=-1)
+
+            indices = group_scores.topk(self.topk_groups, dim=-1)[1]
+            mask = torch.zeros_like(scores[..., 0]).scatter_(1, indices, True)
+            scores = (scores * mask.unsqueeze(-1)).flatten(1)
+
+        indices = torch.topk(scores, self.topk, dim=-1)[1]
+        weights = original_scores.gather(1, indices)
+
+        if self.score_func == "sigmoid":
+            weights /= weights.sum(dim=-1, keepdim=True)
+            original_scores /= original_scores.sum(dim=-1, keepdim=True)
+        weights *= self.route_scale
+
+        if self.bias_update_factor > 0 or self.aux_loss_coeff > 0:
+            expert_load = self._compute_expert_load(indices, token_mask)
+
+        if self.bias_update_factor > 0 and self.training:
+            if self._cumulative_expert_load is None:
+                self._cumulative_expert_load = expert_load.detach()
+            else:
+                self._cumulative_expert_load += expert_load.detach()
+
+        aux_loss = None
+        if self.aux_loss_coeff > 0 and self.training:
+            aux_loss = self._compute_aux_loss(
+                original_scores, expert_load, token_mask, cp_mesh
+            )
+
+        return weights.type_as(x), indices, aux_loss
+
+    def update_bias(self) -> None:
+        """
+        Updates the correction bias used in the gate based on the popularity of experts.
+        This function is a NoOp if the gate is not trained.
+
+        To avoid routing collapse, and to promote better load balance of experts,
+        DeepSeek-V3 uses a correction mechanism to adjust the scores of experts using
+        a learned bias parameter. The bias parameter is updated based on the popularity
+        of experts, i.e., the number of tokens routed to each expert. If an expert is
+        more popular than the average, its bias term is decreased, and vice versa.
+        This encourages the model to route tokens to less popular experts, promoting
+        better load balance.
+        """
+        assert (
+            self.train_gate and self.bias_update_factor > 0
+        ), "Gate bias update is disabled"
+
+        assert self.training, "Gate bias update is only supported during training"
+        assert (
+            self._cumulative_expert_load is not None
+        ), "Score correction bias cannot be updated without the current expert load"
+
+        # 1) Compute the expert load across all DP ranks.
+        # Copy the cumulative load into a local variable, and set the stored load to None.
+        expert_load = self._cumulative_expert_load
+        self._cumulative_expert_load = None
+
+        # Place the expert load on the same device mesh as the score correction
+        # bias parameter, and sum across all ranks.
+        if isinstance(self.e_score_correction_bias, DTensor):
+            expert_load = DTensor.from_local(
+                expert_load,
+                device_mesh=self.e_score_correction_bias.device_mesh,
+                placements=[Partial()] * self.e_score_correction_bias.device_mesh.ndim,
+            )
+            expert_load = expert_load.full_tensor()
+
+        # 2) Compute the bias update by comparing the expert load to the average expert load.
+        expert_load = expert_load.float()
+        average_expert_load = expert_load.mean()
+        bias_update = torch.sign(average_expert_load - expert_load)
+
+        if isinstance(self.e_score_correction_bias, DTensor):
+            # Convert the bias update back to a replicated DTensor with the same device
+            # mesh as the score correction bias parameter.
+            bias_update = DTensor.from_local(
+                bias_update,
+                device_mesh=self.e_score_correction_bias.device_mesh,
+                placements=[Replicate()]
+                * self.e_score_correction_bias.device_mesh.ndim,
+            )
+
+            # The score correction bias parameter could be sharded across FSDP
+            # ranks (dim=-1), and/or optionally replicated across DDP ranks (dim=0).
+            # Redistribute the bias update with the same placement.
+            bias_update = bias_update.redistribute(
+                placements=self.e_score_correction_bias.placements
+            )
+
+        # 3) Update the correction bias using the bias update.
+        with torch.no_grad():
+            # Create full precision master weights
+            if self.e_score_correction_bias_master is None:
+                self.e_score_correction_bias_master = (
+                    self.e_score_correction_bias.clone().detach().float()
+                )
+            self.e_score_correction_bias_master += bias_update * self.bias_update_factor
+            self.e_score_correction_bias.copy_(self.e_score_correction_bias_master)
+
+    def _compute_expert_load(
+        self,
+        indices: torch.Tensor,
+        token_mask: torch.Tensor,
+    ) -> torch.Tensor:
+        """
+        Computes the load of each expert based on the selected indices.
+        Args:
+            indices (torch.Tensor): Indices of the selected experts.
+                Shape is [num_tokens, num_activated_experts].
+            token_mask (torch.Tensor): Boolean mask indicating valid tokens.
+                Shape is [num_tokens].
+
+        Returns:
+            torch.Tensor: Load of each expert (number of tokens routed to each expert).
+                Shape is [num_local_experts].
+        """
+        # Create a mask for the experts based on the selected indices.
+        expert_mask = indices.new_zeros((indices.shape[0], self.n_experts))
+        contribution = (
+            token_mask.to(dtype=expert_mask.dtype)
+            .unsqueeze(-1)
+            .expand(-1, indices.shape[1])
+        )
+        expert_mask.scatter_(dim=1, index=indices, src=contribution)
+        return expert_mask.sum(dim=0)
+
+    def _compute_aux_loss(
+        self,
+        original_scores: torch.Tensor,
+        expert_load: torch.Tensor,
+        token_mask: torch.Tensor,
+        cp_mesh: Optional[DeviceMesh],
+    ) -> torch.Tensor:
+        """
+        Computes the auxiliary loss for load balancing.
+
+        **Warning**: Assumes batch size = 1, if batch size > 1, the aux_loss will
+        be computed across multiple sequences.
+
+        Args:
+            original_scores (torch.Tensor): Original scores from the gating mechanism.
+                Shape is [num_tokens, num_experts].
+            expert_load (torch.Tensor): Load of each expert (number of tokens routed to each expert).
+                Shape is [num_experts].
+            token_mask (torch.Tensor): Boolean mask indicating valid tokens.
+                Shape is [num_tokens].
+            cp_mesh (Optional[DeviceMesh]): Device mesh for context parallel computation.
+
+        Returns:
+            torch.Tensor: Auxiliary loss for load balancing.
+                Shape is [].
+        """
+        context_length = token_mask.sum()
+        expert_scores = (original_scores * token_mask.unsqueeze(-1)).sum(dim=0)
+
+        if cp_mesh is not None:
+            context_length = DTensor.from_local(
+                context_length, device_mesh=cp_mesh, placements=[Partial()]
+            ).full_tensor()
+            expert_load = DTensor.from_local(
+                expert_load, device_mesh=cp_mesh, placements=[Partial()]
+            ).full_tensor()
+            expert_scores = DTensor.from_local(
+                expert_scores, device_mesh=cp_mesh, placements=[Partial()]
+            ).full_tensor()
+
+        # Compute f_i (fraction of tokens dispatched to each expert).
+        # If uniform distribution, expert_load will be topk * num_location / n_experts, and f_i will be 1
+        # Maximum value f_i entries happens when expert_load = num_location, the value will be n_experts / topk
+        f_i = (
+            expert_load * self.n_experts / (self.topk * context_length)
+        )  # Normalized fraction, (n_experts)
+
+        # Compute P_i (average routing probability per expert)
+        P_i = expert_scores / context_length  # (n_experts)
+
+        loss = torch.sum(f_i * P_i)
+        return loss
+
+
+class MoE(nn.Module):
+    """
+    Mixture-of-Experts (MoE) module.
+
+    Attributes:
+        dim (int): Dimensionality of input features.
+        n_routed_experts (int): Total number of experts in the model.
+        n_activated_experts (int): Number of experts activated for each input.
+        gate (nn.Module): Gating mechanism to route inputs to experts.
+        experts (nn.ModuleList): List of expert modules.
+        shared_experts (nn.Module): Shared experts applied to all inputs.
+    """
+
+    def __init__(self, args: MoEArgs):
+        """
+        Initializes the MoE module.
+
+        Args:
+            args (MoEArgs): Model arguments containing MoE parameters.
+        """
+        super().__init__()
+        self.dim = args.dim
+        self.n_routed_experts = args.n_routed_experts
+        self.n_activated_experts = args.n_activated_experts
+
+        if args.fake_balanced_gate:
+            self.gate = FakeBalancedGate(
+                n_routed_experts=args.n_routed_experts,
+                n_activated_experts=args.n_activated_experts,
+            )
+        else:
+            self.gate = Gate(args)
+
+        if args.enable_deepep:
+            self.experts = GroupedExpertsDeepEP(
+                dim=args.dim,
+                inter_dim=args.moe_inter_dim,
+                n_routed_experts=args.n_activated_experts,
+                n_activated_experts=args.n_activated_experts,
+            )
+        else:
+            self.experts = GroupedExperts(
+                dim=args.dim,
+                inter_dim=args.moe_inter_dim,
+                n_routed_experts=args.n_activated_experts,
+            )
+        self.shared_experts = MLP(args.dim, args.n_shared_experts * args.moe_inter_dim)
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        padding_mask: Optional[torch.Tensor] = None,
+        cp_mesh: Optional[DeviceMesh] = None,
+    ) -> tuple[torch.Tensor, Optional[torch.Tensor]]:
+        """
+        Forward pass for the MoE module.
+
+        Args:
+            x (torch.Tensor): Input tensor.
+            padding_mask (Optional[torch.Tensor]): Boolean mask indicating padding positions.
+
+        Returns:
+            torch.Tensor: Output tensor after expert routing and computation.
+            Optional[torch.Tensor]: Auxiliary loss for load balancing (if applicable).
+        """
+        # Reshape the inputs to 2-D since we are just distributing tokens.
+        shape = x.size()
+        x = x.view(-1, self.dim)
+        if padding_mask is not None:
+            token_mask = (~padding_mask).flatten()
+        else:
+            token_mask = torch.ones(x.size(0), dtype=torch.bool, device=x.device)
+
+        weights, indices, aux_loss = self.gate(x, token_mask, cp_mesh)
+
+        # Execute shared experts in a separate stream to overlap compute with the
+        # communication for grouped experts.
+        global _shared_experts_stream
+        if _shared_experts_stream is None:
+            _shared_experts_stream = torch.cuda.Stream()
+
+        _shared_experts_stream.wait_stream(torch.cuda.current_stream())
+        with torch.cuda.stream(_shared_experts_stream):
+            z = self.shared_experts(x)
+
+        y = self.experts(x, token_mask, weights, indices)
+
+        # Wait for the shared experts stream to complete all operations before
+        # adding together the outputs of grouped experts and shared experts.
+        torch.cuda.current_stream().wait_stream(_shared_experts_stream)
+
+        # Reshape the outputs back to 3-D.
+        return (y + z).view(shape), aux_loss
+
+    def init_weights(self) -> None:
+        self.apply(_init_weights)
+
+
+def _init_weights(module):
+    std = 0.02
+
+    def to_local(tensor):
+        if isinstance(tensor, DTensor):
+            return tensor.to_local()
+        else:
+            return tensor
+
+    if isinstance(module, Gate):
+        to_local(module.weight).normal_(mean=0.0, std=std)
+        to_local(module.e_score_correction_bias).zero_()
+    elif isinstance(module, GroupedExperts):
+        to_local(module.gate_projs).normal_(mean=0.0, std=std)
+        to_local(module.up_projs).normal_(mean=0.0, std=std)
+        to_local(module.down_projs).normal_(mean=0.0, std=std)
+    elif isinstance(module, GroupedExpertsDeepEP):
+        to_local(module.gate_and_up_projs).normal_(mean=0.0, std=std)
+        to_local(module.down_projs).normal_(mean=0.0, std=std)
+    elif isinstance(module, MLP):
+        to_local(module.gate_proj.weight).normal_(mean=0.0, std=std)
+        to_local(module.down_proj.weight).normal_(mean=0.0, std=std)
+        to_local(module.up_proj.weight).normal_(mean=0.0, std=std)

--- a/cosmos_rl/policy/model/deepseek_v3/weight_converter.py
+++ b/cosmos_rl/policy/model/deepseek_v3/weight_converter.py
@@ -1,0 +1,339 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import re
+import torch
+import triton
+import triton.language as tl
+from typing import Any, Dict, Optional, Tuple
+
+from cosmos_rl.utils.logging import logger
+from cosmos_rl.utils.parallelism import ParallelDims
+from cosmos_rl.utils.parallelism_registry import (
+    ParallelismStrategyRole,
+    register_parallelism_strategy,
+)
+
+# Pre-compile regex patterns for better performance
+_LAYER_ATTN_NORM_PATTERN = re.compile(
+    r"model\.model\.layers\.(\d+)\.self_attn\.(q_norm|k_norm|v_norm)\.(weight|bias)"
+)
+_LAYER_INPUT_LAYERNORM_PATTERN = re.compile(
+    r"model\.model\.layers\.(\d+)\.input_layernorm\.(weight|bias)"
+)
+_LAYER_ATTN_PROJ_PATTERN = re.compile(
+    r"model\.model\.layers\.(\d+)\.self_attn\.(q_proj|kv_b_proj|q_b_proj)\.(weight|bias)"
+)
+_LAYER_ATTN_KV_A_PATTERN = re.compile(
+    r"model\.model\.layers\.(\d+)\.self_attn\.(kv_a_proj_with_mqa)\.(weight|bias)"
+)
+_LAYER_ATTN_O_PATTERN = re.compile(
+    r"model\.model\.layers\.(\d+)\.self_attn\.(o_proj)\.(weight|bias)"
+)
+_LAYER_MLP_EXPERTS_PATTERN = re.compile(
+    r"model\.model\.layers\.(\d+)\.mlp\.experts\.(\d+)\.(up_proj|gate_proj|down_proj)\.(weight|bias)"
+)
+_LAYER_MLP_SHARED_EXPERTS_PATTERN = re.compile(
+    r"model\.model\.layers\.(\d+)\.mlp\.shared_experts\.(up_proj|gate_proj)\.(weight|bias)"
+)
+_LAYER_MLP_SHARED_EXPERTS_DOWN_PATTERN = re.compile(
+    r"model\.model\.layers\.(\d+)\.mlp\.shared_experts\.down_proj\.(weight|bias)"
+)
+_LAYER_MLP_PROJ_PATTERN = re.compile(
+    r"model\.model\.layers\.(\d+)\.mlp\.(up_proj|gate_proj)\.(weight|bias)"
+)
+_LAYER_MLP_DOWN_PATTERN = re.compile(
+    r"model\.model\.layers\.(\d+)\.mlp\.down_proj\.(weight|bias)"
+)
+_LAYER_POST_ATTENTION_LAYERNORM_PATTERN = re.compile(
+    r"model\.model\.layers\.(\d+)\.post_attention_layernorm\.(weight|bias)"
+)
+_LAYER_KV_A_LAYERNORM_PATTERN = re.compile(
+    r"model\.model\.layers\.(\d+)\.self_attn\.kv_a_layernorm\.(weight|bias)"
+)
+_LAYER_Q_A_PATTERN = re.compile(
+    r"model\.model\.layers\.(\d+)\.self_attn\.(q_a_layernorm|q_a_proj)\.(weight|bias)"
+)
+_LAYER_MLP_GATE_WEIGHT_PATTERN = re.compile(
+    r"model\.model\.layers\.(\d+)\.mlp\.gate\.weight"
+)
+_LAYER_ROTARY_EMB_PATTERN = re.compile(
+    r"model\.model\.layers\.(\d+)\.self_attn\.rotary_emb\.inv_freq"
+)
+_LAYER_MLP_GATE_BIAS_PATTERN = re.compile(
+    r"model\.model\.layers\.(\d+)\.mlp\.gate\.e_score_correction_bias"
+)
+
+# Pre-define common suffixes for faster string matching
+_LM_HEAD_WEIGHT = "lm_head.weight"
+_LM_HEAD_BIAS = "lm_head.bias"
+_EMBED_TOKENS_WEIGHT = "embed_tokens.weight"
+_NORM_WEIGHT = "norm.weight"
+_NORM_BIAS = "norm.bias"
+_BIAS_SUFFIX = ".bias"
+
+
+def map_key_from_hf(name: str) -> str:
+    # The weights in the policy model have a ".model" prefix.
+    return "model." + name
+
+
+def convert_weight_from_hf(
+    tensor: torch.Tensor,
+    name: str,
+    src_model_type: str,
+    parallel_dims: ParallelDims,
+    n_experts: int,
+    ignore_unknown_weights: bool = False,
+) -> Tuple[Optional[str], Optional[torch.Tensor], Optional[int]]:
+    del src_model_type
+
+    tp_ep_rank, tp_ep_size = parallel_dims.tp_coord
+    assert n_experts % tp_ep_size == 0, "n_experts must be divisible by tp_ep_size"
+
+    if parallel_dims.dp_shard_enabled or parallel_dims.cp_enabled:
+        dp_shard_rank = parallel_dims.mesh[tuple(("dp_shard_cp",))].get_local_rank()
+        dp_shard_size = parallel_dims.mesh[tuple(("dp_shard_cp",))].size()
+    else:
+        dp_shard_rank = 0
+        dp_shard_size = 1
+
+    dest_name = map_key_from_hf(name)
+
+    # Fast path for common cases using string suffix matching
+    if dest_name.endswith(_LM_HEAD_WEIGHT):
+        shard = tensor.tensor_split(tp_ep_size, dim=0)[tp_ep_rank]
+    elif dest_name.endswith(_LM_HEAD_BIAS):
+        shard = tensor
+    elif dest_name.endswith(_EMBED_TOKENS_WEIGHT):
+        shard = tensor.tensor_split(tp_ep_size, dim=0)[tp_ep_rank]
+    elif dest_name.endswith(_NORM_WEIGHT) or dest_name.endswith(_NORM_BIAS):
+        shard = tensor
+    # Regex matching for complex patterns
+    elif (match := _LAYER_ATTN_NORM_PATTERN.search(dest_name)) is not None:
+        shard = tensor
+    elif (match := _LAYER_INPUT_LAYERNORM_PATTERN.search(dest_name)) is not None:
+        shard = tensor
+    elif (match := _LAYER_ATTN_PROJ_PATTERN.search(dest_name)) is not None:
+        shard = tensor.tensor_split(tp_ep_size, dim=0)[tp_ep_rank]
+    elif (match := _LAYER_ATTN_KV_A_PATTERN.search(dest_name)) is not None:
+        shard = tensor
+    elif (match := _LAYER_ATTN_O_PATTERN.search(dest_name)) is not None:
+        if dest_name.endswith(_BIAS_SUFFIX):
+            shard = tensor
+        else:
+            shard = tensor.tensor_split(tp_ep_size, dim=-1)[tp_ep_rank]
+
+    elif (match := _LAYER_MLP_EXPERTS_PATTERN.search(dest_name)) is not None:
+        # Check whether this expert belongs to the current process
+        # Groups example (with 32 experts, and 4 EP groups):
+        #  EP=0: 0, 1, 2, 3, 4, 5, 6, 7
+        #  EP=1: 8, 9, 10, 11, 12, 13, 14, 15
+        #  EP=2: 16, 17, 18, 19, 20, 21, 22, 23
+        #  EP=3: 24, 25, 26, 27, 28, 29, 30, 31
+        n_expert_per_ep = n_experts // tp_ep_size
+        n_expert_per_dp = n_expert_per_ep // dp_shard_size
+
+        expert_id = int(match.group(2))
+        belongs_to_current_ep = (expert_id // n_expert_per_ep) == tp_ep_rank
+
+        expert_idx_within_ep = expert_id % n_expert_per_ep
+        belongs_to_current_dp_shard = (
+            expert_idx_within_ep // n_expert_per_dp
+        ) == dp_shard_rank
+
+        if belongs_to_current_ep and belongs_to_current_dp_shard:
+            # remove `experts.$ID.` from dest_name
+            dest_name = dest_name.replace(f"experts.{expert_id}.", "experts.")
+            # change `proj.weight` to `projs`.
+            dest_name = dest_name.replace("proj.weight", "projs")
+
+            shard = tensor
+            return dest_name, shard.contiguous(), expert_id
+        else:
+            # If the expert does not belong to the current rank, return None
+            # to skip this weight.
+            return None, None, None
+
+    elif (match := _LAYER_MLP_SHARED_EXPERTS_PATTERN.search(dest_name)) is not None:
+        shard = tensor.tensor_split(tp_ep_size, dim=0)[tp_ep_rank]
+
+    elif (
+        match := _LAYER_MLP_SHARED_EXPERTS_DOWN_PATTERN.search(dest_name)
+    ) is not None:
+        if dest_name.endswith(_BIAS_SUFFIX):
+            shard = tensor
+        else:
+            shard = tensor.tensor_split(tp_ep_size, dim=-1)[tp_ep_rank]
+    elif (match := _LAYER_MLP_PROJ_PATTERN.search(dest_name)) is not None:
+        shard = tensor.tensor_split(tp_ep_size, dim=0)[tp_ep_rank]
+    elif (match := _LAYER_MLP_DOWN_PATTERN.search(dest_name)) is not None:
+        if dest_name.endswith(_BIAS_SUFFIX):
+            shard = tensor
+        else:
+            shard = tensor.tensor_split(tp_ep_size, dim=-1)[tp_ep_rank]
+    elif (
+        match := _LAYER_POST_ATTENTION_LAYERNORM_PATTERN.search(dest_name)
+    ) is not None:
+        shard = tensor
+    elif (match := _LAYER_KV_A_LAYERNORM_PATTERN.search(dest_name)) is not None:
+        shard = tensor
+    elif (match := _LAYER_Q_A_PATTERN.search(dest_name)) is not None:
+        shard = tensor
+    elif (match := _LAYER_MLP_GATE_WEIGHT_PATTERN.search(dest_name)) is not None:
+        # TODO(cjx): Small enough, forbid FSDP sharding is better
+        shard = tensor
+    elif (match := _LAYER_ROTARY_EMB_PATTERN.search(dest_name)) is not None:
+        return None, None, None
+    elif (match := _LAYER_MLP_GATE_BIAS_PATTERN.search(dest_name)) is not None:
+        shard = tensor
+    elif not ignore_unknown_weights:
+        raise ValueError(f"Unsupported weight: {dest_name}")
+    else:
+        return None, None, None
+
+    # Expert weight are aggregated into (n_experts, in_features, out_features)
+    # Weight are loaded in (out_features, in_features) shape
+    # So we do not do FSDP sharding on expert weights, instead we filter by expert id
+
+    # Do FSDP sharding
+    shard = shard.contiguous()
+    if match := _LAYER_ATTN_KV_A_PATTERN.search(dest_name) is not None and (
+        576 % dp_shard_size != 0
+    ):
+        tensor_shard_size = 576 // dp_shard_size + 1
+        if dp_shard_rank < (576 // tensor_shard_size):
+            shard = shard[
+                dp_shard_rank * tensor_shard_size : (dp_shard_rank + 1)
+                * tensor_shard_size
+            ]
+        else:
+            shard = shard[dp_shard_rank * tensor_shard_size :]
+    else:
+        shard = shard.tensor_split(dp_shard_size, dim=0)[dp_shard_rank]
+
+    return dest_name, shard.contiguous(), None
+
+
+@triton.jit
+def weight_dequant_kernel(x_ptr, s_ptr, y_ptr, M, N, BLOCK_SIZE: tl.constexpr):
+    pid_m = tl.program_id(axis=0)
+    pid_n = tl.program_id(axis=1)
+    n = tl.cdiv(N, BLOCK_SIZE)
+    offs_m = pid_m * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    offs_n = pid_n * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    offs = offs_m[:, None] * N + offs_n[None, :]
+    mask = (offs_m[:, None] < M) & (offs_n[None, :] < N)
+    x = tl.load(x_ptr + offs, mask=mask).to(tl.float32)
+    s = tl.load(s_ptr + pid_m * n + pid_n)
+    y = x * s
+    tl.store(y_ptr + offs, y, mask=mask)
+
+
+def weight_dequant(
+    x: torch.Tensor, s: torch.Tensor, block_size: int = 128
+) -> torch.Tensor:
+    assert x.is_contiguous() and s.is_contiguous()
+    assert x.dim() == 2 and s.dim() == 2
+    M, N = x.size()
+    y = torch.empty_like(x, dtype=torch.get_default_dtype())
+
+    def grid(meta):
+        return (triton.cdiv(M, meta["BLOCK_SIZE"]), triton.cdiv(N, meta["BLOCK_SIZE"]))
+
+    weight_dequant_kernel[grid](x, s, y, M, N, BLOCK_SIZE=block_size)
+    return y
+
+
+@register_parallelism_strategy("deepseek_v3", role=ParallelismStrategyRole.ROLLOUT)
+def map_weight_parallel_dims(
+    n_dim: int,
+    dest_name: str,
+    parallel_dims: ParallelDims,
+    model_config: Any,
+) -> Tuple[Dict[str, int], Dict[int, list], int]:
+    """
+    For the given HuggingFace parameter name (dest_name), return the map from
+    parallel dimension name (e.g. "tp", ...) to the corresponding dimension of the tensor.
+    """
+    del parallel_dims, model_config
+
+    # Why are TP and EP always used together? They should be independent.
+    # TODO(aazzolini): 1.2 implement rollout_parallelism_strategy (tp,ep)
+    dims_map = {}
+
+    tp_dim_map = {
+        # deepseekv3 attention weights
+        ".self_attn.q_a_proj.": None,
+        ".self_attn.q_a_layernorm.": None,
+        ".self_attn.q_b_proj.": 0,
+        ".self_attn.kv_a_proj_with_mqa.": None,
+        ".self_attn.kv_a_layernorm.": None,
+        ".self_attn.kv_b_proj.": 0,
+        ".self_attn.o_proj.": 1,
+        # deepseekv3 dense+moe mlp weights
+        # note on the training side gate_up_proj is fused.
+        ".mlp.gate_proj.": -2,
+        ".mlp.up_proj.": -2,
+        ".mlp.down_proj.": -1,
+        # deepseekv3 moe-related weights
+        ".mlp.gate.": None,
+        ".mlp.shared_experts.gate_proj.": 0,
+        ".mlp.shared_experts.up_proj.": 0,
+        ".mlp.shared_experts.down_proj.": 1,
+        # deepseekv3 layernorms
+        ".input_layernorm.weight": None,
+        ".post_attention_layernorm.weight": None,
+        # deepseekv3 toplevel
+        ".norm.weight": None,
+        "lm_head.weight": 0,
+        ".embed_tokens.": 0,
+        # vit attention
+        ".attention_norm.": None,
+        ".attention.wq_proj.": 0,
+        ".attention.wk_proj.": 0,
+        ".attention.wv_proj.": 0,
+        ".mlp.fc1.bias": 0,
+        ".mlp.fc1.weight": 0,
+        ".mlp.fc2.weight": 1,
+    }
+
+    tp_dim = None
+    for pattern, dim in tp_dim_map.items():
+        if pattern in dest_name:
+            tp_dim = dim
+            if tp_dim is not None and tp_dim < 0:
+                tp_dim += n_dim
+            break
+
+    logger.debug(
+        f"Rollout parallelism mapping: Dest_name: {dest_name}, tp_dim: {tp_dim}"
+    )
+
+    if tp_dim is not None:
+        dims_map["tp"] = tp_dim
+
+    # if dp_shard_size > 1:
+    #    dims_map["dp_shard_cp"] = 0
+
+    # What is this mapping for? It looks like this maps each
+    # tensor dimension to a list of mesh dimensions.
+    tensor_dim_to_parallel_map = {}
+    for k, v in dims_map.items():
+        if v not in tensor_dim_to_parallel_map:
+            tensor_dim_to_parallel_map[v] = []
+        tensor_dim_to_parallel_map[v].append(k)
+    pp_rank = 0
+    return dims_map, tensor_dim_to_parallel_map, pp_rank

--- a/cosmos_rl/policy/model/deepseek_v3/weight_mapper.py
+++ b/cosmos_rl/policy/model/deepseek_v3/weight_mapper.py
@@ -13,250 +13,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import re
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Tuple
 
+import re
 import torch
-import triton
-import triton.language as tl
 from transformers import AutoConfig
 
 from cosmos_rl.policy.model.base import WeightMapper
 from cosmos_rl.utils import util
 from cosmos_rl.utils.logging import logger
-from cosmos_rl.utils.parallelism import ParallelDims
 from cosmos_rl.utils.parallelism_registry import (
-    ParallelismStrategyRole,
     get_rollout_parallelism_strategy,
-    register_parallelism_strategy,
 )
-
-# Pre-compile regex patterns for better performance
-_LAYER_ATTN_NORM_PATTERN = re.compile(
-    r"model\.model\.layers\.(\d+)\.self_attn\.(q_norm|k_norm|v_norm)\.(weight|bias)"
-)
-_LAYER_INPUT_LAYERNORM_PATTERN = re.compile(
-    r"model\.model\.layers\.(\d+)\.input_layernorm\.(weight|bias)"
-)
-_LAYER_ATTN_PROJ_PATTERN = re.compile(
-    r"model\.model\.layers\.(\d+)\.self_attn\.(q_proj|kv_b_proj|q_b_proj)\.(weight|bias)"
-)
-_LAYER_ATTN_KV_A_PATTERN = re.compile(
-    r"model\.model\.layers\.(\d+)\.self_attn\.(kv_a_proj_with_mqa)\.(weight|bias)"
-)
-_LAYER_ATTN_O_PATTERN = re.compile(
-    r"model\.model\.layers\.(\d+)\.self_attn\.(o_proj)\.(weight|bias)"
-)
-_LAYER_MLP_EXPERTS_PATTERN = re.compile(
-    r"model\.model\.layers\.(\d+)\.mlp\.experts\.(\d+)\.(up_proj|gate_proj|down_proj)\.(weight|bias)"
-)
-_LAYER_MLP_SHARED_EXPERTS_PATTERN = re.compile(
-    r"model\.model\.layers\.(\d+)\.mlp\.shared_experts\.(up_proj|gate_proj)\.(weight|bias)"
-)
-_LAYER_MLP_SHARED_EXPERTS_DOWN_PATTERN = re.compile(
-    r"model\.model\.layers\.(\d+)\.mlp\.shared_experts\.down_proj\.(weight|bias)"
-)
-_LAYER_MLP_PROJ_PATTERN = re.compile(
-    r"model\.model\.layers\.(\d+)\.mlp\.(up_proj|gate_proj)\.(weight|bias)"
-)
-_LAYER_MLP_DOWN_PATTERN = re.compile(
-    r"model\.model\.layers\.(\d+)\.mlp\.down_proj\.(weight|bias)"
-)
-_LAYER_POST_ATTENTION_LAYERNORM_PATTERN = re.compile(
-    r"model\.model\.layers\.(\d+)\.post_attention_layernorm\.(weight|bias)"
-)
-_LAYER_KV_A_LAYERNORM_PATTERN = re.compile(
-    r"model\.model\.layers\.(\d+)\.self_attn\.kv_a_layernorm\.(weight|bias)"
-)
-_LAYER_Q_A_PATTERN = re.compile(
-    r"model\.model\.layers\.(\d+)\.self_attn\.(q_a_layernorm|q_a_proj)\.(weight|bias)"
-)
-_LAYER_MLP_GATE_WEIGHT_PATTERN = re.compile(
-    r"model\.model\.layers\.(\d+)\.mlp\.gate\.weight"
-)
-_LAYER_ROTARY_EMB_PATTERN = re.compile(
-    r"model\.model\.layers\.(\d+)\.self_attn\.rotary_emb\.inv_freq"
-)
-_LAYER_MLP_GATE_BIAS_PATTERN = re.compile(
-    r"model\.model\.layers\.(\d+)\.mlp\.gate\.e_score_correction_bias"
-)
-
-# Pre-define common suffixes for faster string matching
-_LM_HEAD_WEIGHT = "lm_head.weight"
-_LM_HEAD_BIAS = "lm_head.bias"
-_EMBED_TOKENS_WEIGHT = "embed_tokens.weight"
-_NORM_WEIGHT = "norm.weight"
-_NORM_BIAS = "norm.bias"
-_BIAS_SUFFIX = ".bias"
-
-
-def map_key_from_hf(name: str, src_model_type: str) -> str:
-    return "model." + name
-
-
-def convert_weight_from_hf(
-    tensor: torch.Tensor,
-    name: str,
-    src_model_type: str,
-    parallel_dims: ParallelDims,
-    n_experts: int,
-    ignore_unknown_weights: bool = False,
-) -> Tuple[Optional[str], Optional[torch.Tensor], Optional[int]]:
-    tp_ep_rank, tp_ep_size = parallel_dims.tp_coord
-    assert n_experts % tp_ep_size == 0, "n_experts must be divisible by tp_ep_size"
-
-    if parallel_dims.dp_shard_enabled or parallel_dims.cp_enabled:
-        dp_shard_rank = parallel_dims.mesh[tuple(("dp_shard_cp",))].get_local_rank()
-        dp_shard_size = parallel_dims.mesh[tuple(("dp_shard_cp",))].size()
-    else:
-        dp_shard_rank = 0
-        dp_shard_size = 1
-
-    # Expert weight are aggregated into (n_experts, in_features, out_features)
-    # Weight are loaded in (out_features, in_features) shape
-    # So we do not do FSDP sharding on expert weights, instead we filter by expert id
-    should_do_fsdp_sharding = True
-
-    dest_name = map_key_from_hf(name, src_model_type)
-
-    # Fast path for common cases using string suffix matching
-    if dest_name.endswith(_LM_HEAD_WEIGHT):
-        shard = tensor.tensor_split(tp_ep_size, dim=0)[tp_ep_rank]
-    elif dest_name.endswith(_LM_HEAD_BIAS):
-        shard = tensor
-    elif dest_name.endswith(_EMBED_TOKENS_WEIGHT):
-        shard = tensor.tensor_split(tp_ep_size, dim=0)[tp_ep_rank]
-    elif dest_name.endswith(_NORM_WEIGHT) or dest_name.endswith(_NORM_BIAS):
-        shard = tensor
-    # Regex matching for complex patterns
-    elif (match := _LAYER_ATTN_NORM_PATTERN.search(dest_name)) is not None:
-        shard = tensor
-    elif (match := _LAYER_INPUT_LAYERNORM_PATTERN.search(dest_name)) is not None:
-        shard = tensor
-    elif (match := _LAYER_ATTN_PROJ_PATTERN.search(dest_name)) is not None:
-        shard = tensor.tensor_split(tp_ep_size, dim=0)[tp_ep_rank]
-    elif (match := _LAYER_ATTN_KV_A_PATTERN.search(dest_name)) is not None:
-        shard = tensor
-    elif (match := _LAYER_ATTN_O_PATTERN.search(dest_name)) is not None:
-        if dest_name.endswith(_BIAS_SUFFIX):
-            shard = tensor
-        else:
-            shard = tensor.tensor_split(tp_ep_size, dim=-1)[tp_ep_rank]
-    elif (match := _LAYER_MLP_EXPERTS_PATTERN.search(dest_name)) is not None:
-        # Check whether this expert belongs to the current process
-        # Groups example (with 32 experts, and 4 EP groups):
-        #  EP=0: 0, 1, 2, 3, 4, 5, 6, 7
-        #  EP=1: 8, 9, 10, 11, 12, 13, 14, 15
-        #  EP=2: 16, 17, 18, 19, 20, 21, 22, 23
-        #  EP=3: 24, 25, 26, 27, 28, 29, 30, 31
-        n_expert_per_ep = n_experts // tp_ep_size
-        belongs_to_current_ep = (
-            tp_ep_rank * n_expert_per_ep
-            <= int(match.group(2))  # Expert index
-            < (tp_ep_rank + 1) * n_expert_per_ep
-        )
-        belongs_to_current_dp_shard = (
-            int(match.group(2)) - tp_ep_rank * n_expert_per_ep
-        ) // (n_expert_per_ep // dp_shard_size) == dp_shard_rank
-        if belongs_to_current_ep and belongs_to_current_dp_shard:
-            should_do_fsdp_sharding = False
-            shard = tensor
-        else:
-            # If the expert does not belong to the current process, return None to skip this weight
-            return None, None, None
-    elif (match := _LAYER_MLP_SHARED_EXPERTS_PATTERN.search(dest_name)) is not None:
-        shard = tensor.tensor_split(tp_ep_size, dim=0)[tp_ep_rank]
-    elif (
-        match := _LAYER_MLP_SHARED_EXPERTS_DOWN_PATTERN.search(dest_name)
-    ) is not None:
-        if dest_name.endswith(_BIAS_SUFFIX):
-            shard = tensor
-        else:
-            shard = tensor.tensor_split(tp_ep_size, dim=-1)[tp_ep_rank]
-    elif (match := _LAYER_MLP_PROJ_PATTERN.search(dest_name)) is not None:
-        shard = tensor.tensor_split(tp_ep_size, dim=0)[tp_ep_rank]
-    elif (match := _LAYER_MLP_DOWN_PATTERN.search(dest_name)) is not None:
-        if dest_name.endswith(_BIAS_SUFFIX):
-            shard = tensor
-        else:
-            shard = tensor.tensor_split(tp_ep_size, dim=-1)[tp_ep_rank]
-    elif (
-        match := _LAYER_POST_ATTENTION_LAYERNORM_PATTERN.search(dest_name)
-    ) is not None:
-        shard = tensor
-    elif (match := _LAYER_KV_A_LAYERNORM_PATTERN.search(dest_name)) is not None:
-        shard = tensor
-    elif (match := _LAYER_Q_A_PATTERN.search(dest_name)) is not None:
-        shard = tensor
-    elif (match := _LAYER_MLP_GATE_WEIGHT_PATTERN.search(dest_name)) is not None:
-        # TODO(cjx): Small enough, forbid FSDP sharding is better
-        shard = tensor
-    elif (match := _LAYER_ROTARY_EMB_PATTERN.search(dest_name)) is not None:
-        return None, None, None
-    elif (match := _LAYER_MLP_GATE_BIAS_PATTERN.search(dest_name)) is not None:
-        shard = tensor
-    elif not ignore_unknown_weights:
-        raise ValueError(f"Unsupported weight: {dest_name}")
-    else:
-        return None, None, None
-
-    # Do FSDP sharding
-    shard = shard.contiguous()
-    if should_do_fsdp_sharding:
-        if match := _LAYER_ATTN_KV_A_PATTERN.search(dest_name) is not None and (
-            576 % dp_shard_size != 0
-        ):
-            tensor_shard_size = 576 // dp_shard_size + 1
-            if dp_shard_rank < (576 // tensor_shard_size):
-                shard = shard[
-                    dp_shard_rank * tensor_shard_size : (dp_shard_rank + 1)
-                    * tensor_shard_size
-                ]
-            else:
-                shard = shard[dp_shard_rank * tensor_shard_size :]
-        else:
-            shard = shard.tensor_split(dp_shard_size, dim=0)[dp_shard_rank]
-
-    expert_id = None
-    if match := re.search(
-        r"model\.model\.layers\.(\d+)\.mlp\.experts\.(\d+)\.(up_proj|gate_proj|down_proj)\.(weight|bias)",
-        dest_name,
-    ):
-        expert_id = int(match.group(2))
-        dest_name = dest_name.replace(f"experts.{expert_id}.", "experts.")
-        dest_name = dest_name.replace(".weight", "s")
-
-    return dest_name, shard.contiguous(), expert_id
-
-
-@triton.jit
-def weight_dequant_kernel(x_ptr, s_ptr, y_ptr, M, N, BLOCK_SIZE: tl.constexpr):
-    pid_m = tl.program_id(axis=0)
-    pid_n = tl.program_id(axis=1)
-    n = tl.cdiv(N, BLOCK_SIZE)
-    offs_m = pid_m * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
-    offs_n = pid_n * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
-    offs = offs_m[:, None] * N + offs_n[None, :]
-    mask = (offs_m[:, None] < M) & (offs_n[None, :] < N)
-    x = tl.load(x_ptr + offs, mask=mask).to(tl.float32)
-    s = tl.load(s_ptr + pid_m * n + pid_n)
-    y = x * s
-    tl.store(y_ptr + offs, y, mask=mask)
-
-
-def weight_dequant(
-    x: torch.Tensor, s: torch.Tensor, block_size: int = 128
-) -> torch.Tensor:
-    assert x.is_contiguous() and s.is_contiguous()
-    assert x.dim() == 2 and s.dim() == 2
-    M, N = x.size()
-    y = torch.empty_like(x, dtype=torch.get_default_dtype())
-
-    def grid(meta):
-        return (triton.cdiv(M, meta["BLOCK_SIZE"]), triton.cdiv(N, meta["BLOCK_SIZE"]))
-
-    weight_dequant_kernel[grid](x, s, y, M, N, BLOCK_SIZE=block_size)
-    return y
 
 
 class DeepseekV3MoEWeightMapper(WeightMapper):
@@ -265,20 +33,37 @@ class DeepseekV3MoEWeightMapper(WeightMapper):
 
     def _rollout_vllm_name_to_hf(self, rollout_weight_name: str) -> str:
         # TODO(aazzolini): 2.2. Implement name_to_hf correctly.
+        # Why is .experts skipped here for HF weights?
         if not rollout_weight_name == "lm_head.weight":
             if "experts.w13_weight" in rollout_weight_name:
                 return rollout_weight_name.replace(
-                    "experts.w13_weight", "gate_up_proj.weight"
+                    "experts.w13_weight", "experts.gate_up_proj.weight"
                 )
             elif "experts.w2_weight" in rollout_weight_name:
                 return rollout_weight_name.replace(
-                    "experts.w2_weight", "down_proj.weight"
+                    "experts.w2_weight", "experts.down_proj.weight"
                 )
         return rollout_weight_name
 
+    def _split_qkv_a_proj_weight(self, weight: torch.Tensor):
+        # Weight has shape [q_lora_rank + kv_lora_rank + qk_rope_head_dim, hidden_dim]
+        # Split it into [q_lora_rank, hidden_dim] and [kv_lora_rank + qk_rope_head_dim, hidden_dim]
+
+        q_lora_rank = self.config.q_lora_rank
+        kv_lora_rank = self.config.kv_lora_rank
+        qk_rope_head_dim = self.config.qk_rope_head_dim
+        assert weight.shape[0] == q_lora_rank + kv_lora_rank + qk_rope_head_dim, (
+            f"weight.shape[0] {weight.shape[0]} != q_lora_rank + kv_lora_rank + qk_rope_head_dim "
+            f"{q_lora_rank + kv_lora_rank + qk_rope_head_dim}"
+        )
+
+        q_a_proj = weight[:q_lora_rank]
+        kv_a_proj_with_mqa = weight[q_lora_rank:]
+        return q_a_proj, kv_a_proj_with_mqa
+
     def _split_gate_up_proj_weight(self, weight: torch.Tensor):
-        # weight has shape [..., 2 * x, hidden_dim]
-        # split it into [..., :x, hidden_dim] and [..., x:, hidden_dim]
+        # Weight has shape [n_experts, 2 * inter_dim, hidden_dim]
+        # Split it into [n_experts, :inter_dim, hidden_dim] and [n_experts, inter_dim:, hidden_dim]
 
         # Note that for MoE we have an extra dimension on the left for for dense we dont.
         split_idx = weight.shape[-2] // 2
@@ -315,121 +100,72 @@ class DeepseekV3MoEWeightMapper(WeightMapper):
             Where "compatible_key" is the HuggingFace param name
         """
         recv_key_n_rank_list = []
-        compatible_weight_map = {}
+        compatible_key_map = {}
         for param_name, param in vllm_model.named_parameters():
             group_keys = []
             compatible_key = self._rollout_vllm_name_to_hf(param_name)
             logger.info(
                 f"[Rollout] param vllm_name {param_name} hf_name: {compatible_key}"
             )
-            if "gate_up_proj" in compatible_key:
-                # split gate and up proj
+
+            if "fused_qkv_a_proj" in compatible_key:
+                # Split q_a and kv_a_proj weights.
+
+                # self_attn.fused_qkv_a_proj.weight
+                # 1) self_attn.q_a_proj.weight
+                # 2) self_attn.kv_a_proj_with_mqa.weight
+                q_a_proj, kv_a_proj_with_mqa = self._split_qkv_a_proj_weight(param)
+
+                q_a_proj_key = compatible_key.replace("fused_qkv_a_proj", "q_a_proj")
+                compatible_key_map[q_a_proj_key] = q_a_proj
+                group_keys.append((q_a_proj_key, q_a_proj.ndim))
+
+                kv_a_proj_with_mqa_key = compatible_key.replace(
+                    "fused_qkv_a_proj", "kv_a_proj_with_mqa"
+                )
+                compatible_key_map[kv_a_proj_with_mqa_key] = kv_a_proj_with_mqa
+                group_keys.append((kv_a_proj_with_mqa_key, kv_a_proj_with_mqa.ndim))
+
+            elif "gate_up_proj" in compatible_key:
+                # Split gate and up proj weights.
                 gate_proj_weight, up_proj_weight = self._split_gate_up_proj_weight(
                     param
                 )
+
                 gate_proj_weight_key = compatible_key.replace(
                     "gate_up_proj", "gate_proj"
                 )
-                compatible_weight_map[gate_proj_weight_key] = gate_proj_weight
+                compatible_key_map[gate_proj_weight_key] = gate_proj_weight
                 group_keys.append((gate_proj_weight_key, gate_proj_weight.ndim))
 
                 up_proj_weight_key = compatible_key.replace("gate_up_proj", "up_proj")
-                compatible_weight_map[up_proj_weight_key] = up_proj_weight
+                compatible_key_map[up_proj_weight_key] = up_proj_weight
                 group_keys.append((up_proj_weight_key, up_proj_weight.ndim))
+
             else:
-                compatible_weight_map[compatible_key] = param
+                compatible_key_map[compatible_key] = param
                 group_keys.append((compatible_key, param.ndim))
+
             recv_key_n_rank_list.append(group_keys)
 
-        return compatible_weight_map, recv_key_n_rank_list
+        return compatible_key_map, recv_key_n_rank_list
 
     def policy_map_local_key_to_hf_key(self, name: str) -> str:
         name = util.clear_weight_name(name)
 
-        name = name[6:]
-        name = name.replace(".mlp.experts.down_projs", ".mlp.down_proj.weight")
-        name = name.replace(".mlp.experts.up_projs", ".mlp.up_proj.weight")
-        name = name.replace(".mlp.experts.gate_projs", ".mlp.gate_proj.weight")
+        # The weights in the policy model have a ".model" prefix.
+        name = name.replace("model.", "")
 
+        if not name == "lm_head.weight":
+            assert name.startswith(
+                "model."
+            ), f"Expected name to start with model., got {name}"
+            if re.search(
+                r"model\.layers\.(\d+)\.mlp\.experts\.(up_projs|gate_projs|down_projs)",
+                name,
+            ):
+                name = name.replace("projs", "proj.weight")
         return name
 
     def get_rollout_parallelism_strategy(self):
         return [get_rollout_parallelism_strategy("deepseek_v3")]
-
-
-@register_parallelism_strategy("deepseek_v3", role=ParallelismStrategyRole.ROLLOUT)
-def map_weight_parallel_dims(
-    n_dim: int,
-    dest_name: str,
-    parallel_dims: ParallelDims,
-    model_config: Any,
-    # ) -> Tuple[Dict[str, int], list, Dict[int, list]]:
-) -> Tuple[Dict[str, int], Dict[int, list], int]:
-    """
-    For the given HuggingFace parameter name (dest_name), return the map from
-    parallel dimension name (e.g. "tp", ...) to the corresponding dimension of the tensor.
-    """
-    # TODO(aazzolini): 1.2 implement rollout_parallelism_strategy (tp,ep)
-    dims_map = {}
-
-    tp_dim_map = {
-        # deepseekv3 attention weights
-        ".self_attn.q_a_proj.": None,
-        ".self_attn.q_a_layernorm.": None,
-        ".self_attn.q_b_proj.": 0,
-        ".self_attn.kv_a_proj_with_mqa.": None,
-        ".self_attn.kv_a_layernorm.": None,
-        ".self_attn.kv_b_proj.": 0,
-        ".self_attn.o_proj.": 1,
-        # deepseekv3 dense+moe mlp weights
-        # note on the training side gate_up_proj is fused.
-        ".mlp.gate_proj.": -2,
-        ".mlp.up_proj.": -2,
-        ".mlp.down_proj.": -1,
-        # deepseekv3 moe-related weights
-        ".mlp.gate.": None,
-        ".mlp.shared_experts.gate_proj.": 0,
-        ".mlp.shared_experts.up_proj.": 0,
-        ".mlp.shared_experts.down_proj.": 1,
-        # deepseekv3 layernorms
-        ".input_layernorm.weight": None,
-        ".post_attention_layernorm.weight": None,
-        # deepseekv3 toplevel
-        ".norm.weight": None,
-        "lm_head.weight": 0,
-        ".embed_tokens.": 0,
-        # vit attention
-        ".attention_norm.": None,
-        ".attention.wq_proj.": 0,
-        ".attention.wk_proj.": 0,
-        ".attention.wv_proj.": 0,
-        ".mlp.fc1.bias": 0,
-        ".mlp.fc1.weight": 0,
-        ".mlp.fc2.weight": 1,
-    }
-
-    tp_dim = None
-    for pattern, dim in tp_dim_map.items():
-        if pattern in dest_name:
-            tp_dim = dim
-            if tp_dim is not None and tp_dim < 0:
-                tp_dim += n_dim
-            break
-
-    logger.debug(
-        f"Rollout parallelism mapping: Dest_name: {dest_name}, tp_dim: {tp_dim}"
-    )
-
-    if tp_dim is not None:
-        dims_map["tp"] = tp_dim
-
-    # if dp_shard_size > 1:
-    #    dims_map["dp_shard_cp"] = 0
-
-    tensor_dim_to_parallel_map = {}
-    for k, v in dims_map.items():
-        if v not in tensor_dim_to_parallel_map:
-            tensor_dim_to_parallel_map[v] = []
-        tensor_dim_to_parallel_map[v].append(k)
-    pp_rank = 0
-    return dims_map, tensor_dim_to_parallel_map, pp_rank

--- a/cosmos_rl/policy/model/qwen3_moe/weight_mapper.py
+++ b/cosmos_rl/policy/model/qwen3_moe/weight_mapper.py
@@ -16,12 +16,14 @@
 import re
 import torch
 from typing import List, Tuple, Dict
+
 from cosmos_rl.policy.model.base import WeightMapper
 from cosmos_rl.utils.parallelism_registry import (
     get_policy_parallelism_strategy,
     get_rollout_parallelism_strategy,
 )
 from cosmos_rl.utils import util
+from cosmos_rl.utils.logging import logger
 from transformers import AutoConfig
 
 
@@ -37,16 +39,16 @@ class Qwen3MoeWeightMapper(WeightMapper):
         if not rollout_weight_name == "lm_head.weight":
             if "experts.w13_weight" in rollout_weight_name:
                 return rollout_weight_name.replace(
-                    "experts.w13_weight", "gate_up_proj.weight"
+                    "experts.w13_weight", "experts.gate_up_proj.weight"
                 )
             elif "experts.w2_weight" in rollout_weight_name:
                 return rollout_weight_name.replace(
-                    "experts.w2_weight", "down_proj.weight"
+                    "experts.w2_weight", "experts.down_proj.weight"
                 )
-            # below are for trtllm weight for gate_up_proj and input_layernorm.
+            # Below are for trtllm weight for gate_up_proj and input_layernorm.
             elif "experts.w3_w1_weight" in rollout_weight_name:
                 return rollout_weight_name.replace(
-                    "experts.w3_w1_weight", "gate_up_proj.weight"
+                    "experts.w3_w1_weight", "experts.gate_up_proj.weight"
                 )
             elif "next_layer_layernorm" in rollout_weight_name:
                 # For trtllm, next_layer_layernorm is:
@@ -59,11 +61,14 @@ class Qwen3MoeWeightMapper(WeightMapper):
                     return f"model.layers.{layer_id + 1}.input_layernorm.weight"
         return rollout_weight_name
 
-    def _rollout_split_qkv_weight(self, name, weight: torch.Tensor):
-        # weight has shape [q_num_heads * head_dim + k_num_heads * head_dim + v_num_heads * head_dim, hidden_dim]
+    def _rollout_split_qkv_weight(self, weight: torch.Tensor):
+        # Note that this follows GQA (Qwen3) design where:
+        # 1) k_num_heads = v_num_heads.
+        # 2) q_num_heads = kv_head_ratio * k_num_heads
+        # Weight has shape [(q_num_heads + k_num_heads + v_num_heads) * head_dim, hidden_dim]
         shares = self.kv_head_ratio + 2
         dim_0 = weight.shape[0]  # for both weight and bias
-        unit_dim = dim_0 // shares
+        unit_dim = dim_0 // shares  # unit_dim = k_num_heads * head_dim
 
         q_weight = weight[: unit_dim * self.kv_head_ratio]
         k_weight = weight[
@@ -72,7 +77,7 @@ class Qwen3MoeWeightMapper(WeightMapper):
         v_weight = weight[unit_dim * (self.kv_head_ratio + 1) :]
         return q_weight, k_weight, v_weight
 
-    def _split_gate_proj_weight(self, name, weight: torch.Tensor):
+    def _rollout_split_gate_up_proj_weight(self, weight: torch.Tensor):
         # weight has shape [num_experts, 2 * x, hidden_dim], first gate_proj, then up_proj
         # if backend is trtllm,  [num_experts, 2 * x, hidden_dim], first up_proj, then gate_proj
         dim_1 = weight.shape[1]
@@ -89,53 +94,87 @@ class Qwen3MoeWeightMapper(WeightMapper):
         Dict[str, torch.Tensor],
         List[List[Tuple[str, torch.Size]]],
     ]:
+        """
+        Given the rollout (e.g. VLLM) nn.Module, return the list of HuggingFace-compatible
+        parameter names along with their tensor views and shapes. Param names produced this
+        method should exactly match policy_model.sorted_params.
+
+        Args:
+           vllm_model: rollout nn.Module
+
+        Returns:
+          Tuple[
+            Dict[
+              str,           # compatible_key
+              Tensor         # param Tensor
+            ],               # compatible weight map
+            List[
+              List[
+                Tuple[
+                  str,         # compatible_key
+                  int,         # param tensor ndim
+                ]
+              ]              # param group (?)
+            ]                # compatible weight list
+
+            Where "compatible_key" is the HuggingFace param name
+        """
         recv_key_n_rank_list = []
-        vllm_weight_inplace_view_map = {}
+        compatible_key_map = {}
         for param_name, param in vllm_model.named_parameters():
             group_keys = []
-            param_name_hf = self._rollout_vllm_name_to_hf(param_name)
-            # logger.info(f"[Rollout] param_name_hf: {param_name_hf}")
-            if "qkv_proj" in param_name_hf:
+            compatible_key = self._rollout_vllm_name_to_hf(param_name)
+            logger.info(
+                f"[Rollout] param vllm_name {param_name} hf_name: {compatible_key}"
+            )
+
+            if "qkv_proj" in compatible_key:
                 # must be inplace slicing.
                 # split qkv weight
-                q_weight, k_weight, v_weight = self._rollout_split_qkv_weight(
-                    param_name_hf, param
-                )
-                q_proj_weight_key = param_name_hf.replace("qkv_proj", "q_proj")
-                k_proj_weight_key = param_name_hf.replace("qkv_proj", "k_proj")
-                v_proj_weight_key = param_name_hf.replace("qkv_proj", "v_proj")
-                vllm_weight_inplace_view_map[q_proj_weight_key] = q_weight
+                q_weight, k_weight, v_weight = self._rollout_split_qkv_weight(param)
+
+                q_proj_weight_key = compatible_key.replace("qkv_proj", "q_proj")
+                compatible_key_map[q_proj_weight_key] = q_weight
                 group_keys.append((q_proj_weight_key, q_weight.ndim))
-                vllm_weight_inplace_view_map[k_proj_weight_key] = k_weight
+
+                k_proj_weight_key = compatible_key.replace("qkv_proj", "k_proj")
+                compatible_key_map[k_proj_weight_key] = k_weight
                 group_keys.append((k_proj_weight_key, k_weight.ndim))
-                vllm_weight_inplace_view_map[v_proj_weight_key] = v_weight
+
+                v_proj_weight_key = compatible_key.replace("qkv_proj", "v_proj")
+                compatible_key_map[v_proj_weight_key] = v_weight
                 group_keys.append((v_proj_weight_key, v_weight.ndim))
-            elif "gate_up_proj" in param_name_hf:
+
+            elif "gate_up_proj" in compatible_key:
                 # split gate and up proj
-                gate_proj_weight, up_proj_weight = self._split_gate_proj_weight(
-                    param_name_hf, param
+                gate_proj_weight, up_proj_weight = (
+                    self._rollout_split_gate_up_proj_weight(param)
                 )
-                gate_proj_weight_key = param_name_hf.replace(
+
+                gate_proj_weight_key = compatible_key.replace(
                     "gate_up_proj", "gate_proj"
                 )
-                vllm_weight_inplace_view_map[gate_proj_weight_key] = gate_proj_weight
+                compatible_key_map[gate_proj_weight_key] = gate_proj_weight
                 group_keys.append((gate_proj_weight_key, gate_proj_weight.ndim))
 
-                up_proj_weight_key = param_name_hf.replace("gate_up_proj", "up_proj")
-                vllm_weight_inplace_view_map[up_proj_weight_key] = up_proj_weight
+                up_proj_weight_key = compatible_key.replace("gate_up_proj", "up_proj")
+                compatible_key_map[up_proj_weight_key] = up_proj_weight
                 group_keys.append((up_proj_weight_key, up_proj_weight.ndim))
+
             else:
-                vllm_weight_inplace_view_map[param_name_hf] = param
-                group_keys.append((param_name_hf, param.ndim))
+                compatible_key_map[compatible_key] = param
+                group_keys.append((compatible_key, param.ndim))
             recv_key_n_rank_list.append(group_keys)
-        return vllm_weight_inplace_view_map, recv_key_n_rank_list
+
+        return compatible_key_map, recv_key_n_rank_list
 
     @torch.no_grad()
     def policy_maybe_decompose_weights_to_hf_naming(
         self, name, expert_weight: torch.Tensor
     ):
         if match := re.search(
-            r"model\.layers\.(\d+)\.mlp\.(up_proj|gate_proj|down_proj)\.(weight)", name
+            r"model\.layers\.(\d+)\.mlp\.experts\.(up_proj|gate_proj|down_proj)\.weight",
+            name,
         ):
             layer_id = int(match.group(1))
             w_name = match.group(2)
@@ -152,8 +191,15 @@ class Qwen3MoeWeightMapper(WeightMapper):
     def policy_map_local_key_to_hf_key(self, name: str) -> str:
         name = util.clear_weight_name(name)
         if not name == "lm_head.weight":
+            # The policy weights do not have the "model." prefix, but the hf weights do.
             if not name.startswith("model."):
                 name = "model." + name
+
+            if re.search(
+                r"model\.layers\.(\d+)\.mlp\.experts\.(up_projs|gate_projs|down_projs)",
+                name,
+            ):
+                name = name.replace("projs", "proj.weight")
         return name
 
     def get_policy_parallelism_strategy(self):


### PR DESCRIPTION
Support DeepEP for MoE for Qwen3.
Tested using SFT.
Reorganized code with qwen3_moe/ and deepseek_v3/ models to accomplish the support.

Code reorganization

* Move the DeepSeek V3 specific MoE implementation back into model/deepseek_v3/moe.py.
* Only keep the common MoE modules that can be reused across models in kernel/moe/moe.py.
* Move the symmetric memory based implementation into the GroupedExpertsSymmMem class in kernel/moe/moe.py.
* Allow the Qwen3 MoE to select between GroupedExpertsSymmMem and GroupedExpertsDeepEP.
* Move the multi-layer perceptron implementation into kernel/mlp.py so it can be reused from multiple modules.

Weight mapper / weight converter changes

* Add support for DeepEP (fused gate_and_up_projs) in Qwen3 weight converter. Support for GRPO will done as a follow-up PR.
* Fix the code in deepseek_v3/ weight mapper, set up the code for supporting MLA, previously it supported GQA.
* Simplify the code in qwen3_moe/ and deepseek_v3/ weight converter regarding the conversion of experts.