### PR TITLE
feat: async R2R weight sync with WeightSyncThread and buffer model

### DIFF
--- a/cosmos_rl/policy/config/__init__.py
+++ b/cosmos_rl/policy/config/__init__.py
@@ -1485,6 +1485,26 @@ class RolloutConfig(BaseModel):
         description="Configuration for async rollout.",
     )
 
+    async_r2r_sync: Literal["disabled", "generation", "inference"] = Field(
+        default="disabled",
+        description=(
+            "Async R2R weight sync mode.  'disabled' runs R2R synchronously on the "
+            "inference stream.  'generation' runs R2R on a background thread and syncs "
+            "the buffer to the live model before each rollout_generation() call.  "
+            "'inference' additionally syncs before each policy forward pass."
+        ),
+    )
+
+    broadcast_all_params: bool = Field(
+        default=False,
+        description=(
+            "When true, R2R broadcasts the full model state_dict (trainable + "
+            "non-trainable) instead of only the trainable subset.  Needed for "
+            "models with frozen components (e.g. vision encoders) that must be "
+            "synced across rollout replicas."
+        ),
+    )
+
     @model_validator(mode="after")
     def check_params_value(self):
         if isinstance(self.parallelism, dict):

--- a/cosmos_rl/rollout/worker/rollout_control.py
+++ b/cosmos_rl/rollout/worker/rollout_control.py
@@ -74,6 +74,15 @@ from cosmos_rl.rollout.schema import RolloutResult
 from cosmos_rl.reward.dispatcher import RewardDispatcher
 from cosmos_rl.dispatcher.data.data_fetcher import WorkerDataFetcher
 from cosmos_rl.collective.collective import P2RCollectiveManager
+from cosmos_rl.rollout.worker.weight_sync import (
+    AsyncR2RSyncMode,
+    get_async_r2r_sync_mode,
+    get_broadcast_all_params,
+    ensure_wst,
+    sync_buffer_to_live,
+    do_nccl_broadcast_grouped,
+    install_inference_sync,
+)
 
 """
 Keep in mind that torch distributed is not thread safe. So try to keep the usage in the same thread.
@@ -852,7 +861,7 @@ class DisaggregatedRolloutControlWorker(RolloutWorkerBase):
                     payloads_list: List[RLPayload] = validation_queue.get()
 
                     rollout_results: List[RolloutResult] = (
-                        self.rollout.rollout_generation(
+                        self._call_rollout_generation(
                             payloads=payloads_list,
                             stream=self.inference_stream,
                             data_packer=self.val_data_packer,
@@ -958,7 +967,8 @@ class DisaggregatedRolloutControlWorker(RolloutWorkerBase):
 
     def lazy_initialize_rollout_engine(self, load_format):
         # lazy initialization of the rollout engine.
-        if not self.rollout.is_engine_initialized():
+        already_initialized = self.rollout.is_engine_initialized()
+        if not already_initialized:
             if self._is_async_rollout:
                 # wait the scheduler thread to initialize the rollout engine.
                 self._start_async_rollout_scheduler(load_format)
@@ -975,13 +985,26 @@ class DisaggregatedRolloutControlWorker(RolloutWorkerBase):
                 )
             self.prepare_shard_infos_for_weight_sync_insts()
 
+            async_mode = get_async_r2r_sync_mode(self)
+            if async_mode != AsyncR2RSyncMode.DISABLED:
+                logger.info(
+                    "[Rollout] Model loaded — creating buffer + WeightSyncThread "
+                    "(async_mode=%s).",
+                    async_mode.value,
+                )
+                ensure_wst(self)
+
     @RolloutWorkerBase.register_rollout_command_handler(PolicyToRolloutUnicastCommand)
     @torch.no_grad()
     def policy_to_rollout_unicast(self, command: PolicyToRolloutUnicastCommand):
-        """
-        Sync the weight from policy to rollout.
+        """Sync the weight from policy to rollout.
+
         This is Policy -> Rollout replica. Will only happen between
         a pair of policy and rollout replica.
+
+        When async R2R mode is enabled, P2R commands are routed to the
+        WeightSyncThread which calls ``_execute_p2r_recv`` on its own
+        CUDA stream.
         """
         # lazy initialization of the rollout engine.
         is_for_weight_resume = command.dst_replica_name == self.replica_name
@@ -991,6 +1014,29 @@ class DisaggregatedRolloutControlWorker(RolloutWorkerBase):
         if command.dst_replica_name != self.replica_name:
             return
 
+        async_mode = get_async_r2r_sync_mode(self)
+        if async_mode != AsyncR2RSyncMode.DISABLED:
+            wst = self._weight_sync_thread
+            wst.enqueue_p2r(command)
+            logger.info(
+                "[Rollout] Enqueued P2R to WeightSyncThread (step=%s).",
+                command.weight_step,
+            )
+            return
+
+        self._execute_p2r_recv(command, self.inference_stream)
+
+    def _execute_p2r_recv(
+        self,
+        command: PolicyToRolloutUnicastCommand,
+        stream: torch.cuda.Stream,
+    ):
+        """Execute the P2R NCCL receive on the given CUDA stream.
+
+        Separated from ``policy_to_rollout_unicast`` so the
+        WeightSyncThread can call this directly with its own stream,
+        without needing to swap ``inference_stream``.
+        """
         self.p2r_collective_manager.setup_manager(command)
 
         comm_id = None
@@ -1031,11 +1077,10 @@ class DisaggregatedRolloutControlWorker(RolloutWorkerBase):
             f"Mismatch in total params and received param keys: {total_params} != {len(self.recv_param_key_n_rank_list)}"
         )
 
-        with torch.cuda.stream(self.inference_stream):
+        with torch.cuda.stream(stream):
             logger.info(
                 f"[Rollout] Starting to execute {len(self.policy_to_rollout_recv_insts)}; {total_params}, {total_recvs} weight sync receives ..."
             )
-            # recv the weight from policy
             st = time.time()
             total_bytes_received = 0
 
@@ -1060,7 +1105,6 @@ class DisaggregatedRolloutControlWorker(RolloutWorkerBase):
                 self.rl_mode != "colocated_separated"
                 and constant.COSMOS_P2R_NCCL_GROUP_SIZE > 0
             ):
-                # Only in non-colocated-separated mode, we could use NCCL group feature.
                 nccl_group_start(comm_id)
 
             skipped_params_cnt = 0
@@ -1069,8 +1113,6 @@ class DisaggregatedRolloutControlWorker(RolloutWorkerBase):
             transferred_groups_cnt = 0
 
             for insts_group in self.policy_to_rollout_recv_insts:
-                # insts_group: WeightSyncInstructionsGroup -> inst collection for a full weight tensor
-                # handle inst group
                 (
                     bytes_received,
                     completion_fn,
@@ -1092,9 +1134,6 @@ class DisaggregatedRolloutControlWorker(RolloutWorkerBase):
                     )
                     != insts_group.param_instructions[0].param_name
                 ):
-                    # The params in the group of this case originally belong to the same param.
-                    # The following counts related with `groups` measure the original params before split.
-                    # The count related with `groups` match the count in R2R which is without split.
                     skipped_groups_cnt += 1 if skipped_cnt > 0 else 0
                     transferred_groups_cnt += 0 if skipped_cnt > 0 else 1
                 else:
@@ -1134,7 +1173,7 @@ class DisaggregatedRolloutControlWorker(RolloutWorkerBase):
                 copy_finished = torch.cuda.Event()
                 copy_finished.record()
 
-            self.inference_stream.wait_event(copy_finished)
+            stream.wait_event(copy_finished)
             self.temp_recv_tensor_queue.queue.clear()
 
             time_eclapsed = time.time() - st
@@ -1162,128 +1201,200 @@ class DisaggregatedRolloutControlWorker(RolloutWorkerBase):
     def broadcast_to_all_rollout_replica(
         self, broadcast_command: RolloutToRolloutBroadcastCommand
     ) -> None:
