### PR TITLE
feat: NCCL payload transfer support (Redis injection and cleanup)

### DIFF
--- a/cosmos_rl/comm/base.py
+++ b/cosmos_rl/comm/base.py
@@ -43,6 +43,11 @@ import multiprocessing as mp
 from cosmos_rl.dispatcher.api.client import APIClient
 from cosmos_rl.colocated.api_client import ColocatedAPIClient
 
+try:
+    import redis as _redis_lib
+except ImportError:
+    _redis_lib = None
+
 
 class CommMixin:
     policy_command_handler_registry = PolicyCommandRegistry()
@@ -170,6 +175,76 @@ class CommMixin:
                 )
 
         util.call_setup(self.val_data_packer, self.config)
+
+        self._inject_redis_into_data_packers()
+
+    def _inject_redis_into_data_packers(self):
+        """Inject the worker's Redis connection into data packers that need one.
+
+        Some data packers expose a ``redis_client`` attribute to receive a
+        shared Redis connection from the worker.  Cosmos-RL calls ``setup()``
+        on the packer *before* ``init_data_packer()``, so any packer feature
+        that depends on Redis would be left disabled after the first setup
+        attempt.  This method provides the live connection and invokes the
+        packer's ``post_redis_injection()`` hook (if present) so the packer
+        can complete any deferred setup.
+
+        No-op for packers without a ``redis_client`` attribute.
+        """
+        self._try_inject_redis(self.data_packer, "data_packer")
+        if (
+            hasattr(self, "val_data_packer")
+            and self.val_data_packer is not self.data_packer
+        ):
+            self._try_inject_redis(self.val_data_packer, "val_data_packer")
+
+    def _try_inject_redis(self, packer, packer_name: str):
+        """Inject Redis client into a single data packer."""
+        if not hasattr(packer, "redis_client"):
+            return
+        if _redis_lib is None:
+            logger.warning(
+                f"[{self.role}] redis package not installed; "
+                f"cannot inject Redis into {packer_name}"
+            )
+            return
+        redis_host, redis_port, redis_db = self._read_redis_endpoint()
+        try:
+            packer.redis_client = _redis_lib.Redis(
+                host=redis_host,
+                port=redis_port,
+                db=redis_db,
+                decode_responses=True,
+            )
+            packer.redis_client.ping()
+            logger.info(
+                f"[{self.role}] Injected Redis client into {packer_name} "
+                f"(host={redis_host}, port={redis_port}, db={redis_db})"
+            )
+            if hasattr(packer, "post_redis_injection"):
+                packer.post_redis_injection()
+        except Exception as e:
+            logger.warning(
+                f"[{self.role}] Failed to inject Redis client into {packer_name}: {e}"
+            )
+
+    def _read_redis_endpoint(self) -> tuple:
+        """Return ``(host, port, db)`` from the worker's live Redis client."""
+        redis_host = "localhost"
+        redis_port = 6379
+        redis_db = 0
+        redis_controller = getattr(self, "redis_controller", None)
+        if redis_controller is not None and hasattr(redis_controller, "redis_clients"):
+            clients = redis_controller.redis_clients
+            if clients:
+                conn_kwargs = clients[0].connection_pool.connection_kwargs
+                redis_host = conn_kwargs.get("host", redis_host)
+                redis_port = conn_kwargs.get("port", redis_port)
+                redis_db = conn_kwargs.get("db", redis_db)
+        config = getattr(self, "config", None)
+        if config is not None and hasattr(config, "redis") and config.redis:
+            redis_port = int(config.redis)
+        return redis_host, redis_port, redis_db
 
     def register_to_controller(self):
         if hasattr(self, "_is_registered"):

--- a/cosmos_rl/dispatcher/status.py
+++ b/cosmos_rl/dispatcher/status.py
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import json
+import os
 import time
 import math
 from queue import Queue
@@ -26,6 +28,13 @@ from cosmos_rl.dispatcher.replica import Replica, Atom, Rollout
 from cosmos_rl.dispatcher.protocol import Role
 import cosmos_rl.dispatcher.command as command
 from cosmos_rl.utils.redis_stream import RedisStreamHandler
