### PR TITLE
feat: trace utility for structured profiling log lines

### DIFF
--- a/cosmos_rl/utils/trace.py
+++ b/cosmos_rl/utils/trace.py
@@ -1,0 +1,343 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Trace timing utilities for performance analysis.
+
+Provides a process-local monotonic time source and a per-process worker
+identity that together support a structured ``[Trace] ...`` log line
+convention.  The accompanying offline analyzer
+(``cosmos_rl.tools.profiler``) parses these lines to produce iteration
+breakdown reports.
+
+See ``docs/profiler/trace_format.rst`` for the full log-line grammar and
+field semantics.
+
+Quick start
+-----------
+
+The high-level :func:`trace_op` context manager wraps the common
+*time-it / format / log* pattern in a single call and is the
+recommended entry point for new instrumentation:
+
+.. code-block:: python
+
+    from cosmos_rl.utils.trace import set_worker_id, trace_op
+
+    set_worker_id("policy_0")
+
+    with trace_op("trainer", "step_training", iter=42):
+        do_work()
+
+    # Attach fields discovered mid-block by mutating the yielded dict:
+    with trace_op("ucxx_prefetch", "ucxx_fetch") as extras:
+        n_bytes = do_fetch()
+        extras["bytes"] = n_bytes
+        extras["count"] = 4
+
+The above emits, e.g.::
+
+    [Trace] worker=policy_0 thread=trainer op=step_training start=12.3 end=42.7 iter=42
+    [Trace] worker=policy_0 thread=ucxx_prefetch op=ucxx_fetch start=43.0 end=45.1 bytes=1048576 count=4
+
+The ``worker=`` field is included automatically when ``set_worker_id``
+has been called; otherwise it is omitted.
+
+Low-level building blocks (:func:`get_trace_time`, :func:`format_trace`)
+remain available for call sites that cannot use a ``with`` block (e.g.
+when start and end straddle async boundaries).
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from contextlib import contextmanager
+from typing import Any, Iterator, Optional
+
+# Characters that, if present in a string field value, would break the
+# `key=value` whitespace-delimited grammar.  Values containing any of
+# these are emitted as JSON-quoted strings instead of raw.
+_UNSAFE_CHARS = frozenset(' \t\n\r="[]')
+
+# Process-local trace start time (set on first call to get_trace_time()).
+_trace_start_time: Optional[float] = None
+
+# Process-local worker identity for trace lines.  Typically set during
+# replica initialization to a short tag (e.g. first 8 hex chars of the
+# cosmos-rl ``replica_name`` UUID, or ``"<role>_<rank>"``).
+_worker_id: Optional[str] = None
+
+
+def set_worker_id(worker_id: str) -> None:
+    """Set the per-process worker identity for trace log lines.
+
+    Should be called once during worker/replica initialization so that
+    subsequent :func:`format_trace` output includes a ``worker=...``
+    field, allowing the offline analyzer to distinguish interleaved
+    output from multiple replicas.
+
+    Args:
+        worker_id: A short identifier for the calling process, e.g.
+            ``"policy_0"`` or the first 8 hex chars of a replica UUID.
+    """
+    global _worker_id
+    _worker_id = worker_id
+
+
+def get_worker_id() -> str:
+    """Return the worker identity, or ``"?"`` if :func:`set_worker_id`
+    has not been called yet."""
+    return _worker_id or "?"
+
+
+def get_trace_time() -> float:
+    """Return milliseconds elapsed since the first trace event.
+
+    The first call to this function in a process records the reference
+    time (t = 0).  All subsequent calls return ``(now - t0) * 1000``.
+
+    Using a process-local zero point keeps trace timestamps small and
+    easy to read while still allowing the offline analyzer to align
+    timelines across processes via wall-clock timestamps that the
+    logging framework prefixes to each line.
+
+    Returns:
+        Milliseconds since the first call to this function in the
+        current process.
+    """
+    global _trace_start_time
+    now = time.perf_counter()
+    if _trace_start_time is None:
+        _trace_start_time = now
+    return (now - _trace_start_time) * 1000.0
+
+
+def reset_trace_time() -> None:
+    """Reset the trace start time.  Useful for tests."""
+    global _trace_start_time
+    _trace_start_time = None
+
+
+def format_trace(
+    *,
+    thread: str,
+    op: str,
+    start: Optional[float] = None,
+    end: Optional[float] = None,
+    **fields: Any,
+) -> str:
+    """Format a structured ``[Trace] ...`` log line.
+
+    The output follows a strict ``key=value`` grammar so the offline
+    analyzer can parse it without ambiguity.  See
+    ``docs/profiler/trace_format.rst`` for the formal grammar.
+
+    Args:
+        thread: Logical thread / role name (``"trainer"``,
+            ``"rollout"``, ``"controller"``, etc.).
+        op: Operation name (e.g. ``"step_training"``,
+            ``"trainer_forward"``).  The analyzer's opcode registry
+            keys off this value.
+        start: Optional start time in ms (typically from
+            :func:`get_trace_time`).
+        end: Optional end time in ms.
+        **fields: Additional ``key=value`` fields appended to the line.
+            Values are converted with ``repr`` for non-numeric / non-
+            string types so the analyzer can round-trip them.
+
+    Returns:
+        A single-line string starting with ``[Trace]``, suitable for
+        passing to ``logger.debug`` or ``logger.info``.
+    """
+    parts: list[str] = ["[Trace]"]
+    worker = _worker_id
+    if worker:
+        parts.append(f"worker={worker}")
+    parts.append(f"thread={thread}")
+    parts.append(f"op={op}")
+    if start is not None:
+        parts.append(f"start={start:.1f}")
+    if end is not None:
+        parts.append(f"end={end:.1f}")
+    for key, value in fields.items():
+        parts.append(f"{key}={_format_value(value)}")
+    return " ".join(parts)
+
+
+def _default_logger() -> Any:
+    """Return the cosmos-rl logger when available, else stdlib logger.
+
+    Resolved lazily so importing :mod:`cosmos_rl.utils.trace` from
+    contexts where the cosmos-rl logging package is not yet importable
+    (early bootstrap, isolated tests) still works.
+    """
+    try:
+        from cosmos_rl.utils.logging import logger as _logger
+
+        return _logger
+    except Exception:
+        import logging
+
+        return logging.getLogger("cosmos_rl.trace")
+
+
+@contextmanager
+def trace_op(
+    thread: str,
+    op: str,
+    *,
+    logger: Optional[Any] = None,
+    log_level: str = "debug",
+    **fields: Any,
+) -> Iterator[dict]:
+    """Context manager that times a block and emits a ``[Trace]`` line.
+
+    Equivalent to::
+
+        start = get_trace_time()
+        try:
+            do_work()
+        finally:
+            end = get_trace_time()
+            logger.debug(format_trace(
+                thread=thread, op=op, start=start, end=end, **fields,
+            ))
+
+    Yielded value
+        A mutable ``dict`` initialised from ``**fields``.  Mutate it
+        inside the ``with`` block to attach fields discovered at run
+        time (e.g. ``extras["bytes"] = n``); the final
+        :func:`format_trace` call uses the post-mutation contents.
+
+    Exception handling
+        If the body raises, the trace line is still emitted (with
+        ``status=error`` and ``err=<exception class name>`` appended)
+        and the exception then propagates unchanged.
+
+    Args:
+        thread: Logical thread / role name passed through to
+            :func:`format_trace`.
+        op: Operation name passed through to :func:`format_trace`.
+        logger: Optional logger object.  Defaults to the cosmos-rl
+            logger (``cosmos_rl.utils.logging.logger``); if that
+            cannot be imported, falls back to a stdlib logger named
+            ``"cosmos_rl.trace"``.
+        log_level: Method name on ``logger`` used to emit the line
+            (``"debug"``, ``"info"``, ``"warning"`` …).  Defaults to
+            ``"debug"`` to match the existing instrumentation style.
+        **fields: Initial extra ``key=value`` fields, identical in
+            semantics to :func:`format_trace`'s ``**fields``.
+
+    Example:
+        Basic block timing::
+
+            with trace_op("trainer", "step_training", iter=current_iter):
+                run_iteration()
+
+        Attaching mid-block metadata::
+
+            with trace_op("rollout", "ucxx_fetch") as extras:
+                n = do_fetch()
+                extras["count"] = n
+                extras["bytes"] = n * SLOT_BYTES
+
+        Custom logger / level::
+
+            with trace_op(
+                "trainer", "trainer_forward",
+                logger=my_logger, log_level="info",
+            ):
+                model(x)
+    """
+    extras: dict = dict(fields)
+    start = get_trace_time()
+    error_class: Optional[str] = None
+    try:
+        yield extras
+    except BaseException as exc:
+        error_class = type(exc).__name__
+        raise
+    finally:
+        end = get_trace_time()
+        if error_class is not None:
+            # Don't clobber a caller-supplied status / err, but make
+            # sure the failure is visible in the emitted line.
+            extras.setdefault("status", "error")
+            extras.setdefault("err", error_class)
+        line = format_trace(thread=thread, op=op, start=start, end=end, **extras)
+        emit_target = logger if logger is not None else _default_logger()
+        method = getattr(emit_target, log_level, None)
+        if method is None:
+            # Fall back to .info if the requested level isn't defined
+            # on the supplied logger; never let the trace path raise.
+            method = getattr(emit_target, "info", None)
+        if method is not None:
+            try:
+                method(line)
+            except Exception:
+                # Never let logging failures mask the user's code path.
+                pass
+
+
+def _quote_string(value: str) -> str:
+    """Return ``value`` raw if it is grammar-safe, else JSON-quoted.
+
+    Free-form string values may contain characters that would break the
+    whitespace-delimited ``key=value`` grammar (notably spaces, ``=``,
+    embedded quotes, and brackets).  When any such character is present
+    -- or when the value is empty -- the value is emitted as a
+    JSON-encoded double-quoted string with standard backslash escapes
+    so the analyzer can recover the original string with ``json.loads``.
+
+    Bare identifiers (matching ``[A-Za-z0-9_./:-]*`` content) round-trip
+    unchanged for readability.
+    """
+    if value == "" or any(ch in _UNSAFE_CHARS for ch in value):
+        return json.dumps(value)
+    return value
+
+
+def _format_value(value: Any) -> str:
+    """Render a trace field value.
+
+    * ``bool`` → ``0`` / ``1`` (numeric for the analyzer).
+    * ``float`` → one decimal place (matching ``start``/``end``).
+    * ``int`` → ``str(value)``.
+    * ``str`` → raw if grammar-safe, else JSON-quoted (see
+      :func:`_quote_string`).
+    * Anything else → ``repr(value)``, then JSON-quoted if the repr
+      itself contains grammar-unsafe characters.  This keeps unusual
+      types parseable as opaque strings rather than silently corrupting
+      the line.
+    """
+    if isinstance(value, bool):
+        return "1" if value else "0"
+    if isinstance(value, float):
+        return f"{value:.1f}"
+    if isinstance(value, int):
+        return str(value)
+    if isinstance(value, str):
+        return _quote_string(value)
+    return _quote_string(repr(value))
+
+
+__all__ = [
+    "format_trace",
+    "get_trace_time",
+    "get_worker_id",
+    "reset_trace_time",
+    "set_worker_id",
+    "trace_op",
+]

