### PR TITLE
Fix: step control for sft-trainer

### DIFF
--- a/cosmos_rl/policy/worker/sft_worker.py
+++ b/cosmos_rl/policy/worker/sft_worker.py
@@ -628,8 +628,6 @@ class SFTPolicyWorker(PolicyWorkerBase):
         # For pre-train validation
         val_avg_loss = self.validate(current_epoch=cur_epoch, is_last_step=False)
         for _ in range(self.start_epoch, self.epoch):
-            if stop_training:
-                break
             if hasattr(self.train_sampler, "set_epoch"):
                 self.train_sampler.set_epoch(cur_epoch)
             logger.info(f"Training epoch {cur_epoch + 1}/{self.epoch}")


### PR DESCRIPTION
The current SFTTrainer can only be controlled by epoch. The control of max-step will fail due to the lack of a jump. This pr has been fixed.