-        """
-        Broadcast the weight to all other rollout replicas.
-        Will only happen between Rollout Replica 0 and all other Rollout Replicas.
+        """Broadcast the weight to all other rollout replicas.
+
+        Will only happen between Rollout Replica 0 and all other Rollout
+        Replicas.
+
+        When ``async_r2r_sync`` is enabled the broadcast is enqueued to
+        the WeightSyncThread which executes it on a dedicated CUDA stream
+        with a Redis barrier.  When ``broadcast_all_params`` is enabled
+        (or in async mode), the full state_dict is broadcast rather than
+        only the trainable subset selected by ``model_param_map``.
         """
         src_replica_name: str = broadcast_command.src_replica_name
         dst_replica_names: List[str] = broadcast_command.dst_replica_names
+
+        # Forward-compat: flush any pending async NCCL sends (e.g. from data
+        # packers) so they complete before weight sync reuses the communicator.
+        if hasattr(self, "data_packer") and hasattr(
+            self.data_packer, "flush_pending_sends"
+        ):
+            self.data_packer.flush_pending_sends()
 
         # lazy initialization of the rollout engine.
         if self.replica_name != src_replica_name:
             # for replicas that needs to be broadcasted, use dummy format.
             self.lazy_initialize_rollout_engine(load_format="dummy")
 
-        if len(dst_replica_names) > 1:
-            self.prepare_trainable_params()
-            skipped_params_cnt = 0
-            transferred_params_cnt = 0
+        was_synced = self.state.weight_synced()
+        trainable_only = broadcast_command.trainable_only
+        if not was_synced and trainable_only:
             logger.info(
-                "[Rollout] Starting broadcasting of parameters to all replicas."
+                "[Rollout] First broadcast has trainable_only=True "
+                "(race: rollout leader was faster). Forcing full broadcast."
             )
-            # Only do broadcast if there are more than one rollout replicas.
-            with torch.cuda.stream(self.inference_stream):
-                assert self.rank_in_rollout_repicas >= 0, (
-                    "[Rollout] rank in rollout replicas should be set before broadcast."
-                )
-                assert len(dst_replica_names) == len(self.replica_name_to_rank), (
-                    "[Rollout] The vaild dst replicas num should match the replicas num that this worker holds."
-                )
+            trainable_only = False
 
-                src_rank = self.replica_name_to_rank[src_replica_name]
-                with torch.inference_mode():
-                    for name, parameter in self.rollout.model_param_map(
-                        self.weight_mapper
-                    ).items():
-                        if (
-                            name not in self.trainable_params
-                            and broadcast_command.trainable_only
-                        ):
-                            logger.debug(
-                                f"[Rollout] Skip {name} in R2R due to non trainable."
+        async_mode = get_async_r2r_sync_mode(self)
+        broadcast_all = get_broadcast_all_params(self)
+
+        if len(dst_replica_names) > 1:
+            if async_mode != AsyncR2RSyncMode.DISABLED:
+                # Enqueue to the WeightSyncThread.
+                wst = self._weight_sync_thread
+                wst.enqueue_r2r(broadcast_command)
+                logger.info(
+                    "[Rollout] Enqueued R2R to WeightSyncThread (mode=%s, step=%s).",
+                    async_mode.value,
+                    broadcast_command.weight_step,
+                )
+            elif broadcast_all:
+                # Synchronous full-model broadcast via grouped NCCL.
+                logger.info(
+                    "[Rollout] Starting full-model broadcast (broadcast_all_params=true)."
+                )
+                t0 = time.time()
+                transferred_params_cnt, bytes_broadcast = do_nccl_broadcast_grouped(
+                    self,
+                    src_replica_name,
+                    self.inference_stream,
+                )
+                self.inference_stream.synchronize()
+                elapsed = time.time() - t0
+                logger.info(
+                    "[Rollout] Finished full-model broadcast: %d params, "
+                    "%.1f MB, %.3f s",
+                    transferred_params_cnt,
+                    bytes_broadcast / (1024 * 1024),
+                    elapsed,
+                )
+                if not self.state.weight_synced():
+                    self.state.set_weight_synced()
+                if not trainable_only:
+                    self.non_trainable_params_received = True
+            else:
+                # Original synchronous per-param broadcast path.
+                self.prepare_trainable_params()
+                skipped_params_cnt = 0
+                transferred_params_cnt = 0
+                logger.info(
+                    "[Rollout] Starting broadcasting of parameters to all replicas."
+                )
+                with torch.cuda.stream(self.inference_stream):
+                    assert self.rank_in_rollout_repicas >= 0, (
+                        "[Rollout] rank in rollout replicas should be set before broadcast."
+                    )
+                    assert len(dst_replica_names) == len(self.replica_name_to_rank), (
+                        "[Rollout] The vaild dst replicas num should match the replicas num that this worker holds."
+                    )
+
+                    src_rank = self.replica_name_to_rank[src_replica_name]
+                    with torch.inference_mode():
+                        for name, parameter in self.rollout.model_param_map(
+                            self.weight_mapper
+                        ).items():
+                            if name not in self.trainable_params and trainable_only:
+                                logger.debug(
+                                    f"[Rollout] Skip {name} in R2R due to non trainable."
+                                )
+                                skipped_params_cnt += 1
+                                continue
+                            transferred_params_cnt += 1
+
+                            recv_tensor = parameter
+                            if not parameter.is_contiguous():
+                                recv_tensor = parameter.contiguous()
+
+                            nccl_broadcast(
+                                recv_tensor, src_rank, self.global_commnicator_idex
                             )
-                            skipped_params_cnt += 1
-                            continue
-                        transferred_params_cnt += 1
 
-                        recv_tensor = parameter
-                        if not parameter.is_contiguous():
-                            recv_tensor = parameter.contiguous()
+                            if not parameter.is_contiguous():
+                                parameter.copy_(recv_tensor)
 
-                        nccl_broadcast(
-                            recv_tensor, src_rank, self.global_commnicator_idex
+                    if not self.state.weight_synced():
+                        assert not trainable_only, (
+                            "[Rollout] Trainable only must be set to False for the first broadcast."
+                        )
+                        self.state.set_weight_synced()
+
+                logger.info(
+                    f"[Rollout] Finished broadcasting of parameters to all replicas. While {skipped_params_cnt} unsplitted non-trainable params skipped and {transferred_params_cnt} unsplitted params transferred."
+                )
+                if not trainable_only:
+                    self.non_trainable_params_received = True
+
+                if trainable_only:
+                    assert self.non_trainable_params_received, (
+                        "[Rollout] Non-trainable params must be received before trainable-only R2R."
+                    )
+                    if not hasattr(self, "r2r_synced_trainable_params_cnt"):
+                        self.r2r_synced_trainable_params_cnt = transferred_params_cnt
+                    if hasattr(self, "p2r_synced_trainable_params_cnt"):
+                        assert (
+                            self.r2r_synced_trainable_params_cnt
+                            == self.p2r_synced_trainable_params_cnt
+                            + len(self.misc_params)
+                        ), (
+                            f"Synced params count in R2R {self.r2r_synced_trainable_params_cnt} must match the sum of count of attribute {self.p2r_synced_trainable_params_cnt} and {len(self.misc_params)}."
                         )
 
-                        if not parameter.is_contiguous():
-                            parameter.copy_(recv_tensor)
-
-                if not self.state.weight_synced():
-                    assert not broadcast_command.trainable_only, (
-                        "[Rollout] Trainable only must be set to False for the first broadcast."
-                    )
-                    self.state.set_weight_synced()
-
-            logger.info(
-                f"[Rollout] Finished broadcasting of parameters to all replicas. While {skipped_params_cnt} unsplitted non-trainable params skipped and {transferred_params_cnt} unsplitted params transferred."
-            )
-            if not broadcast_command.trainable_only:
-                self.non_trainable_params_received = True
-
-            if broadcast_command.trainable_only:
-                assert self.non_trainable_params_received, (
-                    "[Rollout] Non-trainable params must be received before trainable-only R2R."
-                )
-                if not hasattr(self, "r2r_synced_trainable_params_cnt"):
-                    self.r2r_synced_trainable_params_cnt = transferred_params_cnt
-                if hasattr(self, "p2r_synced_trainable_params_cnt"):
-                    # check in R2R sender side.
-                    assert (
-                        self.r2r_synced_trainable_params_cnt
-                        == self.p2r_synced_trainable_params_cnt + len(self.misc_params)
-                    ), (
-                        f"Synced params count in R2R {self.r2r_synced_trainable_params_cnt} must match the sum of count of attribute {self.p2r_synced_trainable_params_cnt} and {len(self.misc_params)}."
-                    )
+        # --- Post-broadcast bookkeeping (weight version, validation, shutdown) ---
 
         current_step = broadcast_command.weight_step
-        if current_step is not None:
-            assert current_step >= self.current_weight_version, (
-                f"current_step: {current_step} must be greater than or equal to self.current_weight_version: {self.current_weight_version}"
-            )
-            self.current_weight_version = current_step
-        else:
-            current_step = self.current_weight_version
 
-        if current_step is not None and current_step >= 0:
-            is_initial_validation = (
-                current_step == 0 and self.config.validation.val_before_train
-            )
-            is_periodic_validation = (
-                current_step > 0 and current_step % self.config.validation.freq == 0
-            )
-            is_final_validation = current_step == broadcast_command.total_steps
+        # When async mode is enabled, the NCCL broadcast hasn't happened yet
+        # (it's queued on the WST).  The WST's _execute_r2r will update
+        # current_weight_version after the broadcast completes.
+        if async_mode == AsyncR2RSyncMode.DISABLED:
+            if current_step is not None:
+                assert current_step >= self.current_weight_version, (
+                    f"current_step: {current_step} must be greater than or equal to self.current_weight_version: {self.current_weight_version}"
+                )
+                self.current_weight_version = current_step
+            else:
+                current_step = self.current_weight_version
 
-            should_do_validation = self.config.validation.enable and (
-                is_initial_validation or is_periodic_validation or is_final_validation
+            if current_step is not None and current_step >= 0:
+                is_initial_validation = (
+                    current_step == 0 and self.config.validation.val_before_train
+                )
+                is_periodic_validation = (
+                    current_step > 0 and current_step % self.config.validation.freq == 0
+                )
+                is_final_validation = current_step == broadcast_command.total_steps
+
+                should_do_validation = self.config.validation.enable and (
+                    is_initial_validation
+                    or is_periodic_validation
+                    or is_final_validation
+                )
+
+                if should_do_validation:
+                    self.current_step = current_step
+                    self.validation_flag.set()
+
+            if broadcast_command.replica_should_stop():
+                data = {
+                    "is_end": True,
+                    "prompt_idx": -1,
+                    "completion_token_ids": [],
+                }
+                self.redis_controller.publish_teacher_request(data, self.replica_name)
+                logger.info("[Rollout] Published end event to reference")
+                if self.validation_flag.is_set():
+                    self.do_validation()
+                self.shutdown_signal.set()
+                self.shutdown_mp_signal.set()
+
+        if not self.state.weight_synced():
+            logger.info(
+                "[Rollout] Setting weight_synced after broadcast (n_dst=%d, step=%s)",
+                len(dst_replica_names),
+                current_step,
             )
-
-            if should_do_validation:
-                self.current_step = current_step
-                # Setting the flag, do validation in the main loop.
-                self.validation_flag.set()
-
-        if broadcast_command.replica_should_stop():
-            data = {
-                "is_end": True,
-                "prompt_idx": -1,
-                "completion_token_ids": [],
-            }
-            self.redis_controller.publish_teacher_request(data, self.replica_name)
-            logger.info("[Rollout] Published end event to reference")
-            # Do validation if the flag is set before stopping.
-            if self.validation_flag.is_set():
-                self.do_validation()
-            self.shutdown_signal.set()
-            self.shutdown_mp_signal.set()
+            self.state.set_weight_synced()
 
     def query_command_from_controller(self):
         """Background task to check commands from the controller"""
@@ -1445,6 +1556,7 @@ class DisaggregatedRolloutControlWorker(RolloutWorkerBase):
     ):
         # Consume all pending commands for weight sync.
         # To ensure the weight update is using the up-to-date commands.
+        async_mode = get_async_r2r_sync_mode(self)
         last_cmd = None
         none_cnt = 0
         start_time = time.time()
@@ -1459,13 +1571,19 @@ class DisaggregatedRolloutControlWorker(RolloutWorkerBase):
             if none_cnt >= constant.COSMOS_ROLLOUT_CMD_WAIT_TIMES and (
                 (
                     last_cmd is not None
-                    and not isinstance(last_cmd, PolicyToRolloutUnicastCommand)
+                    and (
+                        not isinstance(last_cmd, PolicyToRolloutUnicastCommand)
+                        or async_mode != AsyncR2RSyncMode.DISABLED
+                    )
                 )
                 or last_cmd is None
             ):
-                # If continuously get None for COSMOS_ROLLOUT_CMD_WAIT_TIMES times, and the last command is not P2R command, we break.
-                # Since P2R must be followed by another R2R broadcast command, we need wait.
-                # Continuously get None for COSMOS_ROLLOUT_CMD_WAIT_TIMES times to make sure the command queue is empty at that time.
+                # If continuously get None for COSMOS_ROLLOUT_CMD_WAIT_TIMES
+                # times, and the last command is not P2R command, we break.
+                # In synchronous mode P2R must be followed by an R2R broadcast
+                # command on the main thread, so we keep waiting.  In async
+                # mode the R2R is handled by the WeightSyncThread, so there
+                # is no need to block the main thread.
                 break
             time.sleep(constant.COSMOS_ROLLOUT_CMD_WAIT_INTERVAL)
 
@@ -1553,15 +1671,44 @@ class DisaggregatedRolloutControlWorker(RolloutWorkerBase):
                 break
         return payloads, is_validation, step, empty
 
+    def _call_rollout_generation(self, **kwargs) -> list:
+        """Call ``rollout_generation`` with pre-generation buffer sync.
+
+        All call sites should use this instead of calling
+        ``self.rollout.rollout_generation`` directly so that async weight
+        sync and weight-version injection happen consistently.
+        """
+        async_mode = get_async_r2r_sync_mode(self)
+        if async_mode != AsyncR2RSyncMode.DISABLED:
+            if async_mode == AsyncR2RSyncMode.INFERENCE and not getattr(
+                self, "_inference_sync_installed", False
+            ):
+                install_inference_sync(self)
+                self._inference_sync_installed = True
+            sync_buffer_to_live(self)
+
+        kwargs["current_weight_version"] = self.current_weight_version
+        return self.rollout.rollout_generation(**kwargs)
+
     @torch.no_grad()
     def main_loop(self):
+        async_mode = get_async_r2r_sync_mode(self)
+        logger.info("[Rollout] main_loop async_r2r_sync mode: %s", async_mode.value)
+
+        try:
+            self._main_loop_impl()
+        finally:
+            wst = getattr(self, "_weight_sync_thread", None)
+            if wst is not None:
+                wst.stop()
+
+    def _main_loop_impl(self):
+        """Core main loop extracted for clean WST lifecycle management."""
         while not self.shutdown_signal.is_set():
             self.consume_command(cmd_pred=None)
             if self.validation_flag.is_set():
-                # If encounter validation flag during last rollout generation or this command fetch, do validation first.
                 self.do_validation()
 
-            # If weight is not ready, nothing else to do.
             if not self.state.weight_synced():
                 continue
 
@@ -1571,11 +1718,9 @@ class DisaggregatedRolloutControlWorker(RolloutWorkerBase):
             )
 
             if self._is_async_rollout:
-                # In this mode, we perform the stream generation step in the main loop.
                 self.stream_generation_step()
                 continue
 
-            # try fetching new prompts if no ending signal is set
             if not self.state.prompt_fetch_end():
                 no_more_prompts = self.request_new_prompts(
                     self.batch_size,
@@ -1587,7 +1732,6 @@ class DisaggregatedRolloutControlWorker(RolloutWorkerBase):
                         f"[Rollout] Receive prompt end, wait for {self.replica_name} to finish all rollouts generation"
                     )
                     self.state.set_prompt_fetch_end()
-                    # Further make sure to set `prompt_consume_end` if no more prompts to be consumed
                     if self._prompt_queue.empty():
                         self.state.set_prompt_consume_end()
                         if self.global_rank == 0:
@@ -1603,7 +1747,6 @@ class DisaggregatedRolloutControlWorker(RolloutWorkerBase):
             else:
                 logger.debug(f"[Rollout] generate start for rank {self.global_rank}")
 
-                # Check if the prompt is valid for the current weight version
                 first_payload: RLPayload = self._prompt_queue.queue[0][0]
                 is_valid_prompt_for_current_weight_version = (
                     first_payload.weight_version
@@ -1612,7 +1755,6 @@ class DisaggregatedRolloutControlWorker(RolloutWorkerBase):
                 )
 
                 if not is_valid_prompt_for_current_weight_version:
-                    # Fully Synchronized mode is enabled, we need to wait until the weight version is updated
                     continue
 
                 self.one_step_generation()
@@ -1728,7 +1870,7 @@ class DisaggregatedRolloutControlWorker(RolloutWorkerBase):
         """
         payloads_list: List[RLPayload] = self._prompt_queue.get()
 
