### PR TITLE
Add expandable segmentation for pytorch allocator

### DIFF
--- a/cosmos_rl/launcher/launch_replica.sh
+++ b/cosmos_rl/launcher/launch_replica.sh
@@ -114,6 +114,7 @@ if [ "$TYPE" == "rollout" ]; then
 elif [ "$TYPE" == "policy" ]; then
   DEFAULT_MODULE="cosmos_rl.policy.train"
   export COSMOS_ROLE="Policy"
+  set_env "PYTORCH_CUDA_ALLOC_CONF" "expandable_segments:True"
 else
   echo "Error: Invalid --type value '$TYPE'. Must be 'rollout' or 'policy'."
   print_help


### PR DESCRIPTION
When enable expandable_segments for pytorch allocator, it will significantly decrease reserved memory for pytorch allocator.
Ref: https://docs.pytorch.org/docs/stable/notes/cuda.html#optimizing-memory-usage-with-pytorch-cuda-alloc-conf

Test on qwen2.5-7b dp_shard=2 policy=1
- memory info read out from pynvml and pytorch allocator after step 3 parameter update:
  - Before
  Allocated (real tensor memory): 60.93 GB     Reserved  (cached by PyTorch): 126.97 GB     Max reserved this process ever: 126.97 GB
  pynvml info: (pid 752970: 128.88 GiB)

  - After
  Allocated (real tensor memory): 60.81 GB     Reserved  (cached by PyTorch): 96.61 GB     Max reserved this process ever: 96.61 GB
  pynvml info: (pid 800722: 98.74 GiB)