### PR TITLE
Set p2r nccl group size default to 1.

### DIFF
--- a/cosmos_rl/utils/constant.py
+++ b/cosmos_rl/utils/constant.py
@@ -39,7 +39,8 @@ COSMOS_ROLLOUT_STEP_INTERVAL = int(
 COSMOS_NCCL_ERROR_CLEAN_REPLICA_DELAY = int(
     os.environ.get("COSMOS_NCCL_ERROR_CLEAN_REPLICA_DELAY", "10")
 )
-COSMOS_P2R_NCCL_GROUP_SIZE = int(os.environ.get("COSMOS_P2R_NCCL_GROUP_SIZE", "4"))
+# FIXME: (lms) Setting this greater than 1 could cause P2R NCCL hang when PP and FSDP are both enabled.
+COSMOS_P2R_NCCL_GROUP_SIZE = int(os.environ.get("COSMOS_P2R_NCCL_GROUP_SIZE", "1"))
 COSMOS_ROLLOUT_CMD_WAIT_TIMEOUT = int(
     os.environ.get("COSMOS_ROLLOUT_CMD_WAIT_TIMEOUT", "600")
 )


### PR DESCRIPTION
By default, NCCL group size in P2R is `4`, this could cause NCCL hang for pp > 1 and fsdp > 1.  See: #307 
We temporarily set this to `1` to avoid the hang.