-        rollout_results: List[RolloutResult] = self.rollout.rollout_generation(
+        rollout_results: List[RolloutResult] = self._call_rollout_generation(
             payloads=payloads_list,
             stream=self.inference_stream,
             data_packer=self.data_packer,

--- a/cosmos_rl/rollout/worker/rollout_control.py
+++ b/cosmos_rl/rollout/worker/rollout_control.py
@@ -1397,7 +1397,14 @@ class DisaggregatedRolloutControlWorker(RolloutWorkerBase):
             self.state.set_weight_synced()
 
     def query_command_from_controller(self):
-        """Background task to check commands from the controller"""
+        """Background task to check commands from the controller.
+
+        When async R2R mode is active and the WeightSyncThread is ready,
+        P2R and R2R commands are routed directly to the WST instead of
+        going through ``_command_queue``.  This avoids the latency of
+        waiting for the main thread (which may be running a long
+        simulation) to drain the queue before weight-sync begins.
+        """
         while not self.shutdown_signal.is_set():
             commands = []
             try:
@@ -1411,6 +1418,28 @@ class DisaggregatedRolloutControlWorker(RolloutWorkerBase):
             for instruction in commands:
                 command = Command.depack(instruction)
                 logger.debug(f"[Rollout] Received command: {command.command_type}")
+
+                wst = getattr(self, "_weight_sync_thread", None)
+                if wst is not None and isinstance(
+                    command, PolicyToRolloutUnicastCommand
+                ):
+                    if command.dst_replica_name == self.replica_name:
+                        wst.enqueue_p2r(command)
+                    else:
+                        logger.debug(
+                            "[Rollout] Skipping P2R for other replica %s",
+                            command.dst_replica_name,
+                        )
+                    continue
+
+                if wst is not None and isinstance(
+                    command, RolloutToRolloutBroadcastCommand
+                ):
+                    wst.enqueue_r2r(command)
+                    if not self.state.weight_synced():
+                        self.state.set_weight_synced()
+                    continue
+
                 self._command_queue.put(command)
 
     def teacher_interact_loop(self):
@@ -1554,9 +1583,15 @@ class DisaggregatedRolloutControlWorker(RolloutWorkerBase):
         cmd_pred: Optional[Callable[[Command], bool]] = None,
         timeout=constant.COSMOS_ROLLOUT_CMD_WAIT_TIMEOUT,
     ):
-        # Consume all pending commands for weight sync.
-        # To ensure the weight update is using the up-to-date commands.
-        async_mode = get_async_r2r_sync_mode(self)
+        """Consume all pending commands from the command queue.
+
+        In async R2R mode, P2R/R2R commands are routed directly to the
+        WeightSyncThread by ``query_command_from_controller`` and never
+        appear in ``_command_queue``.  The "wait for R2R after P2R"
+        logic only applies when both command types flow through the
+        queue (synchronous mode).
+        """
+        async_wst_active = getattr(self, "_weight_sync_thread", None) is not None
         last_cmd = None
         none_cnt = 0
         start_time = time.time()
@@ -1569,21 +1604,13 @@ class DisaggregatedRolloutControlWorker(RolloutWorkerBase):
             else:
                 none_cnt += 1
             if none_cnt >= constant.COSMOS_ROLLOUT_CMD_WAIT_TIMES and (
-                (
+                async_wst_active
+                or (
                     last_cmd is not None
-                    and (
-                        not isinstance(last_cmd, PolicyToRolloutUnicastCommand)
-                        or async_mode != AsyncR2RSyncMode.DISABLED
-                    )
+                    and not isinstance(last_cmd, PolicyToRolloutUnicastCommand)
                 )
                 or last_cmd is None
             ):
-                # If continuously get None for COSMOS_ROLLOUT_CMD_WAIT_TIMES
-                # times, and the last command is not P2R command, we break.
-                # In synchronous mode P2R must be followed by an R2R broadcast
-                # command on the main thread, so we keep waiting.  In async
-                # mode the R2R is handled by the WeightSyncThread, so there
-                # is no need to block the main thread.
                 break
             time.sleep(constant.COSMOS_ROLLOUT_CMD_WAIT_INTERVAL)
 

--- a/cosmos_rl/rollout/worker/rollout_control.py
+++ b/cosmos_rl/rollout/worker/rollout_control.py
@@ -80,6 +80,7 @@ from cosmos_rl.rollout.worker.weight_sync import (
     get_broadcast_all_params,
     ensure_wst,
     sync_buffer_to_live,
+    process_wst_deferred_actions,
     do_nccl_broadcast_grouped,
     install_inference_sync,
 )
@@ -1388,7 +1389,10 @@ class DisaggregatedRolloutControlWorker(RolloutWorkerBase):
                 self.shutdown_signal.set()
                 self.shutdown_mp_signal.set()
 
-        if not self.state.weight_synced():
+        # In async mode the WST's _execute_r2r calls set_weight_synced
+        # after the broadcast actually completes.  Calling it here would
+        # be premature (the NCCL transfer is only enqueued, not done).
+        if async_mode == AsyncR2RSyncMode.DISABLED and not self.state.weight_synced():
             logger.info(
                 "[Rollout] Setting weight_synced after broadcast (n_dst=%d, step=%s)",
                 len(dst_replica_names),
@@ -1436,8 +1440,6 @@ class DisaggregatedRolloutControlWorker(RolloutWorkerBase):
                     command, RolloutToRolloutBroadcastCommand
                 ):
                     wst.enqueue_r2r(command)
-                    if not self.state.weight_synced():
-                        self.state.set_weight_synced()
                     continue
 
                 self._command_queue.put(command)
@@ -1722,6 +1724,15 @@ class DisaggregatedRolloutControlWorker(RolloutWorkerBase):
         async_mode = get_async_r2r_sync_mode(self)
         logger.info("[Rollout] main_loop async_r2r_sync mode: %s", async_mode.value)
 
+        assert not (
+            self._is_async_rollout and async_mode != AsyncR2RSyncMode.DISABLED
+        ), (
+            "async_r2r_sync is not supported with rollout.mode='async'. "
+            "async_r2r_sync targets the synchronous rollout path; the async "
+            "rollout scheduler (vllm_async) uses a separate generation path "
+            "that bypasses the buffer model."
+        )
+
         try:
             self._main_loop_impl()
         finally:
@@ -1731,8 +1742,15 @@ class DisaggregatedRolloutControlWorker(RolloutWorkerBase):
 
     def _main_loop_impl(self):
         """Core main loop extracted for clean WST lifecycle management."""
+        async_mode = get_async_r2r_sync_mode(self)
         while not self.shutdown_signal.is_set():
             self.consume_command(cmd_pred=None)
+
+            # Process deferred validation/shutdown from the WST on the
+            # main thread — never inside inference callbacks.
+            if async_mode != AsyncR2RSyncMode.DISABLED:
+                process_wst_deferred_actions(self)
+
             if self.validation_flag.is_set():
                 self.do_validation()
 

--- a/cosmos_rl/rollout/worker/weight_sync.py
+++ b/cosmos_rl/rollout/worker/weight_sync.py
@@ -178,6 +178,11 @@ def redirect_view_map_to_buffer(worker) -> None:
 def sync_buffer_to_live(worker) -> None:
     """Copy buffer params to live model if a new version is available.
 
+    This is a pure data-plane operation: it copies tensors from the
+    buffer model into the live model.  It does **not** trigger
+    validation or shutdown — those are handled by
+    ``process_wst_deferred_actions`` on the main thread.
+
     Non-blocking on CPU.  inference_stream.wait_event(last_event) ensures
     the GPU-side copy executes after the most recently completed write on
     the weight-sync stream.
@@ -228,6 +233,15 @@ def sync_buffer_to_live(worker) -> None:
         elapsed_ms,
     )
 
+
+def process_wst_deferred_actions(worker) -> None:
+    """Handle validation and shutdown flags set by the WeightSyncThread.
+
+    Must be called on the main thread only (never from inference
+    callbacks).  The WST sets lightweight flags when it completes a
+    broadcast that requires validation or shutdown; this function
+    reacts to those flags.
+    """
     if getattr(worker, "_pending_validation_step", None) is not None:
         worker._pending_validation_step = None
         if worker.validation_flag.is_set():
@@ -416,6 +430,17 @@ class WeightSyncThread:
 
         if command.replica_should_stop():
             worker._pending_shutdown = True
+
+        # Mark weight_synced only after the broadcast has completed,
+        # so the main loop does not start serving before weights are
+        # actually available in the buffer.
+        if not worker.state.weight_synced():
+            worker.state.set_weight_synced()
+            logger.info(
+                "[WeightSyncThread] set_weight_synced after first R2R broadcast "
+                "(step=%s)",
+                weight_step,
+            )
 
         elapsed_ms = (time.monotonic() - t0) * 1000
         logger.info(

--- a/cosmos_rl/rollout/worker/weight_sync.py
+++ b/cosmos_rl/rollout/worker/weight_sync.py
@@ -371,24 +371,38 @@ class WeightSyncThread:
         )
 
     def _execute_r2r(self, command) -> None:
-        """Redis barrier + grouped NCCL broadcast on buffer_model."""
+        """Redis barrier + grouped NCCL broadcast on buffer_model.
+
+        When commands are routed directly from the background command
+        thread (bypassing the main-thread handler), the WST is
+        responsible for bookkeeping that would normally be done in the
+        handler: ``flush_pending_sends``, ``set_weight_synced``.
+        """
+        worker = self._worker
+
+        # Flush any pending async NCCL sends before reusing the communicator.
+        if hasattr(worker, "data_packer") and hasattr(
+            worker.data_packer, "flush_pending_sends"
+        ):
+            worker.data_packer.flush_pending_sends()
+
         weight_step = command.weight_step
-        r2r_barrier(self._worker, weight_step)
+        r2r_barrier(worker, weight_step)
         t0 = time.monotonic()
         transferred_cnt, bytes_broadcast = do_nccl_broadcast_grouped(
-            self._worker,
+            worker,
             command.src_replica_name,
             self._stream,
         )
         self._last_event = torch.cuda.Event()
         self._last_event.record(self._stream)
-        self._worker._buffer_version += 1
+        worker._buffer_version += 1
 
         if weight_step is not None:
-            self._worker.current_weight_version = weight_step
+            worker.current_weight_version = weight_step
 
         if weight_step is not None and weight_step >= 0:
-            cfg = self._worker.config
+            cfg = worker.config
             is_initial = weight_step == 0 and cfg.validation.val_before_train
             is_periodic = weight_step > 0 and weight_step % cfg.validation.freq == 0
             is_final = weight_step == command.total_steps
@@ -396,12 +410,12 @@ class WeightSyncThread:
                 is_initial or is_periodic or is_final
             )
             if should_do_validation:
-                self._worker.current_step = weight_step
-                self._worker.validation_flag.set()
-                self._worker._pending_validation_step = weight_step
+                worker.current_step = weight_step
+                worker.validation_flag.set()
+                worker._pending_validation_step = weight_step
 
         if command.replica_should_stop():
-            self._worker._pending_shutdown = True
+            worker._pending_shutdown = True
 
         elapsed_ms = (time.monotonic() - t0) * 1000
         logger.info(
@@ -410,7 +424,7 @@ class WeightSyncThread:
             bytes_broadcast / (1024 * 1024),
             elapsed_ms,
             weight_step,
-            self._worker.current_weight_version,
+            worker.current_weight_version,
         )
 
 

--- a/cosmos_rl/rollout/worker/weight_sync.py
+++ b/cosmos_rl/rollout/worker/weight_sync.py
@@ -1,0 +1,672 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Async weight synchronization for disaggregated rollout workers.
+
+This module implements an opt-in asynchronous weight sync path where P2R
+(policy-to-rollout) and R2R (rollout-to-rollout) weight transfers execute
+on a dedicated background thread with its own CUDA stream.  Weights are
+written into a *buffer model* (a parameter-only clone) and copied to the
+live model at explicit sync points -- either before each
+``rollout_generation()`` call or before each policy inference call.
+
+Architecture
+------------
+
+::
+
+    Main thread                    WeightSyncThread
+    ───────────                    ────────────────
+    rollout_generation()           ← P2R/R2R commands from controller
+      └─ sync_buffer_to_live()        └─ execute on weight_sync_stream
+           copy buffer → live              write into buffer_state_dict
+           (on inference_stream)           record CUDA event
+                                           bump _buffer_version
+
+Enabling
+--------
+Set ``[rollout].async_r2r_sync`` to ``"generation"`` or ``"inference"``
+in the experiment config.  Default is ``"disabled"`` (synchronous path).
+
+- ``generation``: sync buffer to live before each ``rollout_generation()``.
+- ``inference``: additionally sync before each policy forward pass.
+
+The ``[rollout].broadcast_all_params`` toggle (default ``false``) controls
+whether R2R broadcasts all model parameters or only trainable ones.  Set
+to ``true`` for models with non-trainable params that must be synced
+(e.g. frozen vision encoders).
+"""
+
+from __future__ import annotations
+
+import os
+import queue
+import threading
+import time
+from enum import Enum
+from typing import TYPE_CHECKING
+
+import torch
+
+from cosmos_rl.utils.logging import logger
+from cosmos_rl.utils.pynccl import nccl_broadcast, nccl_group_end, nccl_group_start
+
+if TYPE_CHECKING:
+    pass
+
+try:
+    import redis as _redis_lib
+except ImportError:
+    _redis_lib = None
+
+
+class AsyncR2RSyncMode(Enum):
+    """When to synchronize the async R2R broadcast with inference.
+
+    - ``DISABLED``: R2R runs synchronously on ``inference_stream``.
+    - ``GENERATION``: R2R runs on a separate CUDA stream; buffer is synced
+      to live model before each ``rollout_generation()`` call.
+    - ``INFERENCE``: Like GENERATION, but also syncs before each policy
+      inference call inside the rollout servicer.
+    """
+
+    DISABLED = "disabled"
+    GENERATION = "generation"
+    INFERENCE = "inference"
+
+
+_R2R_BARRIER_TIMEOUT_S = 120
+_SYNC_NOOP_LOG_INTERVAL = 50
+
+
+# ---------------------------------------------------------------------------
+# Config helpers
+# ---------------------------------------------------------------------------
+
+
+def get_async_r2r_sync_mode(worker) -> AsyncR2RSyncMode:
+    """Read ``async_r2r_sync`` from ``[rollout]`` in worker config."""
+    return AsyncR2RSyncMode(worker.config.rollout.async_r2r_sync)
+
+
+def get_broadcast_all_params(worker) -> bool:
+    """Read ``broadcast_all_params`` from ``[rollout]`` in worker config."""
+    return worker.config.rollout.broadcast_all_params
+
+
+# ---------------------------------------------------------------------------
+# Buffer model helpers
+# ---------------------------------------------------------------------------
+
+
+def create_buffer_model(worker, device=None) -> None:
+    """Create a parameter-only buffer by cloning live model state_dict."""
+    model = worker.rollout.get_underlying_model()
+    target_device = device or next(model.parameters()).device
+    buffer_sd: dict[str, torch.Tensor] = {}
+    for name, param in model.state_dict().items():
+        buffer_sd[name] = param.detach().clone().to(target_device)
+    worker._buffer_state_dict = buffer_sd
+    # Monotonic counters: _buffer_version is bumped by WeightSyncThread,
+    # _buffer_synced_version by sync_buffer_to_live on the main thread.
+    # CPython GIL guarantees atomic int reads/writes, so no lock is needed.
+    worker._buffer_version = 0
+    worker._buffer_synced_version = 0
+    total_bytes = sum(t.nelement() * t.element_size() for t in buffer_sd.values())
+    logger.info(
+        "[WeightSync] Created buffer model: %d tensors, %.1f MB on %s",
+        len(buffer_sd),
+        total_bytes / (1024 * 1024),
+        target_device,
+    )
+
+
+def redirect_view_map_to_buffer(worker) -> None:
+    """Replace weight_inplace_view_map entries with buffer_model tensors.
+
+    After this call, P2R nccl_recv writes directly into the buffer
+    tensors instead of the live model parameters.
+    """
+    buffer_sd = worker._buffer_state_dict
+    old_map = worker.weight_inplace_view_map
+    model = worker.rollout.get_underlying_model()
+
+    sd = model.state_dict()
+    ptr_to_sd_key: dict[int, str] = {}
+    for name, tensor in sd.items():
+        ptr_to_sd_key[tensor.data_ptr()] = name
+
+    new_map: dict[str, torch.Tensor] = {}
+    redirected = 0
+    for hf_key, view_tensor in old_map.items():
+        if hf_key in buffer_sd and buffer_sd[hf_key].shape == view_tensor.shape:
+            new_map[hf_key] = buffer_sd[hf_key]
+            redirected += 1
+            continue
+        sd_key = ptr_to_sd_key.get(view_tensor.data_ptr())
+        if sd_key is not None and sd_key in buffer_sd:
+            new_map[hf_key] = buffer_sd[sd_key]
+            redirected += 1
+            continue
+        logger.warning(
+            "[WeightSync] Could not redirect view map key %r to buffer; "
+            "keeping original tensor.",
+            hf_key,
+        )
+        new_map[hf_key] = view_tensor
+
+    worker.weight_inplace_view_map = new_map
+    logger.info(
+        "[WeightSync] Redirected %d/%d view map entries to buffer tensors",
+        redirected,
+        len(old_map),
+    )
+
+
+def sync_buffer_to_live(worker) -> None:
+    """Copy buffer params to live model if a new version is available.
+
+    Non-blocking on CPU.  inference_stream.wait_event(last_event) ensures
+    the GPU-side copy executes after the most recently completed write on
+    the weight-sync stream.
+    """
+    buf_ver = getattr(worker, "_buffer_version", 0)
+    synced_ver = getattr(worker, "_buffer_synced_version", 0)
+    if buf_ver <= synced_ver:
+        cnt = getattr(worker, "_sync_noop_cnt", 0) + 1
+        worker._sync_noop_cnt = cnt
+        if cnt == 1 or cnt % _SYNC_NOOP_LOG_INTERVAL == 0:
+            logger.debug(
+                "[WeightSync] sync_buffer_to_live: no-op (buf_ver=%d, "
+                "synced_ver=%d, noop_count=%d)",
+                buf_ver,
+                synced_ver,
+                cnt,
+            )
+        return
+
+    worker._sync_noop_cnt = 0
+    wst: WeightSyncThread | None = getattr(worker, "_weight_sync_thread", None)
+    has_event = wst is not None and wst._last_event is not None
+
+    inf_stream = worker.inference_stream
+    if has_event:
+        inf_stream.wait_event(wst._last_event)
+
+    live_sd = getattr(worker, "_live_state_dict_cache", None)
+    if live_sd is None:
+        model = worker.rollout.get_underlying_model()
+        live_sd = model.state_dict()
+        worker._live_state_dict_cache = live_sd
+    buffer_sd = worker._buffer_state_dict
+    t0 = time.monotonic()
+    with torch.cuda.stream(inf_stream):
+        for name in live_sd:
+            if name in buffer_sd:
+                live_sd[name].copy_(buffer_sd[name])
+    worker._buffer_synced_version = buf_ver
+    elapsed_ms = (time.monotonic() - t0) * 1000
+    logger.info(
+        "[WeightSync] Synced buffer -> live (%d params, ver %d->%d, "
+        "wait_event=%s, %.1f ms CPU enqueue)",
+        len(live_sd),
+        synced_ver,
+        buf_ver,
+        has_event,
+        elapsed_ms,
+    )
+
+    if getattr(worker, "_pending_validation_step", None) is not None:
+        worker._pending_validation_step = None
+        if worker.validation_flag.is_set():
+            worker.do_validation()
+    if getattr(worker, "_pending_shutdown", False):
+        worker._pending_shutdown = False
+        data = {"is_end": True, "prompt_idx": -1, "completion_token_ids": []}
+        worker.redis_controller.publish_teacher_request(data, worker.replica_name)
+        logger.info("[WeightSync] Published end event to reference")
+        if worker.validation_flag.is_set():
+            worker.do_validation()
+        worker.shutdown_signal.set()
+        worker.shutdown_mp_signal.set()
+
+
+# ---------------------------------------------------------------------------
+# WeightSyncThread
+# ---------------------------------------------------------------------------
+
+
+class WeightSyncThread:
+    """Background thread executing P2R and R2R on a dedicated CUDA stream.
+
+    P2R commands have higher priority (0) than R2R commands (1).
+    The thread writes into ``_buffer_state_dict``; the live model is
+    never touched.
+
+    P2R is executed by calling ``worker._execute_p2r_recv(command, stream)``
+    directly with the WST's own CUDA stream, avoiding any stream-swap hacks.
+    """
+
+    def __init__(self, worker):
+        self._worker = worker
+        self._queue: queue.PriorityQueue = queue.PriorityQueue()
+        self._seq = 0
+        self._stream = torch.cuda.Stream()
+        self._stop = threading.Event()
+        self._idle = threading.Event()
+        self._idle.set()
+        self._last_event: torch.cuda.Event | None = None
+        self._thread = threading.Thread(
+            target=self._run,
+            daemon=True,
+            name="weight-sync",
+        )
+
+    def start(self) -> None:
+        """Start the background thread."""
+        self._thread.start()
+        logger.info("[WeightSyncThread] Started background thread")
+
+    def enqueue_p2r(self, command) -> None:
+        """Enqueue a P2R command with highest priority."""
+        self._seq += 1
+        self._idle.clear()
+        self._queue.put((0, self._seq, ("p2r", command)))
+        logger.info(
+            "[WeightSyncThread] Enqueued P2R (step=%s, seq=%d, buf_ver=%d)",
+            getattr(command, "weight_step", "?"),
+            self._seq,
+            getattr(self._worker, "_buffer_version", -1),
+        )
+
+    def enqueue_r2r(self, command) -> None:
+        """Enqueue an R2R command with lower priority."""
+        self._seq += 1
+        self._idle.clear()
+        self._queue.put((1, self._seq, ("r2r", command)))
+        logger.info(
+            "[WeightSyncThread] Enqueued R2R (step=%s, seq=%d, buf_ver=%d)",
+            getattr(command, "weight_step", "?"),
+            self._seq,
+            getattr(self._worker, "_buffer_version", -1),
+        )
+
+    def drain(self, timeout: float = 120.0) -> None:
+        """Block until the queue is empty and no operation is in-flight."""
+        if not self._thread.is_alive():
+            return
+        done = threading.Event()
+
+        def _join_with_timeout():
+            self._queue.join()
+            done.set()
+
+        t = threading.Thread(target=_join_with_timeout, daemon=True)
+        t.start()
+        if not done.wait(timeout=timeout):
+            logger.warning(
+                "[WeightSyncThread] drain() timed out after %.1fs",
+                timeout,
+            )
+
+    def stop(self) -> None:
+        """Signal the thread to stop and wait for it to finish."""
+        self._stop.set()
+        if self._thread.is_alive():
+            self._thread.join(timeout=10.0)
+
+    def _run(self) -> None:
+        torch.cuda.set_device(self._worker.device)
+        logger.info(
+            "[WeightSyncThread] Thread started on device %s",
+            self._worker.device,
+        )
+        while not self._stop.is_set():
+            try:
+                _, seq, (cmd_type, command) = self._queue.get(timeout=0.1)
+            except queue.Empty:
+                self._idle.set()
+                continue
+            try:
+                if cmd_type == "p2r":
+                    self._execute_p2r(command)
+                elif cmd_type == "r2r":
+                    self._execute_r2r(command)
+            except Exception:
+                logger.exception(
+                    "[WeightSyncThread] Error executing %s command",
+                    cmd_type,
+                )
+            finally:
+                self._queue.task_done()
+                if self._queue.empty():
+                    self._idle.set()
+
+    def _execute_p2r(self, command) -> None:
+        """Run the P2R receive on the WST's CUDA stream."""
+        t0 = time.monotonic()
+        self._worker._execute_p2r_recv(command, self._stream)
+
+        self._last_event = torch.cuda.Event()
+        self._last_event.record(self._stream)
+        self._worker._buffer_version += 1
+        elapsed_ms = (time.monotonic() - t0) * 1000
+        logger.info(
+            "[WeightSyncThread] P2R done (step=%s, ver=%s, %.1f ms)",
+            command.weight_step,
+            self._worker.current_weight_version,
+            elapsed_ms,
+        )
+
+    def _execute_r2r(self, command) -> None:
+        """Redis barrier + grouped NCCL broadcast on buffer_model."""
+        weight_step = command.weight_step
+        r2r_barrier(self._worker, weight_step)
+        t0 = time.monotonic()
+        transferred_cnt, bytes_broadcast = do_nccl_broadcast_grouped(
+            self._worker,
+            command.src_replica_name,
+            self._stream,
+        )
+        self._last_event = torch.cuda.Event()
+        self._last_event.record(self._stream)
+        self._worker._buffer_version += 1
+
+        if weight_step is not None:
+            self._worker.current_weight_version = weight_step
+
+        if weight_step is not None and weight_step >= 0:
+            cfg = self._worker.config
+            is_initial = weight_step == 0 and cfg.validation.val_before_train
+            is_periodic = weight_step > 0 and weight_step % cfg.validation.freq == 0
+            is_final = weight_step == command.total_steps
+            should_do_validation = cfg.validation.enable and (
+                is_initial or is_periodic or is_final
+            )
+            if should_do_validation:
+                self._worker.current_step = weight_step
+                self._worker.validation_flag.set()
+                self._worker._pending_validation_step = weight_step
+
+        if command.replica_should_stop():
+            self._worker._pending_shutdown = True
+
+        elapsed_ms = (time.monotonic() - t0) * 1000
+        logger.info(
+            "[WeightSyncThread] R2R done: %d params, %.1f MB, %.0f ms, step=%s, ver=%s",
+            transferred_cnt,
+            bytes_broadcast / (1024 * 1024),
+            elapsed_ms,
+            weight_step,
+            self._worker.current_weight_version,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Redis barrier for R2R
+# ---------------------------------------------------------------------------
+
+
+def setup_redis_barrier(worker) -> None:
+    """Set up Redis client and barrier prefix for R2R coordination.
+
+    Idempotent.  The WeightSyncThread uses these attributes in
+    ``r2r_barrier`` to synchronize all rollout workers before each
+    NCCL broadcast.
+    """
+    if hasattr(worker, "_r2r_redis"):
+        return
+
+    worker._r2r_redis = None
+    worker._r2r_world_size = len(getattr(worker, "replica_name_to_rank", {}))
+
+    if _redis_lib is not None:
+        try:
+            redis_host = "localhost"
+            redis_port = 6379
+            redis_db = 0
+            redis_controller = getattr(worker, "redis_controller", None)
+            if redis_controller and hasattr(redis_controller, "redis_clients"):
+                clients = redis_controller.redis_clients
+                if clients:
+                    conn_kwargs = clients[0].connection_pool.connection_kwargs
+                    redis_host = conn_kwargs.get("host", redis_host)
+                    redis_port = conn_kwargs.get("port", redis_port)
+                    redis_db = conn_kwargs.get("db", redis_db)
+            config = getattr(worker, "config", None)
+            if config and hasattr(config, "redis") and config.redis:
+                redis_port = int(config.redis)
+            r2r_redis = _redis_lib.Redis(
+                host=redis_host,
+                port=redis_port,
+                db=redis_db,
+                decode_responses=True,
+            )
+            r2r_redis.ping()
+            worker._r2r_redis = r2r_redis
+        except Exception as exc:
+            logger.warning(
+                "[WeightSync] Redis unavailable for R2R barrier (%s); "
+                "barrier will be skipped.",
+                exc,
+            )
+
+    exp_name = "default"
+    try:
+        exp_name = getattr(worker.config.logging, "experiment_name", "default")
+    except Exception:
+        pass
+    job_id = os.environ.get("SLURM_JOB_ID", "test")
+    worker._r2r_barrier_prefix = f"cosmos_rl:{exp_name}:{job_id}:r2r"
+
+    logger.info(
+        "[WeightSync] Redis barrier setup (redis=%s, world_size=%d, barrier_prefix=%s)",
+        worker._r2r_redis is not None,
+        worker._r2r_world_size,
+        worker._r2r_barrier_prefix,
+    )
+
+
+def r2r_barrier(worker, weight_step: int) -> None:
+    """Redis-based barrier so all rollout workers start R2R broadcast together.
+
+    Uses an atomic INCR counter per weight step.  The last worker to arrive
+    publishes a "go" signal; earlier workers block on pub/sub until they
+    receive it (or timeout).  Silently skipped if Redis is unavailable.
+    """
+    r2r_redis = getattr(worker, "_r2r_redis", None)
+    world_size = getattr(worker, "_r2r_world_size", 0)
+    if r2r_redis is None or world_size <= 1:
+        return
+
+    prefix = worker._r2r_barrier_prefix
+    barrier_key = f"{prefix}:barrier:{weight_step}"
+    go_channel = f"{prefix}:go:{weight_step}"
+
+    try:
+        count = r2r_redis.incr(barrier_key)
+        r2r_redis.expire(barrier_key, 600)
+
+        if count >= world_size:
+            r2r_redis.publish(go_channel, "go")
+            logger.info(
+                "[R2R Barrier] Last worker arrived (count=%d/%d, step=%d), "
+                "published go signal.",
+                count,
+                world_size,
+                weight_step,
+            )
+            return
+
+        logger.info(
+            "[R2R Barrier] Waiting for other workers (count=%d/%d, step=%d)...",
+            count,
+            world_size,
+            weight_step,
+        )
+        t0 = time.monotonic()
+
+        pubsub = r2r_redis.pubsub()
+        pubsub.subscribe(go_channel)
+        try:
+            recheck = int(r2r_redis.get(barrier_key) or 0)
+            if recheck >= world_size:
+                elapsed_ms = (time.monotonic() - t0) * 1000
+                logger.info(
+                    "[R2R Barrier] Go signal already sent (recheck=%d/%d), "
+                    "%.1f ms wait.",
+                    recheck,
+                    world_size,
+                    elapsed_ms,
+                )
+                return
+
+            deadline = time.monotonic() + _R2R_BARRIER_TIMEOUT_S
+            while time.monotonic() < deadline:
+                msg = pubsub.get_message(timeout=1.0)
+                if msg is not None and msg.get("type") == "message":
+                    break
+            else:
+                logger.warning(
+                    "[R2R Barrier] Timed out after %ds waiting for go signal "
+                    "(step=%d). Proceeding anyway.",
+                    _R2R_BARRIER_TIMEOUT_S,
+                    weight_step,
+                )
+        finally:
+            pubsub.unsubscribe(go_channel)
+            pubsub.close()
+
+        elapsed_ms = (time.monotonic() - t0) * 1000
+        logger.info(
+            "[R2R Barrier] All workers ready (step=%d), waited %.1f ms.",
+            weight_step,
+            elapsed_ms,
+        )
+    except Exception as exc:
+        logger.warning("[R2R Barrier] Redis error (%s); skipping barrier.", exc)
+
+
+# ---------------------------------------------------------------------------
+# NCCL broadcast helpers
+# ---------------------------------------------------------------------------
+
+
+def do_nccl_broadcast_grouped(worker, src_replica_name: str, stream) -> tuple:
+    """Grouped NCCL broadcast of all model params using group start/end.
+
+    Uses buffer tensors when ``_buffer_state_dict`` exists.
+    Returns ``(param_count, bytes_broadcast)``.
+    """
+    bytes_broadcast = 0
+    transferred_cnt = 0
+    non_contig: list[tuple[torch.Tensor, torch.Tensor]] = []
+    with torch.cuda.stream(stream):
+        assert worker.rank_in_rollout_repicas >= 0
+        assert len(worker.replica_name_to_rank) > 0
+        comm_idx = worker.global_commnicator_idex
+        src_rank = worker.replica_name_to_rank[src_replica_name]
+
+        buffer_sd = getattr(worker, "_buffer_state_dict", None)
+        if buffer_sd is not None:
+            params_iter = buffer_sd.items()
+        else:
+            model = worker.rollout.get_underlying_model()
+            params_iter = model.state_dict().items()
+
+        with torch.inference_mode():
+            nccl_group_start(comm_idx)
+            for _, param in params_iter:
+                if param.is_contiguous():
+                    nccl_broadcast(param, src_rank, comm_idx)
+                else:
+                    recv_tensor = param.contiguous()
+                    nccl_broadcast(recv_tensor, src_rank, comm_idx)
+                    non_contig.append((param, recv_tensor))
+                bytes_broadcast += param.nelement() * param.element_size()
+                transferred_cnt += 1
+            nccl_group_end(comm_idx)
+            for param, recv_tensor in non_contig:
+                param.copy_(recv_tensor)
+    return transferred_cnt, bytes_broadcast
+
+
+# ---------------------------------------------------------------------------
+# Orchestration: ensure_wst, install_inference_sync
+# ---------------------------------------------------------------------------
+
+
+def ensure_wst(worker) -> WeightSyncThread:
+    """Idempotent setup: buffer model, Redis barrier, view-map redirect, WST.
+
+    Safe to call multiple times.  After this returns the WST is running
+    and all P2R / R2R commands can be enqueued to it.
+    """
+    if not hasattr(worker, "_buffer_state_dict"):
+        create_buffer_model(worker)
+    if hasattr(worker, "weight_inplace_view_map") and not getattr(
+        worker, "_view_map_redirected", False
+    ):
+        redirect_view_map_to_buffer(worker)
+        worker._view_map_redirected = True
+    setup_redis_barrier(worker)
+    if not hasattr(worker, "_weight_sync_thread"):
+        worker._weight_sync_thread = WeightSyncThread(worker)
+    wst: WeightSyncThread = worker._weight_sync_thread
+    if not wst._thread.is_alive():
+        wst.start()
+    return wst
+
+
+def install_inference_sync(worker) -> None:
+    """Wrap the rollout servicer's policy_fn to sync buffer before each call.
+
+    In "inference" mode, P2R/R2R may still be in-flight on the WST
+    when a callback triggers policy inference.  This wrapper ensures
+    buffer params are copied to the live model before each forward pass.
+    """
+    rollout = worker.rollout
+    servicer = getattr(rollout, "_servicer", None)
+    if servicer is None:
+        logger.warning(
+            "[WeightSync] Cannot install inference-level sync: "
+            "rollout has no _servicer attribute. Falling back to "
+            "generation-level sync."
+        )
+        return
+
+    original_policy_fn = servicer.policy_fn
+    _inf_sync_count = [0]
+
+    def _synced_policy_fn(observation):
+        _inf_sync_count[0] += 1
+        t0 = time.monotonic()
+        sync_buffer_to_live(worker)
+        sync_ms = (time.monotonic() - t0) * 1000
+        if sync_ms > 0.5 or _inf_sync_count[0] <= 3:
+            logger.info(
+                "[InferenceSync] policy_fn call #%d: sync=%.2fms, "
+                "buf_ver=%d, synced_ver=%d",
+                _inf_sync_count[0],
+                sync_ms,
+                getattr(worker, "_buffer_version", -1),
+                getattr(worker, "_buffer_synced_version", -1),
+            )
+        return original_policy_fn(observation)
+
+    servicer.policy_fn = _synced_policy_fn
+    logger.info(
+        "[WeightSync] Installed inference-level buffer sync on rollout servicer"
+    )

--- a/tests/test_weight_sync.py
+++ b/tests/test_weight_sync.py
@@ -1,0 +1,290 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for async R2R weight sync in rollout/worker/weight_sync.py.
+
+Tests the config parsing, enum values, buffer model helpers, and
+install_inference_sync wiring — all without a real GPU or NCCL.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+import torch
+
+from cosmos_rl.rollout.worker.weight_sync import (
+    AsyncR2RSyncMode,
+    create_buffer_model,
+    get_async_r2r_sync_mode,
+    get_broadcast_all_params,
+    install_inference_sync,
+    redirect_view_map_to_buffer,
+    sync_buffer_to_live,
+)
+
+
+# ---------------------------------------------------------------------------
+# AsyncR2RSyncMode enum
+# ---------------------------------------------------------------------------
+
+
+class TestAsyncR2RSyncMode:
+    """Verify enum values match the TOML config strings."""
+
+    def test_disabled_value(self):
+        assert AsyncR2RSyncMode.DISABLED.value == "disabled"
+
+    def test_generation_value(self):
+        assert AsyncR2RSyncMode.GENERATION.value == "generation"
+
+    def test_inference_value(self):
+        assert AsyncR2RSyncMode.INFERENCE.value == "inference"
+
+    def test_roundtrip_from_string(self):
+        for mode in AsyncR2RSyncMode:
+            assert AsyncR2RSyncMode(mode.value) is mode
+
+    def test_invalid_value_raises(self):
+        with pytest.raises(ValueError):
+            AsyncR2RSyncMode("bogus")
+
+
+# ---------------------------------------------------------------------------
+# get_async_r2r_sync_mode — config parsing
+# ---------------------------------------------------------------------------
+
+
+def _make_worker(async_r2r_sync="disabled", broadcast_all=False):
+    """Build a minimal stub that looks like DisaggregatedRolloutControlWorker."""
+    worker = SimpleNamespace()
+    worker.config = SimpleNamespace(
+        rollout=SimpleNamespace(
+            async_r2r_sync=async_r2r_sync,
+            broadcast_all_params=broadcast_all,
+        ),
+    )
+    return worker
+
+
+class TestGetAsyncR2RSyncMode:
+    """Test config parsing from worker.config.rollout."""
+
+    def test_defaults_to_disabled(self):
+        worker = _make_worker()
+        assert get_async_r2r_sync_mode(worker) == AsyncR2RSyncMode.DISABLED
+
+    def test_parses_disabled(self):
+        worker = _make_worker("disabled")
+        assert get_async_r2r_sync_mode(worker) == AsyncR2RSyncMode.DISABLED
+
+    def test_parses_generation(self):
+        worker = _make_worker("generation")
+        assert get_async_r2r_sync_mode(worker) == AsyncR2RSyncMode.GENERATION
+
+    def test_parses_inference(self):
+        worker = _make_worker("inference")
+        assert get_async_r2r_sync_mode(worker) == AsyncR2RSyncMode.INFERENCE
+
+    def test_invalid_value_raises(self):
+        worker = _make_worker("banana")
+        with pytest.raises(ValueError):
+            get_async_r2r_sync_mode(worker)
+
+
+class TestGetBroadcastAllParams:
+    """Test broadcast_all_params config parsing."""
+
+    def test_defaults_to_false(self):
+        worker = _make_worker()
+        assert get_broadcast_all_params(worker) is False
+
+    def test_returns_true(self):
+        worker = _make_worker(broadcast_all=True)
+        assert get_broadcast_all_params(worker) is True
+
+
+# ---------------------------------------------------------------------------
+# create_buffer_model — CPU-only tests
+# ---------------------------------------------------------------------------
+
+
+class TestCreateBufferModel:
+    """Test buffer model creation from a mock underlying model."""
+
+    def _make_model_worker(self):
+        """Create a worker with a simple 2-param model stub."""
+        p1 = torch.randn(4, 4)
+        p2 = torch.randn(3)
+        model = MagicMock()
+        model.state_dict.return_value = {"layer.weight": p1, "layer.bias": p2}
+        model.parameters.return_value = iter([p1, p2])
+
+        rollout = SimpleNamespace(get_underlying_model=lambda: model)
+        worker = SimpleNamespace(rollout=rollout)
+        return worker, p1, p2
+
+    def test_creates_buffer_state_dict(self):
+        worker, p1, p2 = self._make_model_worker()
+        create_buffer_model(worker, device="cpu")
+
+        assert hasattr(worker, "_buffer_state_dict")
+        assert set(worker._buffer_state_dict.keys()) == {"layer.weight", "layer.bias"}
+
+    def test_buffer_is_clone_not_alias(self):
+        worker, p1, _ = self._make_model_worker()
+        create_buffer_model(worker, device="cpu")
+
+        buf_w = worker._buffer_state_dict["layer.weight"]
+        assert torch.equal(buf_w, p1)
+        assert buf_w.data_ptr() != p1.data_ptr()
+
+    def test_initializes_version_counters(self):
+        worker, _, _ = self._make_model_worker()
+        create_buffer_model(worker, device="cpu")
+        assert worker._buffer_version == 0
+        assert worker._buffer_synced_version == 0
+
+
+# ---------------------------------------------------------------------------
+# redirect_view_map_to_buffer
+# ---------------------------------------------------------------------------
+
+
+class TestRedirectViewMapToBuffer:
+    """Test that view map entries are redirected to buffer tensors."""
+
+    def test_redirects_matching_keys(self):
+        p1 = torch.randn(4, 4)
+        buf_p1 = p1.clone()
+        model = MagicMock()
+        model.state_dict.return_value = {"layer.weight": p1}
+
+        worker = SimpleNamespace(
+            rollout=SimpleNamespace(get_underlying_model=lambda: model),
+            weight_inplace_view_map={"layer.weight": p1},
+            _buffer_state_dict={"layer.weight": buf_p1},
+        )
+
+        redirect_view_map_to_buffer(worker)
+
+        assert worker.weight_inplace_view_map["layer.weight"] is buf_p1
+        assert worker.weight_inplace_view_map["layer.weight"] is not p1
+
+    def test_keeps_unmatched_keys(self):
+        p1 = torch.randn(4)
+        model = MagicMock()
+        model.state_dict.return_value = {}
+
+        worker = SimpleNamespace(
+            rollout=SimpleNamespace(get_underlying_model=lambda: model),
+            weight_inplace_view_map={"unknown_key": p1},
+            _buffer_state_dict={},
+        )
+
+        redirect_view_map_to_buffer(worker)
+        assert worker.weight_inplace_view_map["unknown_key"] is p1
+
+
+# ---------------------------------------------------------------------------
+# sync_buffer_to_live — version gating (CPU-only)
+# ---------------------------------------------------------------------------
+
+
+class TestSyncBufferToLive:
+    """Test version-gated sync logic without CUDA."""
+
+    def _make_sync_worker(self, buf_ver=0, synced_ver=0):
+        """Build a worker stub for sync_buffer_to_live tests."""
+        worker = SimpleNamespace()
+        worker._buffer_version = buf_ver
+        worker._buffer_synced_version = synced_ver
+        worker._buffer_state_dict = {}
+        return worker
+
+    def test_noop_when_versions_equal(self):
+        worker = self._make_sync_worker(buf_ver=3, synced_ver=3)
+        sync_buffer_to_live(worker)
+        assert worker._buffer_synced_version == 3
+
+    def test_noop_when_synced_ahead(self):
+        worker = self._make_sync_worker(buf_ver=2, synced_ver=5)
+        sync_buffer_to_live(worker)
+        assert worker._buffer_synced_version == 5
+
+
+# ---------------------------------------------------------------------------
+# install_inference_sync — policy_fn wrapping
+# ---------------------------------------------------------------------------
+
+
+class TestInstallInferenceSync:
+    """Test that install_inference_sync wraps the servicer's policy_fn."""
+
+    def test_wraps_policy_fn(self):
+        call_log = []
+
+        def original_fn(obs):
+            call_log.append(("original", obs))
+            return {"action": 1}
+
+        servicer = SimpleNamespace(policy_fn=original_fn)
+        rollout = SimpleNamespace(_servicer=servicer)
+        worker = SimpleNamespace(rollout=rollout)
+
+        install_inference_sync(worker)
+
+        assert servicer.policy_fn is not original_fn
+        with patch("cosmos_rl.rollout.worker.weight_sync.sync_buffer_to_live"):
+            result = servicer.policy_fn({"obs": 42})
+        assert result == {"action": 1}
+        assert call_log == [("original", {"obs": 42})]
+
+    def test_wrapped_fn_calls_sync_buffer_to_live(self):
+        def original_fn(obs):
+            return {"action": 1}
+
+        servicer = SimpleNamespace(policy_fn=original_fn)
+        rollout = SimpleNamespace(_servicer=servicer)
+        worker = SimpleNamespace(rollout=rollout)
+
+        install_inference_sync(worker)
+
+        with patch(
+            "cosmos_rl.rollout.worker.weight_sync.sync_buffer_to_live"
+        ) as mock_sync:
+            servicer.policy_fn({"obs": 1})
+            mock_sync.assert_called_once_with(worker)
+
+    def test_warns_when_no_servicer(self):
+        rollout = SimpleNamespace()
+        worker = SimpleNamespace(rollout=rollout)
+
+        with patch("cosmos_rl.rollout.worker.weight_sync.logger") as mock_logger:
+            install_inference_sync(worker)
+            mock_logger.warning.assert_called_once()
+            assert "no _servicer" in mock_logger.warning.call_args[0][0]
+
+
+# ---------------------------------------------------------------------------
+# Config validation — Literal type enforcement
+# ---------------------------------------------------------------------------
+
+
+class TestConfigLiteralValidation:
+    """Test that RolloutConfig validates async_r2r_sync values."""
+
+    def test_valid_values_accepted(self):
+        from cosmos_rl.policy.config import RolloutConfig
+
+        for val in ("disabled", "generation", "inference"):
+            cfg = RolloutConfig(async_r2r_sync=val)
+            assert cfg.async_r2r_sync == val
+
+    def test_invalid_value_rejected(self):
+        from cosmos_rl.policy.config import RolloutConfig
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError):
+            RolloutConfig(async_r2r_sync="banana")


### PR DESCRIPTION
Add opt-in asynchronous R2R (rollout-to-rollout) weight synchronization that runs NCCL broadcasts on a background thread while the main loop continues serving inference requests.

Key changes:

- New module `weight_sync.py`: WeightSyncThread, buffer model creation, view-map redirection, and generation/inference-level sync hooks.
- `rollout_control.py`: refactored main_loop to use `_call_rollout_generation` for consistent pre-generation buffer sync and weight-version injection.
- `RolloutConfig`: added `async_r2r_sync` (Literal["disabled","generation", "inference"]) and `broadcast_all_params` (bool) fields.
- Unit tests for buffer model, view-map redirect, sync gating, and config validation.

Modes:
- "disabled" (default): synchronous R2R on inference stream (no change).
- "generation": background R2R, buffer synced before each rollout_generation().
- "inference": additionally syncs before each policy forward pass.