### PR TITLE
fix: sft-trainer weight upload at final step

### DIFF
--- a/cosmos_rl/policy/trainer/diffusers_trainer/sft_trainer.py
+++ b/cosmos_rl/policy/trainer/diffusers_trainer/sft_trainer.py
@@ -124,6 +124,7 @@ class SFTTrainer(DiffusersTrainer):
                     scheduler=self.lr_schedulers,
                     step=train_step,
                     total_steps=total_steps,
+                    is_final=is_last_step,
                 )
                 # TODO(yy): support save safetensor
                 # self.ckpt_manager.save_check(

--- a/cosmos_rl/policy/trainer/llm_trainer/sft_trainer.py
+++ b/cosmos_rl/policy/trainer/llm_trainer/sft_trainer.py
@@ -578,6 +578,7 @@ class SFTTrainer(LLMTrainer):
                     scheduler=self.lr_schedulers,
                     step=train_step,
                     total_steps=total_steps,
+                    is_final=is_last_step,
                     **kwargs,
                 )
                 self.ckpt_manager.save_check(

--- a/cosmos_rl/policy/worker/base.py
+++ b/cosmos_rl/policy/worker/base.py
@@ -118,4 +118,11 @@ class PolicyWorkerBase(WorkerBase, CommMixin):
             traceback.print_exc()
             raise e
         finally:
+            # Ensure any async checkpoint uploads are flushed before exit.
+            ckpt_manager = getattr(self.trainer, "ckpt_manager", None)
+            if ckpt_manager is not None and hasattr(ckpt_manager, "finalize"):
+                try:
+                    ckpt_manager.finalize()
+                except Exception as e:
+                    logger.error(f"Failed to finalize checkpoint manager: {e}")
             self.destroy_worker()

--- a/cosmos_rl/utils/checkpoint.py
+++ b/cosmos_rl/utils/checkpoint.py
@@ -121,6 +121,22 @@ class CheckpointMananger:
                 state_dict_cpu[key] = value
         return state_dict
 
+    def finalize(self) -> None:
+        """Wait for any pending async checkpoint saves/uploads to finish.
+        This should be called before process exit to avoid losing uploads when
+        `save_mode == "async"`.
+        """
+        if self.save_mode != "async" or not hasattr(self, "executor"):
+            return
+        if self.pre_save_futures:
+            for future in futures.as_completed(self.pre_save_futures):
+                try:
+                    future.result()
+                except Exception as e:
+                    logger.error(f"Async checkpoint save/upload failed: {e}")
+            self.pre_save_futures = []
+        self.executor.shutdown(wait=True)
+
     def save_checkpoint(
         self,
         model: Union[torch.nn.Module, Dict],


### PR DESCRIPTION
SFT Trainer has an issue where it does not upload the weights of the last step, and there is a situation where the upload of the last step's weights is interrupted after training ends.