### PR TITLE
Revert changes in config `from_dict` function

### DIFF
--- a/cosmos_rl/policy/config/__init__.py
+++ b/cosmos_rl/policy/config/__init__.py
@@ -19,7 +19,6 @@ from pydantic_core import core_schema
 from datetime import datetime
 from typing import Any, Dict, Union, Optional, List, Literal
 import os
-import re
 import json
 import hashlib
 from cosmos_rl.utils.modelscope import update_config_if_modelscope
@@ -1548,18 +1547,6 @@ class Config(BaseModel):
                 config_data["train"]["timestamp"] = datetime.now().strftime(
                     "%Y%m%d%H%M%S"
                 )
-                config_data["train"]["output_dir"] = os.path.join(
-                    config_data["train"]["output_dir"],
-                    config_data["train"]["timestamp"],
-                )
-            else:
-                timestamp = str(config_data["train"]["timestamp"])
-                if not re.match(r"^\d{14}$", timestamp):
-                    raise ValueError(
-                        f"Invalid timestamp format: '{timestamp}'. "
-                        f"Expected format: YYYYMMDDHHMMSS (14 digits), e.g., '20250203120000'."
-                    )
-                # append the timestamp to the output_dir
                 config_data["train"]["output_dir"] = os.path.join(
                     config_data["train"]["output_dir"],
                     config_data["train"]["timestamp"],


### PR DESCRIPTION
The changes in previous PR [546](https://github.com/nvidia-cosmos/cosmos-rl/pull/546) accidentally causes inconsistent output_dir when controller broadcasts it to policies.