### PR TITLE
Fix DiffusionNFT beta config

### DIFF
--- a/configs/cosmos-predict2-5/cosmos-predict2-5_2b_720_nft.toml
+++ b/configs/cosmos-predict2-5/cosmos-predict2-5_2b_720_nft.toml
@@ -28,6 +28,7 @@ offload = false
 max_prompt_length = 512
 inference_size = [512, 512]
 timestep_fraction = 0.99
+nft_beta = 1.0
 weight_copy_decay_type = 1
 train_frames = 93
 

--- a/configs/stable-diffusion-3-5/stable-diffusion-3-5-medium_720_nft.toml
+++ b/configs/stable-diffusion-3-5/stable-diffusion-3-5-medium_720_nft.toml
@@ -29,6 +29,7 @@ offload = false
 max_prompt_length = 128
 inference_size = [512, 512]
 timestep_fraction = 0.99
+nft_beta = 1.0
 weight_copy_decay_type = 1
 
 [policy.diffusers.sample]

--- a/cosmos_rl/policy/config/__init__.py
+++ b/cosmos_rl/policy/config/__init__.py
@@ -1087,6 +1087,10 @@ class DiffusersConfig(BaseModel):
         default=1.0,
         description="Fraction of timesteps to use during training. if set to less than 1.0, the model will be trained on a subset of the timesteps for each sample. this will speed up training but reduce the accuracy of policy gradient estimates.",
     )
+    nft_beta: float = Field(
+        default=1.0,
+        description="Beta for the DiffusionNFT positive and negative loss computation",
+    )
     weight_copy_decay_type: int = Field(
         default=0,
         description="Weight copy decay type for diffusers model in rl training",

--- a/cosmos_rl/policy/trainer/diffusers_trainer/nft_trainer.py
+++ b/cosmos_rl/policy/trainer/diffusers_trainer/nft_trainer.py
@@ -526,15 +526,15 @@ class NFTTrainer(DiffusersTrainer):
                             r = torch.clamp(normalized_advantages_clip, 0, 1)
 
                             positive_prediction = (
-                                self.config.train.train_policy.kl_beta
+                                self.config.policy.diffusers.nft_beta
                                 * forward_prediction
-                                + (1 - self.config.train.train_policy.kl_beta)
+                                + (1 - self.config.policy.diffusers.nft_beta)
                                 * old_prediction.detach()
                             )
                             implicit_negative_prediction = (
-                                (1.0 + self.config.train.train_policy.kl_beta)
+                                (1.0 + self.config.policy.diffusers.nft_beta)
                                 * old_prediction.detach()
-                                - self.config.train.train_policy.kl_beta
+                                - self.config.policy.diffusers.nft_beta
                                 * forward_prediction
                             )
 
@@ -568,10 +568,10 @@ class NFTTrainer(DiffusersTrainer):
                             ori_policy_loss = (
                                 r
                                 * positive_loss
-                                / self.config.train.train_policy.kl_beta
+                                / self.config.policy.diffusers.nft_beta
                                 + (1.0 - r)
                                 * negative_loss
-                                / self.config.train.train_policy.kl_beta
+                                / self.config.policy.diffusers.nft_beta
                             )
                             policy_loss = (
                                 ori_policy_loss


### PR DESCRIPTION
The beta of diffusionNFT is different from kl_beta, which is confusing in the [official implementation](https://github.com/NVlabs/DiffusionNFT/blob/24af5554898d85e93efa492f42b5e9cdf4156e9b/config/nft.py#L61).