--- a/docs/profiler/trace_format.rst
+++ b/docs/profiler/trace_format.rst
@@ -1,0 +1,152 @@
+Trace log line format
+=====================
+
+This page documents the structured ``[Trace] ...`` log line grammar
+emitted by :mod:`cosmos_rl.utils.trace` and consumed by the offline
+profiler (``cosmos_rl.tools.profiler``).  Components that wish to
+participate in profiling should emit lines in this exact format so the
+analyzer can parse them.
+
+Grammar
+-------
+
+Each trace line is a single newline-terminated string with the
+following grammar (EBNF-ish)::
+
+    trace_line     := "[Trace]" SP fields
+    fields         := field (SP field)*
+    field          := key "=" value
+    key            := identifier         ; ASCII letters, digits, underscores
+    value          := number | bare_value | quoted_string
+    bare_value     := /[^\s"=\[\]]+/     ; grammar-safe characters only
+    quoted_string  := JSON string literal (double-quoted, backslash-escaped)
+
+Producers (e.g. :func:`cosmos_rl.utils.trace.format_trace`) emit
+free-form ``str`` values raw when they contain only grammar-safe
+characters, and as JSON-quoted strings otherwise (including the empty
+string and any value containing whitespace, ``=``, ``"``, ``[``, or
+``]``).  Consumers can safely round-trip a ``quoted_string`` value
+with ``json.loads``.
+
+Required fields (in this order):
+
+* ``thread`` — logical thread / role name
+  (``"trainer"``, ``"rollout"``, ``"controller"``, ``"ucxx_prefetch"``).
+* ``op`` — operation name; the analyzer's opcode registry keys off this
+  value.
+
+Optional well-known fields (when present, parsed as floats in
+milliseconds):
+
+* ``start`` — start time relative to the process trace zero.
+* ``end`` — end time, same reference frame.
+* ``waited_ms`` — time spent blocked (e.g. waiting on a prefetch).
+* ``transfer_ms`` — wire-time spent on a UCXX transfer.
+* ``copy_ms`` — host-to-device or device-to-device copy time.
+
+Optional well-known integer / size fields:
+
+* ``count`` — number of items (rollouts, slots, episodes).
+* ``bytes`` — total bytes transferred.
+* ``iter`` — current training iteration.
+
+Optional identity field (auto-emitted when
+:func:`cosmos_rl.utils.trace.set_worker_id` has been called):
+
+* ``worker`` — short tag identifying the producing process.
+
+All other ``key=value`` pairs are passed through to the analyzer as
+free-form metadata.
+
+Example
+-------
+
+::
+
+    [Trace] worker=policy_0 thread=trainer op=step_training start=12.3 end=42.7 iter=42
+    [Trace] worker=policy_0 thread=trainer op=trainer_forward start=14.1 end=22.0
+    [Trace] worker=policy_0 thread=trainer op=trainer_backward start=22.0 end=33.5
+    [Trace] worker=rollout_0 thread=ucxx_prefetch op=ucxx_fetch start=8.0 end=11.5 transfer_ms=2.1 copy_ms=1.0 count=4 bytes=1048576
+
+Producing trace lines
+---------------------
+
+The recommended entry point is the :func:`cosmos_rl.utils.trace.trace_op`
+context manager, which combines start/end timing, line formatting, and
+logger dispatch in a single ``with`` block:
+
+.. code-block:: python
+
+    from cosmos_rl.utils.trace import set_worker_id, trace_op
+
+    set_worker_id("policy_0")
+
+    # Basic block timing.
+    with trace_op("trainer", "step_training", iter=current_iter):
+        run_training_step()
+
+    # Attach fields discovered mid-block by mutating the yielded dict.
+    with trace_op("ucxx_prefetch", "ucxx_fetch") as extras:
+        n_bytes = do_fetch()
+        extras["bytes"] = n_bytes
+        extras["count"] = 4
+
+    # Custom logger / level.
+    with trace_op(
+        "trainer", "trainer_forward",
+        logger=my_logger, log_level="info",
+    ):
+        model(x)
+
+If the body raises, the ``[Trace]`` line is still emitted (with
+``status=error`` and ``err=<exception class name>`` appended) and the
+exception then propagates unchanged.
+
+Low-level building blocks
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+For call sites that cannot use a ``with`` block (start and end straddle
+async boundaries, deferred-collect patterns, etc.) the underlying
+primitives remain available:
+
+.. code-block:: python
+
+    from cosmos_rl.utils.trace import (
+        format_trace, get_trace_time, set_worker_id,
+    )
+    from cosmos_rl.utils.logging import logger
+
+    set_worker_id("policy_0")
+
+    start = get_trace_time()
+    # ... do work, possibly across an async boundary ...
+    end = get_trace_time()
+    logger.debug(format_trace(
+        thread="trainer", op="step_training",
+        start=start, end=end, iter=current_iter,
+    ))
+
+Recommended opcodes
+-------------------
+
+The analyzer ships with an opcode registry; new transports can register
+their own opcodes via the analyzer API.  The core set used by
+upstream cosmos-rl trainers includes:
+
+* ``step_training`` — full training iteration boundary.
+* ``trainer_forward`` / ``trainer_backward`` / ``trainer_optimizer`` —
+  per-phase timing within a training step.
+* ``rollout_processing`` — rollout decode/prep before training.
+* ``batch_preparation`` — batch concatenation.
+* ``prefetch_submit`` / ``prefetch_collect`` /
+  ``deferred_prefetch_collect`` — UCXX prefetch lifecycle (see
+  :mod:`cosmos_rl.utils.payload_transport.ucxx`).
+* ``ucxx_fetch`` — bg-thread UCXX fetch with ``transfer_ms`` /
+  ``copy_ms`` / ``count`` / ``bytes`` fields.
+
+Stability
+---------
+
+The grammar above is stable: new well-known field names may be added,
+but existing field names will not change semantics.  Free-form
+``key=value`` fields are always permitted.

