### PR TITLE
Fix checkpoint offload and loading to CPU

### DIFF
--- a/cosmos_rl/utils/checkpoint.py
+++ b/cosmos_rl/utils/checkpoint.py
@@ -647,6 +647,14 @@ class CheckpointMananger:
                             optimizer_path, weights_only=False, map_location="cpu"
                         )
                     )
+
+                    # Release CUDA cached memory to avoid fragmentation-induced
+                    # OOM during the first training step after resume.
+                    import gc
+
+                    gc.collect()
+                    if torch.cuda.is_available():
+                        torch.cuda.empty_cache()
                     logger.info(
                         f"[Policy] Checkpoint loaded successfully from {base_path}."
                     )


### PR DESCRIPTION
## Fix two critical bugs in checkpoint management:

1. **Fix `offload_state_dict_cpu` returning the wrong variable**: The method was returning the original `state_dict` instead of `state_dict_cpu`, which means offloading to CPU had no effect. Also added recursive handling for nested dicts within the state dict. This bug can cause saving inconsistent weights in async mode.

2. **Add `map_location="cpu"` to all `torch.load` calls**: When loading checkpoints (model, optimizer, scheduler, extra info), tensors were being loaded to the GPU they were saved from, which could cause OOM or device mismatch errors. Now all checkpoint loads explicitly map to CPU first.

## Avoid OOM due to CUDA memory fragmentation

**Fix CUDA memory fragmentation OOM after checkpoint resume**: `optimizer.load_state_dict()` creates temporary GPU tensors during loading, causing CUDA's caching allocator to reserve significantly more memory than actually needed (~83 GB reserved vs ~49 GB allocated). This left insufficient free memory for the first training step, causing OOM during FSDP all-gather. Added `gc.collect()` + `torch.cuda.empty_cache()` after checkpoint loading to release the cached memory.

Experiments on `configs/qwen3/qwen3-8b-p-fsdp1-tp4-fp8-r-tp4-pp1-fp8-grpo.toml`
Before:
```
[rank6]:[cosmos] 2026-02-06 13:46:40,969 - cosmos - INFO - [Policy][Debug] GPU mem AFTER model load: allocated=16.38 GB, reserved=16.69 GB
[rank6]:[cosmos] 2026-02-06 13:47:09,909 - cosmos - INFO - [Policy][Debug] GPU mem AFTER optimizer load: allocated=49.15 GB, reserved=83.44 GB
```

After
```
[rank6]:[cosmos] 2026-02-06 14:04:17,650 - cosmos - INFO - [Policy][Debug] GPU mem AFTER model load: allocated=16.38 GB, reserved=16.69 GB
[rank6]:[cosmos] 2026-02-06 14:04:48,226 - cosmos - INFO - [Policy][Debug] GPU mem AFTER optimizer load + empty_cache: allocated=49.15 GB, reserved=50.07 GB
```