### PR TITLE
Supporting pure text prompt for qwen2.5-vl

### DIFF
--- a/cosmos_rl/utils/util.py
+++ b/cosmos_rl/utils/util.py
@@ -1127,36 +1127,37 @@ def decode_vision_info(prompts):
     new_prompts = []
     for prompt in prompts:
         new_prompt = prompt.copy()
-        multi_modal_data = new_prompt.pop("multi_modal_data")
-        if "image" in multi_modal_data:
-            img_obj = multi_modal_data["image"]
-            assert isinstance(
-                img_obj, list
-            ), f"image should be a list, but got {type(img_obj)}"
-            img_type = type(img_obj[0])
-            if img_type == str:
-                for i, img_b64 in enumerate(img_obj):
-                    img_bytes = base64.b64decode(img_b64)
-                    img_buffer = io.BytesIO(img_bytes)
-                    image = Image.open(img_buffer)
-                    multi_modal_data["image"][i] = image
-            elif img_type == torch.Tensor:
-                pass
-            else:
-                raise ValueError(f"Unsupported image type: {img_type}")
-        if "video" in multi_modal_data:
-            video_obj = multi_modal_data["video"]
-            assert isinstance(
-                video_obj, list
-            ), f"video should be a list, but got {type(video_obj)}"
-            video_type = type(video_obj[0])
-            # No need to decode video tensor
-            if video_type == torch.Tensor:
-                pass
-            else:
-                raise ValueError(f"Unsupported video type: {video_type}")
+        if "multi_modal_data" in new_prompt:  # Skip if text-only prompt
+            multi_modal_data = new_prompt.pop("multi_modal_data")
+            if "image" in multi_modal_data:
+                img_obj = multi_modal_data["image"]
+                assert isinstance(
+                    img_obj, list
+                ), f"image should be a list, but got {type(img_obj)}"
+                img_type = type(img_obj[0])
+                if img_type == str:
+                    for i, img_b64 in enumerate(img_obj):
+                        img_bytes = base64.b64decode(img_b64)
+                        img_buffer = io.BytesIO(img_bytes)
+                        image = Image.open(img_buffer)
+                        multi_modal_data["image"][i] = image
+                elif img_type == torch.Tensor:
+                    pass
+                else:
+                    raise ValueError(f"Unsupported image type: {img_type}")
+            if "video" in multi_modal_data:
+                video_obj = multi_modal_data["video"]
+                assert isinstance(
+                    video_obj, list
+                ), f"video should be a list, but got {type(video_obj)}"
+                video_type = type(video_obj[0])
+                # No need to decode video tensor
+                if video_type == torch.Tensor:
+                    pass
+                else:
+                    raise ValueError(f"Unsupported video type: {video_type}")
 
-        new_prompt["multi_modal_data"] = multi_modal_data
+            new_prompt["multi_modal_data"] = multi_modal_data
         new_prompts.append(new_prompt)
     return new_prompts
 


### PR DESCRIPTION
Previously, a key not found error will be raised if the prompt contains no multimedia data. However, it is sometimes necessary for an VLM to handle text-only data.