### PR TITLE
Disable DeepEP for architectures older than Hopper

### DIFF
--- a/cosmos_rl/policy/kernel/moe/moe.py
+++ b/cosmos_rl/policy/kernel/moe/moe.py
@@ -50,7 +50,7 @@ def is_deepep_supported():
     supported = False
     # DeepEP is built for TORCH_CUDA_ARCH_LIST=9.0 by default
     # which causes issues for older GPUs like L20
-    # Judging from https://github.com/deepseek-ai/DeepEP/issues/481 
+    # Judging from https://github.com/deepseek-ai/DeepEP/issues/481
     # in order to install DeepEP for older architectures we would need to
     # disable some features available for newer ones
     if torch.cuda.get_device_properties().major >= 9:


### PR DESCRIPTION
By default we use `DeepEP` for MoE, which is build with `TORCH_CUDA_ARCH_LIST=9.0`, which makes it not work with older GPUs like L40. Looking at `DeepEP` [issue](https://github.com/deepseek-ai/DeepEP/issues/481) it seems that building it for older architectures would require disabling some features, so it seems we can either have different Dockerfiles for different architectures or disable `DeepEP` for older GPUs. This MR disables `DeepEP` for GPUs older than `Hopper`