### PR TITLE
slurm launcher - improve the discovery of cosmos_rl path

### DIFF
--- a/cosmos_rl/tools/slurm/cosmos_rl_job_multi_node.sh
+++ b/cosmos_rl/tools/slurm/cosmos_rl_job_multi_node.sh
@@ -68,7 +68,7 @@ srun \
     '
     # Start the controller
     export COSMOS_LOG_LEVEL=DEBUG
-    cd $(python -c "import cosmos_rl,os;print(os.path.dirname(os.path.dirname(cosmos_rl.__file__)))")
+    cd $(python -c "import logging;logging.disable(logging.CRITICAL);import cosmos_rl,os;print(os.path.dirname(os.path.dirname(cosmos_rl.__file__)))")
     ./cosmos_rl/launcher/launch_controller.sh --port ${CONTROLLER_PORT} --config /opt/tmp_config/$(basename [[CONFIG_PATH]]) --script [[LAUNCHER]] [[LAUNCHER_ARGS]]
     ' \
     &
@@ -88,7 +88,7 @@ srun \
     -e ${OUTDIR}/%j/policy/%t.err \
     bash -c \
     '
-    cd $(python -c "import cosmos_rl,os;print(os.path.dirname(os.path.dirname(cosmos_rl.__file__)))")
+    cd $(python -c "import logging;logging.disable(logging.CRITICAL);import cosmos_rl,os;print(os.path.dirname(os.path.dirname(cosmos_rl.__file__)))")
     python ./cosmos_rl/tools/slurm/cosmos_rl_slurm_launch.py --type policy --config /opt/tmp_config/$(basename [[CONFIG_PATH]]) [[LAUNCHER]] [[LAUNCHER_ARGS]]
     ' \
     &
@@ -109,7 +109,7 @@ if [[ ${NUM_ROLLOUT_NODES} -gt 0 ]]; then
         -e ${OUTDIR}/%j/rollout/%t.err \
         bash -c \
         '
-        cd $(python -c "import cosmos_rl,os;print(os.path.dirname(os.path.dirname(cosmos_rl.__file__)))")
+        cd $(python -c "import logging;logging.disable(logging.CRITICAL);import cosmos_rl,os;print(os.path.dirname(os.path.dirname(cosmos_rl.__file__)))")
         python ./cosmos_rl/tools/slurm/cosmos_rl_slurm_launch.py --type rollout --config /opt/tmp_config/$(basename [[CONFIG_PATH]]) [[LAUNCHER]] [[LAUNCHER_ARGS]]
         ' \
         &


### PR DESCRIPTION
# The problem

Here is the issue I encountered on two of the clusters, where `import cosmos_rl` emits lines of warnings.
And these extra lines caused `cd $(python -c "import cosmos_rl,os;print(os.path.dirname(os.path.dirname(cosmos_rl.__file__)))")` to fail.

vincentz@xxx-001:/$ python

```Python

Python 3.12.3 (main, Feb  4 2025, 14:48:35) [GCC 13.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.

>>> import cosmos_rl
INFO 02-10 14:27:43 [__init__.py:241] Automatically detected platform cuda.
[cosmos] 2026-02-10 14:27:44,122 - cosmos - ERROR - Failed to import VLLM Rollout. Please make sure vllm is installed. Error: cannot import name 'ResponsePrompt' from 'openai.types.responses' (/usr/local/lib/python3.12/dist-packages/openai/types/responses/__init__.py)
/usr/local/lib/python3.12/dist-packages
```

# The solution

The fix is basically to surpress the extra logs via `disable(logging.CRITICAL`