+from cosmos_rl.utils.nccl_transfer_protocol import (
+    NCCL_COMPLETION_PREFIX,
+    build_cleanup_channel,
+    build_nccl_prefix,
+    build_rollout_prefix,
+    build_transfer_rollout_candidates,
+)
 from cosmos_rl.utils.report.wandb_logger import (
     is_wandb_available,
     log_wandb,
@@ -121,6 +130,10 @@ class PolicyStatusManager:
         self.train_report_data = RollingDict(maxlen=20)
 
         self.replica_scaling_log = []
+
+        # NCCL payload transfer cleanup: disabled by default, auto-enabled
+        # when the first nccl:-prefixed rollout is seen.
+        self._nccl_cleanup_enabled = False
 
         # Validation related
         self.val_report_data: Dict[int, List[Any]] = {}
@@ -799,6 +812,11 @@ class PolicyStatusManager:
     def filter_outdated_rollouts(self, rollouts: List[Rollout]) -> List[Rollout]:
         """
         Filter out the outdated rollouts based on the current step.
+
+        When NCCL payload transfer is active, discarded rollouts may hold
+        GPU buffers on the rollout worker.  This method publishes explicit
+        cleanup messages so the rollout worker releases them immediately
+        instead of waiting for age-based cleanup.
         """
         filtered_rollouts = []
         for idx, rollout in enumerate(rollouts):
@@ -829,7 +847,105 @@ class PolicyStatusManager:
         self.filter_records[k] = (
             self.filter_records.get(k, 0) + len(rollouts) - len(filtered_rollouts)
         )
+
+        discarded_count = len(rollouts) - len(filtered_rollouts)
+        if discarded_count > 0 and getattr(self, "_nccl_cleanup_enabled", False):
+            self._publish_nccl_cleanup_for_discarded(rollouts, filtered_rollouts)
+
         return filtered_rollouts
+
+    def _publish_nccl_cleanup_for_discarded(
+        self,
+        rollouts: List[Rollout],
+        filtered: List[Rollout],
+    ) -> None:
+        """Publish Redis cleanup for discarded NCCL-bearing rollouts.
+
+        When NCCL payload transfer is enabled, rollout completions are
+        prefixed with ``nccl:``.  If such rollouts are discarded as outdated,
+        the rollout worker still holds GPU buffers for the pending NCCL send.
+        Publishing a cleanup message lets the worker release them immediately.
+
+        This is a no-op when no discarded rollouts use NCCL transfer.
+        """
+        kept_ids = {id(r) for r in filtered}
+        nccl_transfer_ids: list[str] = []
+        for rollout in rollouts:
+            if id(rollout) in kept_ids:
+                continue
+            completion = getattr(rollout, "completion", None)
+            if isinstance(completion, str) and completion.startswith(
+                NCCL_COMPLETION_PREFIX
+            ):
+                nccl_transfer_ids.append(completion[len(NCCL_COMPLETION_PREFIX) :])
+
+        if not nccl_transfer_ids:
+            return
+
+        if not self._nccl_cleanup_enabled:
+            self._nccl_cleanup_enabled = True
+            logger.info(
+                "[Controller] Detected nccl:-prefixed rollouts; "
+                "NCCL cleanup publishing is now active."
+            )
+
+        redis_handler = getattr(self, "redis_handler", None)
+        if redis_handler is None:
+            return
+        redis_client = None
+        if hasattr(redis_handler, "redis_clients") and redis_handler.redis_clients:
+            redis_client = redis_handler.redis_clients[0]
+        elif hasattr(redis_handler, "redis_client"):
+            redis_client = redis_handler.redis_client
+        if redis_client is None:
+            return
+
+        experiment_name = "default"
+        try:
+            experiment_name = self.config.logging.experiment_name
+        except AttributeError:
+            pass
+        job_id = os.environ.get("SLURM_JOB_ID", "test")
+        prefix = build_nccl_prefix(experiment_name=experiment_name, job_id=job_id)
+
+        num_rollout_replicas = None
+        try:
+            num_rollout_replicas = self.config.rollout.parallelism.n_init_replicas
+        except AttributeError:
+            pass
+
+        published = 0
+        max_retries = 3
+        for transfer_id in nccl_transfer_ids:
+            try:
+                rollout_indices = build_transfer_rollout_candidates(
+                    transfer_id=transfer_id,
+                    num_rollout_replicas=num_rollout_replicas,
+                )
+                for rollout_idx in rollout_indices:
+                    channel = build_cleanup_channel(
+                        build_rollout_prefix(prefix, rollout_idx)
+                    )
+                    payload = json.dumps({"transfer_id": transfer_id})
+                    for attempt in range(max_retries):
+                        try:
+                            redis_client.publish(channel, payload)
+                            break
+                        except Exception:
+                            if attempt == max_retries - 1:
+                                raise
+                            time.sleep(0.1 * (attempt + 1))
+                published += 1
+            except Exception as e:
+                logger.debug(
+                    f"[Controller] Failed to publish NCCL cleanup for "
+                    f"transfer {transfer_id[:32]}: {e}"
+                )
+        if published > 0:
+            logger.debug(
+                f"[Controller] Published NCCL cleanup for {published}/"
+                f"{len(nccl_transfer_ids)} discarded transfers"
+            )
 
     def sft_report_summary(
         self,

--- a/cosmos_rl/utils/nccl_transfer_protocol.py
+++ b/cosmos_rl/utils/nccl_transfer_protocol.py
@@ -1,0 +1,130 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Redis channel naming protocol for NCCL-based payload transfer.
+
+Background
+----------
+By default, Cosmos-RL transfers rollout completion payloads (token IDs,
+log-probs, etc.) from rollout workers to the controller via Redis streams.
+For workloads with large payloads — such as VLA policies that produce
+high-dimensional action tensors — the Redis path becomes a bottleneck.
+
+**NCCL payload transfer** is an opt-in alternative where the payload
+tensors are sent directly between GPUs using NCCL point-to-point
+operations.  Redis is still used as the *control plane*: rollout workers
+publish transfer requests, the controller acknowledges them, and cleanup
+messages are sent when stale transfers are discarded.
+
+How it works
+------------
+1. A data packer that supports NCCL transfer (e.g. ``TensorDataPacker``)
+   exposes a ``redis_client`` attribute.  ``CommMixin.init_data_packer``
+   injects the worker's live Redis connection into the packer after
+   creation.  The packer then calls ``post_redis_injection()`` to
+   complete any deferred setup (e.g. establishing NCCL communicators).
+
+2. Rollout completions transferred via NCCL have their ``completion``
+   field prefixed with ``nccl:`` followed by a transfer ID.
+
+3. When the controller discards outdated rollouts
+   (``PolicyStatusManager.filter_outdated_rollouts``), it publishes
+   cleanup messages for any ``nccl:``-prefixed completions so the
+   rollout worker can release the associated GPU buffers immediately.
+
+Enabling
+--------
+Set ``[custom].nccl_payload_transfer = true`` in the experiment config.
+The data packer must support this feature (see ``BaseDataPacker`` docs).
+
+Redis key convention
+--------------------
+All keys are scoped by ``{namespace}:{experiment_name}:{slurm_job_id}``
+so multiple jobs sharing a Redis instance do not collide.
+"""
+
+from __future__ import annotations
+
+import numbers
+from typing import Any, Optional
+
+NCCL_REDIS_NAMESPACE = "cosmos_rl"
+
+NCCL_COMPLETION_PREFIX = "nccl:"
+
+
+def build_nccl_prefix(*, experiment_name: str, job_id: str) -> str:
+    """Root prefix for all NCCL transfer Redis keys."""
+    return f"{NCCL_REDIS_NAMESPACE}:{experiment_name}:{job_id}"
+
+
+def build_rollout_prefix(prefix: str, rollout_idx: int) -> str:
+    """Per-rollout-replica prefix."""
+    return f"{prefix}:rollout_comm:{rollout_idx}"
+
+
+def build_cleanup_channel(prefix: str) -> str:
+    """Pub/sub channel for cleanup messages."""
+    return f"{prefix}:nccl_cleanup"
+
+
+def build_request_channel(prefix: str) -> str:
+    """Pub/sub channel for transfer requests."""
+    return f"{prefix}:nccl_req"
+
+
+def parse_transfer_rollout_idx(transfer_id: str) -> int:
+    """Extract the rollout index encoded in the transfer ID prefix."""
+    if ":" not in transfer_id:
+        return -1
+    prefix = transfer_id.split(":", maxsplit=1)[0]
+    try:
+        return int(prefix)
+    except ValueError:
+        return -1
+
+
+def build_transfer_rollout_candidates(
+    *,
+    transfer_id: str,
+    num_rollout_replicas: Optional[int] = None,
+) -> list[int]:
+    """Return the canonical rollout index encoded in ``transfer_id``, if valid."""
+    normalized = _coerce_nonnegative_int(num_rollout_replicas)
+    parsed_prefix = parse_transfer_rollout_idx(transfer_id)
+    if parsed_prefix < 0:
+        return []
+    if normalized is not None and parsed_prefix >= normalized:
+        return []
+    return [parsed_prefix]
+
+
+def _coerce_nonnegative_int(value: Any) -> Optional[int]:
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, numbers.Integral):
+        coerced = int(value)
+    elif isinstance(value, str):
+        try:
+            coerced = int(value)
+        except ValueError:
+            return None
+    else:
+        return None
+    if coerced < 0:
+        return None
+    return coerced


### PR DESCRIPTION
Add infrastructure for NCCL-based payload transfer, an opt-in alternative to Redis streams for workloads with large payloads (e.g. VLA action tensors).

1. New module `cosmos_rl/utils/nccl_transfer_protocol.py`: Redis key naming convention for NCCL transfer coordination, with documentation explaining the feature's architecture and how to enable it.

2. `CommMixin.init_data_packer` (`comm/base.py`): after creating data packers, inject the worker's Redis connection into any packer that exposes a `redis_client` attribute, then call the packer's `post_redis_injection()` hook for deferred setup. No-op for standard data packers.

3. `PolicyStatusManager.filter_outdated_rollouts` (`status.py`): when discarding outdated rollouts whose completion is prefixed with "nccl:", publish Redis cleanup messages so rollout workers release GPU buffers immediately. No-op when no NCCL transfers are involved.

All changes are backward-compatible and no-op when NCCL payload transfer is not in use.
