### PR TITLE
feat: controller hardening and P2R initial sync fix

### DIFF
--- a/cosmos_rl/dispatcher/controller.py
+++ b/cosmos_rl/dispatcher/controller.py
@@ -240,7 +240,26 @@ maxmemory-policy allkeys-lfu
         validation_step: Optional[int] = None,
         rank_in_mesh: Optional[int] = None,
     ) -> Tuple[List[RLPayload], bool]:
+        return await self._get_batched_prompt_impl(n, validation_step, rank_in_mesh)
+
+    async def _get_batched_prompt_impl(
+        self,
+        n: int,
+        validation_step: Optional[int] = None,
+        rank_in_mesh: Optional[int] = None,
+    ) -> Tuple[List[RLPayload], bool]:
         is_validation = validation_step is not None
+
+        # Short-circuit when all policy replicas have unregistered during
+        # teardown.  Without this guard, global_batch_size becomes 0 and
+        # downstream asserts / divisions crash the controller.
+        if len(self.policy_status_manager) == 0:
+            logger.warning(
+                "[Controller] No policy replicas registered. "
+                "Assuming training is finished; signaling end of rollouts."
+            )
+            return [], True
+
         # Tag the prompt with specific weight-version for weight version control in on-policy training or outdated rollout control.
         rollouts_per_global_batch = self.config.train.train_batch_per_replica * len(
             self.policy_status_manager
@@ -263,24 +282,22 @@ maxmemory-policy allkeys-lfu
         )
 
         if step_fetched_count_control:
-            # Throttle the generation speed:
+            current_pending_rollouts = self.policy_status_manager.samples_on_the_fly
+
+            # Soft throttle:
             # 1. Detect the current left pending rollouts in all policy replicas.
             # 2. Check the config.train.train_policy.allowed_outdated_steps.
             # 3. If the current pending rollouts is larger than the allowed outdated version count, reduce the number of prompts to generate.
-            current_pending_rollouts = self.policy_status_manager.samples_on_the_fly
             if (
                 current_pending_rollouts
                 >= (self.config.train.train_policy.allowed_outdated_steps + 1)
                 * rollouts_per_global_batch
             ) and self.config.train.train_policy.variant != "dapo":
-                # For non dapo variant, we only need to control the number of outdated weight versions when fetching new prompts.
-                # Since the number of fetched prompts is directly related to the number of rollouts to be trained.
                 n = min(
                     n,
                     self.config.train.train_policy.outdated_rollout_fetch_batch_size,
                 )
                 if n > 0:
-                    # Log only when n is reduced but not when set to 0 since 0 is logged too frequently
                     logger.warning(
                         f"[Controller] Current pending rollouts {current_pending_rollouts} is larger than the allowed outdated version count {self.config.train.train_policy.allowed_outdated_steps * len(self.policy_status_manager)}. Generate with batch {n}"
                     )
@@ -319,6 +336,20 @@ maxmemory-policy allkeys-lfu
                         logger.warning(
                             f"[Controller] Current pending rollouts {current_pending_rollouts} is larger than the allowed outdated version count {self.config.train.train_policy.allowed_outdated_steps * len(self.policy_status_manager)}. Generate with batch {n}"
                         )
+
+            # Hard throttle: reject all remaining prompts when pending
+            # rollouts hit a hard ceiling.  This prevents unbounded
+            # accumulation when outdated_rollout_fetch_batch_size > 0.
+            # The validator guarantees max_inflight_steps >= allowed_outdated_steps + 1
+            # so that the non-DAPO soft throttle always fires first.  For DAPO
+            # the soft threshold is higher (scaled by max_retry_for_on_policy),
+            # so the hard throttle may fire before DAPO's soft throttle — set
+            # max_inflight_steps accordingly if using DAPO.
+            max_inflight = self.config.train.train_policy.max_inflight_steps
+            if max_inflight is not None:
+                hard_threshold = max_inflight * rollouts_per_global_batch
+                if current_pending_rollouts >= hard_threshold:
+                    return [], is_validation
 
         if (
             step_fetched_count_control

--- a/cosmos_rl/policy/config/__init__.py
+++ b/cosmos_rl/policy/config/__init__.py
@@ -585,6 +585,21 @@ class GrpoConfig(BaseModel):
         description="Number of outdated rollouts to fetch. If set to 0, the rollout engine will stop generating rollouts if the weight is outdated.",
     )
 