--- a/tests/test_trace.py
+++ b/tests/test_trace.py
@@ -1,0 +1,464 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for ``cosmos_rl.utils.trace``."""
+
+import json
+import re
+import sys
+import time
+import unittest
+
+from cosmos_rl.utils.trace import (
+    format_trace,
+    get_trace_time,
+    get_worker_id,
+    reset_trace_time,
+    set_worker_id,
+    trace_op,
+)
+from cosmos_rl.utils import trace as _trace_mod
+
+
+# Tokenizer that understands the trace grammar: bare values OR JSON
+# double-quoted strings.  Matches the producer-side grammar in
+# cosmos_rl.utils.trace.
+_KV_RE = re.compile(r'(\w+)=("(?:[^"\\]|\\.)*"|\S+)')
+
+
+def _split_kv_pairs(line: str):
+    return _KV_RE.findall(line)
+
+
+class TestGetTraceTime(unittest.TestCase):
+    def setUp(self):
+        reset_trace_time()
+        # Reset worker id so tests are independent.
+        set_worker_id("")
+
+    def test_first_call_returns_near_zero(self):
+        t = get_trace_time()
+        # First call defines t=0; we should be within a couple ms.
+        self.assertLess(abs(t), 5.0)
+
+    def test_subsequent_calls_are_monotonic(self):
+        t0 = get_trace_time()
+        t1 = get_trace_time()
+        self.assertGreaterEqual(t1, t0)
+
+    def test_elapsed_matches_sleep(self):
+        get_trace_time()  # zero
+        time.sleep(0.05)
+        elapsed = get_trace_time()
+        # Allow generous slack for CI flakiness.
+        self.assertGreaterEqual(elapsed, 40.0)
+        self.assertLess(elapsed, 500.0)
+
+    def test_reset_zeros_time(self):
+        get_trace_time()
+        time.sleep(0.01)
+        reset_trace_time()
+        t = get_trace_time()
+        self.assertLess(abs(t), 5.0)
+
+
+class TestWorkerId(unittest.TestCase):
+    def setUp(self):
+        set_worker_id("")
+
+    def test_default_is_question_mark(self):
+        # Empty / unset => fallback "?"
+        self.assertEqual(get_worker_id(), "?")
+
+    def test_set_and_get(self):
+        set_worker_id("policy_0")
+        self.assertEqual(get_worker_id(), "policy_0")
+
+
+class TestFormatTrace(unittest.TestCase):
+    def setUp(self):
+        reset_trace_time()
+        set_worker_id("")
+
+    def test_minimum_required_fields(self):
+        line = format_trace(thread="trainer", op="step_training")
+        self.assertTrue(line.startswith("[Trace] "))
+        self.assertIn("thread=trainer", line)
+        self.assertIn("op=step_training", line)
+        # No worker= when unset.
+        self.assertNotIn("worker=", line)
+
+    def test_includes_worker_when_set(self):
+        set_worker_id("policy_0")
+        line = format_trace(thread="trainer", op="step_training")
+        self.assertIn("worker=policy_0", line)
+
+    def test_start_end_formatted_one_decimal(self):
+        line = format_trace(
+            thread="trainer",
+            op="trainer_forward",
+            start=12.345,
+            end=42.987,
+        )
+        # One-decimal formatting for ms timestamps keeps the analyzer
+        # output stable.
+        self.assertIn("start=12.3", line)
+        self.assertIn("end=43.0", line)
+
+    def test_extra_fields_appended(self):
+        line = format_trace(
+            thread="ucxx_prefetch",
+            op="ucxx_fetch",
+            start=0.0,
+            end=10.0,
+            transfer_ms=2.5,
+            copy_ms=1.0,
+            count=4,
+            bytes=1048576,
+        )
+        self.assertIn("transfer_ms=2.5", line)
+        self.assertIn("copy_ms=1.0", line)
+        self.assertIn("count=4", line)
+        self.assertIn("bytes=1048576", line)
+
+    def test_bool_fields_render_as_int(self):
+        # Bools render as 0/1 so the analyzer can treat them numerically.
+        line = format_trace(
+            thread="trainer",
+            op="step_training",
+            cold_start=True,
+            skipped=False,
+        )
+        self.assertIn("cold_start=1", line)
+        self.assertIn("skipped=0", line)
+
+    def test_field_order_is_stable(self):
+        # The analyzer doesn't depend on field order, but a stable
+        # order (worker, thread, op, start, end, then extras) keeps
+        # logs human-readable.
+        set_worker_id("rollout_2")
+        line = format_trace(
+            thread="rollout",
+            op="rollout_processing",
+            start=0.0,
+            end=5.0,
+            count=8,
+        )
+        # Check substring positions form a strictly increasing sequence.
+        order = ["worker=", "thread=", "op=", "start=", "end=", "count="]
+        positions = [line.index(token) for token in order]
+        self.assertEqual(positions, sorted(positions))
+
+    def test_only_start_emitted(self):
+        line = format_trace(thread="t", op="o", start=1.5)
+        self.assertIn("start=1.5", line)
+        self.assertNotIn("end=", line)
+
+    def test_only_end_emitted(self):
+        line = format_trace(thread="t", op="o", end=2.5)
+        self.assertIn("end=2.5", line)
+        # The 'end=' check above passes only if there is no 'start=' field;
+        # explicitly assert no spurious start.
+        self.assertNotIn("start=", line)
+
+    def test_no_start_no_end(self):
+        line = format_trace(thread="t", op="o", iter=1)
+        self.assertNotIn("start=", line)
+        self.assertNotIn("end=", line)
+        self.assertIn("iter=1", line)
+
+    def test_string_with_space_is_quoted(self):
+        line = format_trace(thread="t", op="o", note="hello world")
+        # JSON-quoted so the analyzer can recover the original string.
+        self.assertIn('note="hello world"', line)
+        # And it round-trips through json.loads.
+        kv = dict(_split_kv_pairs(line))
+        self.assertEqual(json.loads(kv["note"]), "hello world")
+
+    def test_string_with_equals_is_quoted(self):
+        line = format_trace(thread="t", op="o", expr="x=1")
+        self.assertIn('expr="x=1"', line)
+
+    def test_string_with_quote_is_escaped(self):
+        line = format_trace(thread="t", op="o", note='say "hi"')
+        kv = dict(_split_kv_pairs(line))
+        self.assertEqual(json.loads(kv["note"]), 'say "hi"')
+
+    def test_string_with_brackets_is_quoted(self):
+        line = format_trace(thread="t", op="o", note="[Trace]-like")
+        kv = dict(_split_kv_pairs(line))
+        self.assertEqual(json.loads(kv["note"]), "[Trace]-like")
+
+    def test_empty_string_is_quoted(self):
+        line = format_trace(thread="t", op="o", note="")
+        self.assertIn('note=""', line)
+
+    def test_safe_string_emitted_raw(self):
+        # Plain identifiers / dotted paths / paths stay unquoted for
+        # readability and to preserve backward compatibility.
+        line = format_trace(thread="t", op="o", file="path/to/x.py")
+        self.assertIn("file=path/to/x.py", line)
+
+    def test_none_value_falls_back_to_repr(self):
+        line = format_trace(thread="t", op="o", missing=None)
+        self.assertIn("missing=None", line)
+
+    def test_list_value_falls_back_to_repr(self):
+        line = format_trace(thread="t", op="o", shape=[1, 2, 3])
+        # repr produces "[1, 2, 3]" which contains spaces+brackets and
+        # therefore must be quoted.
+        kv = dict(_split_kv_pairs(line))
+        self.assertEqual(json.loads(kv["shape"]), "[1, 2, 3]")
+
+    def test_custom_object_falls_back_to_repr(self):
+        # repr() yielding a grammar-safe string is emitted raw.
+        class _Marker:
+            def __repr__(self):
+                return "<marker>"
+
+        line = format_trace(thread="t", op="o", obj=_Marker())
+        self.assertIn("obj=<marker>", line)
+
+    def test_custom_object_with_unsafe_repr_is_quoted(self):
+        # repr() containing whitespace must be quoted to keep the line
+        # parseable.
+        class _Detailed:
+            def __repr__(self):
+                return "Detailed(name='x y')"
+
+        line = format_trace(thread="t", op="o", obj=_Detailed())
+        kv = dict(_split_kv_pairs(line))
+        self.assertEqual(json.loads(kv["obj"]), "Detailed(name='x y')")
+
+    def test_format_is_deterministic_for_identical_inputs(self):
+        a = format_trace(thread="t", op="o", start=1.0, end=2.0, iter=3)
+        b = format_trace(thread="t", op="o", start=1.0, end=2.0, iter=3)
+        self.assertEqual(a, b)
+
+    def test_line_round_trips_through_simple_parser(self):
+        # Validate that the format is parseable with a trivial regex
+        # (a stand-in for the analyzer's parser).
+        set_worker_id("policy_0")
+        line = format_trace(
+            thread="trainer",
+            op="trainer_forward",
+            start=10.0,
+            end=20.0,
+            iter=42,
+        )
+        pattern = re.compile(
+            r"^\[Trace\]"
+            r"(?:\s+(?P<key>[A-Za-z_][A-Za-z0-9_]*)=(?P<val>\S+))+\s*$"
+        )
+        # Findall over key=val pairs to check we get the expected set.
+        kv_pattern = re.compile(r"(?P<k>[A-Za-z_][A-Za-z0-9_]*)=(?P<v>\S+)")
+        kvs = dict(kv_pattern.findall(line))
+        self.assertEqual(kvs["worker"], "policy_0")
+        self.assertEqual(kvs["thread"], "trainer")
+        self.assertEqual(kvs["op"], "trainer_forward")
+        self.assertEqual(kvs["start"], "10.0")
+        self.assertEqual(kvs["end"], "20.0")
+        self.assertEqual(kvs["iter"], "42")
+        # The full line also satisfies the higher-level pattern.
+        self.assertTrue(pattern.match(line) or " " in line)
+
+
+class _RecordingLogger:
+    """Minimal logger stand-in that records calls per level."""
+
+    def __init__(self):
+        self.records: list[tuple[str, str]] = []
+
+    def _record(self, level: str, msg: str) -> None:
+        self.records.append((level, msg))
+
+    def debug(self, msg):
+        self._record("debug", msg)
+
+    def info(self, msg):
+        self._record("info", msg)
+
+    def warning(self, msg):
+        self._record("warning", msg)
+
+
+class TestTraceOp(unittest.TestCase):
+    def setUp(self):
+        reset_trace_time()
+        set_worker_id("")
+
+    def test_basic_block_emits_single_line(self):
+        log = _RecordingLogger()
+        with trace_op("trainer", "step_training", logger=log):
+            time.sleep(0.005)
+        self.assertEqual(len(log.records), 1)
+        level, line = log.records[0]
+        self.assertEqual(level, "debug")
+        self.assertTrue(line.startswith("[Trace] "))
+        self.assertIn("thread=trainer", line)
+        self.assertIn("op=step_training", line)
+        self.assertIn("start=", line)
+        self.assertIn("end=", line)
+
+    def test_initial_fields_are_emitted(self):
+        log = _RecordingLogger()
+        with trace_op("trainer", "step_training", logger=log, iter=42):
+            pass
+        _, line = log.records[0]
+        self.assertIn("iter=42", line)
+
+    def test_yielded_extras_are_appended(self):
+        log = _RecordingLogger()
+        with trace_op("rollout", "ucxx_fetch", logger=log) as extras:
+            extras["bytes"] = 1048576
+            extras["count"] = 4
+        _, line = log.records[0]
+        self.assertIn("bytes=1048576", line)
+        self.assertIn("count=4", line)
+
+    def test_yielded_extras_can_override_initial_fields(self):
+        log = _RecordingLogger()
+        with trace_op("rollout", "ucxx_fetch", logger=log, count=0) as extras:
+            extras["count"] = 9
+        _, line = log.records[0]
+        self.assertIn("count=9", line)
+        self.assertNotIn("count=0", line)
+
+    def test_includes_worker_when_set(self):
+        log = _RecordingLogger()
+        set_worker_id("policy_0")
+        with trace_op("trainer", "step_training", logger=log):
+            pass
+        _, line = log.records[0]
+        self.assertIn("worker=policy_0", line)
+
+    def test_end_after_start(self):
+        log = _RecordingLogger()
+        with trace_op("trainer", "step_training", logger=log):
+            time.sleep(0.01)
+        _, line = log.records[0]
+        # Pull start / end out of the line and confirm end >= start.
+        kvs = dict(s.split("=", 1) for s in line.split(" ")[1:])
+        self.assertGreaterEqual(float(kvs["end"]), float(kvs["start"]))
+        self.assertGreater(float(kvs["end"]) - float(kvs["start"]), 0.0)
+
+    def test_custom_log_level_used(self):
+        log = _RecordingLogger()
+        with trace_op("trainer", "step_training", logger=log, log_level="info"):
+            pass
+        self.assertEqual(log.records[0][0], "info")
+
+    def test_unknown_log_level_falls_back_to_info(self):
+        log = _RecordingLogger()
+        with trace_op("trainer", "step_training", logger=log, log_level="nope"):
+            pass
+        # Falls back to .info rather than crashing.
+        self.assertEqual(log.records[0][0], "info")
+
+    def test_exception_is_reraised_and_line_is_emitted_with_status(self):
+        log = _RecordingLogger()
+        with self.assertRaises(ValueError):
+            with trace_op("trainer", "step_training", logger=log):
+                raise ValueError("boom")
+        self.assertEqual(len(log.records), 1)
+        _, line = log.records[0]
+        self.assertIn("status=error", line)
+        self.assertIn("err=ValueError", line)
+
+    def test_caller_supplied_status_is_not_overwritten_on_error(self):
+        log = _RecordingLogger()
+        with self.assertRaises(RuntimeError):
+            with trace_op(
+                "trainer",
+                "step_training",
+                logger=log,
+                status="custom",
+            ):
+                raise RuntimeError("x")
+        _, line = log.records[0]
+        self.assertIn("status=custom", line)
+        self.assertIn("err=RuntimeError", line)
+
+    def test_logger_failure_does_not_propagate(self):
+        class ExplodingLogger:
+            def debug(self, msg):
+                raise RuntimeError("logger broke")
+
+        # Should complete cleanly even though logging itself raises.
+        with trace_op("trainer", "step_training", logger=ExplodingLogger()):
+            pass
+
+    def test_default_logger_is_used_when_none_supplied(self):
+        # Smoke: just confirm the with block works without an explicit
+        # logger.  We can't easily intercept the cosmos_rl logger here,
+        # so we only verify the call doesn't raise and the extras dict
+        # is the expected type.
+        with trace_op("trainer", "step_training") as extras:
+            self.assertIsInstance(extras, dict)
+
+    def test_nested_blocks_both_emit_with_inner_inside_outer(self):
+        log = _RecordingLogger()
+        with trace_op("trainer", "step_training", logger=log):
+            time.sleep(0.002)
+            with trace_op("trainer", "trainer_forward", logger=log):
+                time.sleep(0.002)
+        self.assertEqual(len(log.records), 2)
+        # Inner finishes (and is logged) first; outer logs second.
+        ops = [dict(_split_kv_pairs(line))["op"] for _, line in log.records]
+        self.assertEqual(ops, ["trainer_forward", "step_training"])
+        # Inner is fully contained within outer.
+        kv_inner = dict(_split_kv_pairs(log.records[0][1]))
+        kv_outer = dict(_split_kv_pairs(log.records[1][1]))
+        self.assertGreaterEqual(float(kv_inner["start"]), float(kv_outer["start"]))
+        self.assertLessEqual(float(kv_inner["end"]), float(kv_outer["end"]))
+
+    def test_base_exception_still_emits_and_propagates(self):
+        # KeyboardInterrupt is BaseException, not Exception.  trace_op
+        # should still emit the line with status=error before re-raising.
+        log = _RecordingLogger()
+        with self.assertRaises(KeyboardInterrupt):
+            with trace_op("trainer", "step_training", logger=log):
+                raise KeyboardInterrupt()
+        self.assertEqual(len(log.records), 1)
+        _, line = log.records[0]
+        self.assertIn("status=error", line)
+        self.assertIn("err=KeyboardInterrupt", line)
+
+    def test_default_logger_falls_back_when_cosmos_rl_logging_unimportable(self):
+        # Simulate cosmos_rl.utils.logging being unimportable by
+        # injecting a stub module that raises on attribute access.
+        sentinel_name = "cosmos_rl.utils.logging"
+        prev = sys.modules.get(sentinel_name, None)
+        broken = type(sys)("cosmos_rl.utils.logging")
+
+        def _explode(name):
+            raise AttributeError(name)
+
+        broken.__getattr__ = _explode  # type: ignore[attr-defined]
+        sys.modules[sentinel_name] = broken
+        try:
+            fallback = _trace_mod._default_logger()
+        finally:
+            if prev is None:
+                sys.modules.pop(sentinel_name, None)
+            else:
+                sys.modules[sentinel_name] = prev
+        # Falls back to a stdlib logger (has .debug / .info methods).
+        self.assertTrue(hasattr(fallback, "debug"))
+        self.assertTrue(hasattr(fallback, "info"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Introduce cosmos_rl.utils.trace as the producer-side counterpart of an upcoming offline profiler.  Provides:

- get_trace_time(): process-local monotonic ms-since-zero clock.
- set_worker_id() / get_worker_id(): per-process identity tag.
- format_trace(): structured "[Trace] thread=... op=... start=... end=..." log-line builder with auto-included worker= field and stable field ordering for analyzer-friendly output.

The grammar is documented in docs/profiler/trace_format.rst so downstream tools and future trainers can target a stable contract. No call sites in cosmos-rl are converted in this MR; existing trainers opt in over time.

Tests cover the time source, worker identity, field formatting, ordering stability, and round-trip parseability of the emitted lines.