### PR TITLE
fix: accurate weight version control & cumem of nccl default off

### DIFF
--- a/cosmos_rl/dispatcher/status.py
+++ b/cosmos_rl/dispatcher/status.py
@@ -114,7 +114,6 @@ class PolicyStatusManager:
 
         self.rollout_buffer = Queue()
         self.remain_samples_num = 0
-        self.consumed_samples_num = 0
         self.samples_on_the_fly = 0
 
         self.status = {}
@@ -773,7 +772,6 @@ class PolicyStatusManager:
                 )
             n_samples += 1
             self.put_rollout(rollout)
-            self.consumed_samples_num += 1
             if self.config.train.train_policy.on_policy:
                 if self.total_pending_rollouts() == 0:
                     self.on_policy_rollout_completed = True

--- a/cosmos_rl/launcher/launch_replica.sh
+++ b/cosmos_rl/launcher/launch_replica.sh
@@ -96,8 +96,11 @@ if [ -z "$TYPE" ]; then
   exit 1
 fi
 
-# NCCL related
-set_env "NCCL_CUMEM_ENABLE" "1"
+# NCCL related, to avoid potential unstable issues such as https://github.com/NVIDIA/nccl/issues/1234
+# Only set if not set by user to avoid overwriting user specified envs. `NCCL_CUMEM_ENABLE` -> 0
+if [ -z "$NCCL_CUMEM_ENABLE" ]; then
+  set_env "NCCL_CUMEM_ENABLE" "0"
+fi
 
 if [ "$BACKEND" == "trtllm" ]; then
   # BACKEND won't have affect on policy.


### PR DESCRIPTION
Previous using consumed_samples_num for weight version calculation might be not proper when replicas number changes during training. Moreover, resume case weight version calculation might not consider the resumed consumed_samples_num in previous run. We change the weight version calculation to using total pending samples with current weight version, which will be more accurate.