+    max_inflight_steps: Optional[int] = Field(
+        default=None,
+        description=(
+            "Hard ceiling on in-flight rollout samples, expressed as a multiple "
+            "of one global training batch.  When the number of pending samples "
+            "reaches max_inflight_steps * n_policy_replicas * train_batch_per_replica, "
+            "all new prompt requests are rejected until the policy catches up.  "
+            "Auto-clamped to >= allowed_outdated_steps + 1 so the standard soft "
+            "throttle fires first.  For DAPO, the soft throttle threshold is "
+            "higher (scaled by max_retry_for_on_policy), so set this value "
+            "above that threshold if you want soft-before-hard ordering.  "
+            "None disables the hard throttle."
+        ),
+    )
+
     min_filter_prefix_tokens: Optional[int] = Field(
         default=None,
         description="Minimum number of tokens to filter the prefix tokens for the rollouts inside the same group. "
@@ -682,6 +697,14 @@ class GrpoConfig(BaseModel):
                 logger.warning(
                     "DAPO is enabled, so outdated_rollout_fetch_batch_size is set to 128 as a large value."
                 )
+        if self.max_inflight_steps is not None:
+            min_allowed = self.allowed_outdated_steps + 1
+            if self.max_inflight_steps < min_allowed:
+                logger.warning(
+                    f"max_inflight_steps ({self.max_inflight_steps}) is below "
+                    f"allowed_outdated_steps + 1 ({min_allowed}); raising to {min_allowed}."
+                )
+                self.max_inflight_steps = min_allowed
         if self.uncentralized_training and self.variant != "grpo":
             raise ValueError(
                 "Uncentralized training is only suitable for GRPO, but the current variant is {}. Please make sure this is intended.".format(
@@ -1862,6 +1885,18 @@ class Config(BaseModel):
             logger.warning(
                 f"allowed_outdated_steps is less than sync_weight_interval - 1, setting allowed_outdated_steps to {self.train.sync_weight_interval - 1}."
             )
+            # Re-clamp max_inflight_steps against the (now-raised) allowed_outdated_steps
+            # so the hard throttle never fires before the soft throttle.
+            tp = self.train.train_policy
+            if tp.max_inflight_steps is not None:
+                min_allowed = tp.allowed_outdated_steps + 1
+                if tp.max_inflight_steps < min_allowed:
+                    logger.warning(
+                        f"max_inflight_steps ({tp.max_inflight_steps}) is below "
+                        f"allowed_outdated_steps + 1 ({min_allowed}) after "
+                        f"sync_weight_interval adjustment; raising to {min_allowed}."
+                    )
+                    tp.max_inflight_steps = min_allowed
 
         # Handle for evaludation configuration.
         if isinstance(self.validation.dataset.split, str):


### PR DESCRIPTION
Two correctness fixes for multi-replica RL training stability:

Shutdown race tolerance: Short-circuit get_batched_prompt when len(policy_status_manager) == 0. When policy replicas unregister during teardown, global_batch_size becomes 0, causing ZeroDivisionError and AssertionError crashes. The guard returns ([], True) to signal end-of-training.

Hard prompt throttle: Return empty prompt list immediately when pending rollouts exceed the hard capacity threshold (max_inflight_steps * rollouts_per_global_batch). This prevents OOM on rollout workers in async RL mode. The existing soft throttle (which reduces batch size to outdated_rollout_fetch_batch_size) still applies at a lower threshold. max_inflight_steps is configurable (default: None = disabled) and auto-clamped to >= allowed_outdated_steps + 1, including after sync_weight_interval adjustment.

Made-with: Cursor