### PR TITLE
Remove dp_replicate from `dp_cp_tp` mesh dimension names

### DIFF
--- a/cosmos_rl/utils/parallelism.py
+++ b/cosmos_rl/utils/parallelism.py
@@ -247,8 +247,6 @@ class ParallelDims:
         if self.dp_replicate_enabled:
             dp_mesh_dim_names.append("dp_replicate")
             dp_cp_mesh_dim_names.append("dp_replicate")
-            # Add dp_replicate to dp_cp_tp_mesh_dim_names
-            dp_cp_tp_mesh_dim_names.append("dp_replicate")
         if self.dp_shard_enabled:
             dp_mesh_dim_names.append("dp_shard")
             dp_shard_cp_mesh_dim_names.append("dp_shard")


### PR DESCRIPTION
`dp_cp_tp` represents the truly FSDP sharding group.