### PR TITLE
feat: Reduce peak memory in P2R check process

### DIFF
--- a/cosmos_rl/utils/constant.py
+++ b/cosmos_rl/utils/constant.py
@@ -54,6 +54,10 @@ COSMOS_ROLLOUT_REPORT_INTERVAL = int(
     os.environ.get("COSMOS_ROLLOUT_REPORT_INTERVAL", "100")
 )
 
+COSMOS_RECV_TENSOR_QUEUE_SIZE = int(
+    os.environ.get("COSMOS_RECV_TENSOR_QUEUE_SIZE", "8")
+)
+
 # Internal model type for HFModel
 COSMOS_HF_MODEL_TYPES = "hfmodel"
 

--- a/tests/launch_test_worker.py
+++ b/tests/launch_test_worker.py
@@ -26,6 +26,7 @@ from transformers import AutoTokenizer
 from cosmos_rl.policy.model import ModelRegistry, WeightMapper
 import msgpack
 import threading
+from queue import Queue
 from cosmos_rl.policy.trainer.grpo_trainer import GRPOTrainer
 from cosmos_rl.policy.trainer import Trainer
 from cosmos_rl.policy.trainer.sft_trainer import SFTTrainer
@@ -320,7 +321,7 @@ class TestRollout:
 
         self.rollout = vLLMRollout(self.config, tokenizer)
 
-        self.total_temp_tensor_pool = []
+        self.temp_recv_tensor_queue = Queue()
         self.prepare_trainable_params()
         self.validation_flag = threading.Event()
 


### PR DESCRIPTION
Reduce the peak memory in P2R recv part
The previous gpt-oss memory corruption problem can be still solved in this PR. The curve looks fine.
<img width="842" height="597" alt="image" src="https://github.com/user-attachments/assets/d85bb999-87c6-4e15-8a03-dd9d52744913" />
