### PR TITLE
fix: fix unmatched token numbers in calculating token-mean loss

### DIFF
--- a/cosmos_rl/policy/config/__init__.py
+++ b/cosmos_rl/policy/config/__init__.py
@@ -136,6 +136,11 @@ class SFTDataConfig(BaseModel):
         description="System prompt for the model, which will be prepended to the prompt",
     )
 
+    balance_dp_token: bool = Field(
+        default=True,
+        description="Whether to balance the number of tokens in each data parallel replica when calculating the loss.",
+    )
+
     @model_validator(mode="after")
     def check_params_value(self):
         if self.dataloader_num_workers <= 0:
@@ -399,6 +404,11 @@ class GrpoConfig(BaseModel):
     reset_optimizer_with_reference: bool = Field(
         default=True,
         description="Whether to reset the optimizer state when the reference model is reset.",
+    )
+
+    balance_dp_token: bool = Field(
+        default=False,
+        description="Whether to balance the number of tokens in each data parallel replica when calculating the loss.",
     )
 
     @model_validator(mode="after")

--- a/cosmos_rl/policy/trainer/sft_trainer.py
+++ b/cosmos_rl/policy/trainer/sft_trainer.py
@@ -556,7 +556,9 @@ class SFTTrainer(Trainer):
 
         self.loss_fn = partial(
             async_safe_ce,
-            dp_group=dp_group,
+            dp_group=dp_group
+            if self.config.train.train_policy.balance_dp_token
+            else None,
             cp_group=cp_group,
         )
 
@@ -1096,7 +1098,9 @@ class SFTTrainer(Trainer):
             partial(
                 async_safe_ce,
                 loss_scaling_factor=loss_scaling_factor,
-                dp_group=dp_group,
+                dp_group=dp_group
+                if self.config.train.train_policy.balance_dp_token
+                else None,
                 cp_group=cp_group,
             )
         )


### PR DESCRIPTION
Previous calculation is use loss sum among local-dp token number divided by cross-dp mean token number, which might cause the two token count mismatch?