### PR TITLE
refactor: pluggable payload-transport registry (no behavior change)

### DIFF
--- a/cosmos_rl/comm/base.py
+++ b/cosmos_rl/comm/base.py
@@ -38,6 +38,12 @@ import cosmos_rl.utils.constant as constant
 import cosmos_rl.utils.distributed as dist_utils
 from cosmos_rl.dispatcher.protocol import MESH_NAMES
 import cosmos_rl.utils.util as util
+from cosmos_rl.utils.payload_transport import (
+    PayloadTransportRegistry,
+    RedisEndpoint,
+    get_payload_transfer_mode,
+    is_payload_transfer_mode_explicit,
+)
 from transformers import AutoConfig
 import multiprocessing as mp
 from cosmos_rl.dispatcher.api.client import APIClient
@@ -176,60 +182,171 @@ class CommMixin:
 
         util.call_setup(self.val_data_packer, self.config)
 
-        self._inject_redis_into_data_packers()
+        self._attach_payload_transport()
 
-    def _inject_redis_into_data_packers(self):
-        """Inject the worker's Redis connection into data packers that need one.
+    # ------------------------------------------------------------------
+    # Worker-side payload-transport attachment.
+    #
+    # Two compatibility surfaces are preserved here -- search for these
+    # comments if downstream code (e.g. Yuxiao's PolicyDataPacker
+    # introduced in PR #670 / commit 55745c) breaks:
+    #
+    #   (1) NCCL fast path:
+    #       NcclPayloadTransport.attach_data_packer assigns
+    #       packer.redis_client and THEN calls
+    #       packer.post_redis_injection().  This is the literal
+    #       contract from 55745c, hardened to survive ping failures
+    #       without crashing init.
+    #
+    #   (2) Opportunistic Redis injection compat fallback:
+    #       Pre-55745c convention (and any downstream packer that
+    #       lazily depends on ``redis_client`` without selecting NCCL
+    #       mode) expected a Redis client to land on the packer
+    #       regardless of the active transport.  We replicate that
+    #       behavior for any packer whose ``redis_client`` attribute is
+    #       ``None`` after attach -- but ONLY when the active mode is
+    #       NOT "nccl", to avoid double-injection (NCCL's attach
+    #       already handled it).
+    #
+    # The deprecation shim ``_inject_redis_into_data_packers`` below
+    # delegates to this method, keeping the old name reachable for
+    # downstream callers that monkey-patched or invoked it directly.
+    # ------------------------------------------------------------------
+    def _attach_payload_transport(self):
+        """Unified worker-side hook to wire payload transport into packers.
 
-        Some data packers expose a ``redis_client`` attribute to receive a
-        shared Redis connection from the worker.  Cosmos-RL calls ``setup()``
-        on the packer *before* ``init_data_packer()``, so any packer feature
-        that depends on Redis would be left disabled after the first setup
-        attempt.  This method provides the live connection and invokes the
-        packer's ``post_redis_injection()`` hook (if present) so the packer
-        can complete any deferred setup.
+        Replaces the inline Redis-injection logic that used to live in
+        ``_inject_redis_into_data_packers``.  Looks up the active
+        :class:`PayloadTransport` from the registry, then for each data
+        packer:
 
-        No-op for packers without a ``redis_client`` attribute.
+        1. Calls ``transport.attach_data_packer(...)`` so the transport
+           can wire its own state in (e.g. NCCL injects a Redis client
+           and runs ``post_redis_injection()``; UCXX starts prefetch
+           threads; Redis default no-ops).
+        2. Falls back to opportunistic Redis injection for non-NCCL
+           modes to preserve pre-55745c behavior for packers that
+           passively expose a ``redis_client`` attribute.
+
+        Failure handling follows the ``explicit_fatal`` policy: when
+        the user explicitly selected the transport in config, ``ImportError``
+        / ``RuntimeError`` from attach is re-raised so misconfiguration
+        (e.g. ``payload_transfer="ucxx"`` with no ``ucxx-cu12`` installed)
+        crashes loudly.  Other failures are logged and swallowed.
         """
-        self._try_inject_redis(self.data_packer, "data_packer")
+        mode = get_payload_transfer_mode(self.config)
+        explicit = is_payload_transfer_mode_explicit(self.config)
+        transport = PayloadTransportRegistry.get_optional(mode)
+        endpoint = self._build_redis_endpoint()
+        device = getattr(self, "device", None)
+
+        packers = [(self.data_packer, "data_packer")]
         if (
             hasattr(self, "val_data_packer")
             and self.val_data_packer is not self.data_packer
         ):
-            self._try_inject_redis(self.val_data_packer, "val_data_packer")
+            packers.append((self.val_data_packer, "val_data_packer"))
 
-    def _try_inject_redis(self, packer, packer_name: str):
-        """Inject Redis client into a single data packer."""
+        for packer, packer_name in packers:
+            if transport is not None:
+                try:
+                    transport.attach_data_packer(
+                        packer,
+                        config=self.config,
+                        device=device,
+                        redis_endpoint=endpoint,
+                    )
+                except (ImportError, RuntimeError) as exc:
+                    if explicit:
+                        # User-chosen transport failed hard (e.g.
+                        # ucxx-cu12 not installed but config sets
+                        # payload_transfer="ucxx").  Re-raise per
+                        # explicit_fatal policy so the misconfig is
+                        # visible immediately.
+                        raise
+                    logger.warning(
+                        f"[{self.role}] {mode} attach_data_packer for "
+                        f"{packer_name} failed: {exc}"
+                    )
+                except Exception as exc:
+                    logger.warning(
+                        f"[{self.role}] {mode} attach_data_packer for "
+                        f"{packer_name} raised "
+                        f"{type(exc).__name__}: {exc}"
+                    )
+
+            # (2) Opportunistic Redis injection compat fallback.  See
+            # the long-form comment above for why this exists.  Skipped
+            # when the active mode is NCCL because NCCL's attach is
+            # already responsible for the assignment-then-hook order
+            # from 55745c -- running it again here would either
+            # double-inject or stomp on the assigned client.
+            if mode != "nccl":
+                self._opportunistic_inject_redis(packer, packer_name, endpoint)
+
+    def _opportunistic_inject_redis(self, packer, packer_name: str, endpoint):
+        """Best-effort Redis injection for non-NCCL modes.
+
+        Compatibility surface (2) from ``_attach_payload_transport``:
+        preserves pre-55745c permissive injection for downstream packers
+        that lazily depend on ``redis_client`` without selecting NCCL
+        mode.  No-op when the packer has no ``redis_client`` attribute,
+        already has one wired up, or the redis library is unavailable.
+        """
         if not hasattr(packer, "redis_client"):
             return
-        if _redis_lib is None:
-            logger.warning(
-                f"[{self.role}] redis package not installed; "
-                f"cannot inject Redis into {packer_name}"
-            )
+        if getattr(packer, "redis_client", None) is not None:
+            # Some other code path (e.g. a transport's attach hook) has
+            # already wired one in -- don't stomp on it.
             return
-        redis_host, redis_port, redis_db = self._read_redis_endpoint()
+        if endpoint is None or _redis_lib is None:
+            return
         try:
-            packer.redis_client = _redis_lib.Redis(
-                host=redis_host,
-                port=redis_port,
-                db=redis_db,
+            client = _redis_lib.Redis(
+                host=endpoint.host,
+                port=endpoint.port,
+                db=endpoint.db,
                 decode_responses=True,
             )
-            packer.redis_client.ping()
-            logger.info(
-                f"[{self.role}] Injected Redis client into {packer_name} "
-                f"(host={redis_host}, port={redis_port}, db={redis_db})"
-            )
-            if hasattr(packer, "post_redis_injection"):
-                packer.post_redis_injection()
-        except Exception as e:
+            client.ping()
+        except Exception as exc:
             logger.warning(
-                f"[{self.role}] Failed to inject Redis client into {packer_name}: {e}"
+                f"[{self.role}] Opportunistic Redis injection for "
+                f"{packer_name} failed: {exc}"
             )
+            return
+        packer.redis_client = client
+        logger.info(
+            f"[{self.role}] Injected Redis client into {packer_name} "
+            f"(host={endpoint.host}, port={endpoint.port}, db={endpoint.db})"
+        )
+        hook = getattr(packer, "post_redis_injection", None)
+        if callable(hook):
+            try:
+                hook()
+            except Exception as exc:
+                logger.warning(
+                    f"[{self.role}] post_redis_injection on {packer_name} "
+                    f"raised {type(exc).__name__}: {exc}"
+                )
 
-    def _read_redis_endpoint(self) -> tuple:
-        """Return ``(host, port, db)`` from the worker's live Redis client."""
+    def _inject_redis_into_data_packers(self):
+        """DEPRECATED: use :meth:`_attach_payload_transport`.
+
+        Kept as a one-line shim because some downstream forks (search
+        PR #670 / commit 55745c) call this method by name or
+        monkey-patch it directly.  Remove no earlier than two minor
+        releases after the unification PR lands.
+        """
+        return self._attach_payload_transport()
+
+    def _build_redis_endpoint(self) -> Optional[RedisEndpoint]:
+        """Return a :class:`RedisEndpoint` for the worker's Redis, or None.
+
+        Resolves to the live ``redis_controller`` connection coordinates
+        when available, falling back to ``("localhost", 6379, 0)``
+        overridden by ``config.redis`` (port-only, historical).
+        """
         redis_host = "localhost"
         redis_port = 6379
         redis_db = 0
@@ -244,7 +361,7 @@ class CommMixin:
         config = getattr(self, "config", None)
         if config is not None and hasattr(config, "redis") and config.redis:
             redis_port = int(config.redis)
-        return redis_host, redis_port, redis_db
+        return RedisEndpoint(host=redis_host, port=int(redis_port), db=int(redis_db))
 
     def register_to_controller(self):
         if hasattr(self, "_is_registered"):

--- a/cosmos_rl/dispatcher/status.py
+++ b/cosmos_rl/dispatcher/status.py
@@ -13,8 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import json
-import os
 import time
 import math
 from queue import Queue
@@ -28,13 +26,7 @@ from cosmos_rl.dispatcher.replica import Replica, Atom, Rollout
 from cosmos_rl.dispatcher.protocol import Role
 import cosmos_rl.dispatcher.command as command
 from cosmos_rl.utils.redis_stream import RedisStreamHandler
-from cosmos_rl.utils.nccl_transfer_protocol import (
-    NCCL_COMPLETION_PREFIX,
-    build_cleanup_channel,
-    build_nccl_prefix,
-    build_rollout_prefix,
-    build_transfer_rollout_candidates,
-)
+from cosmos_rl.utils.payload_transport import PayloadTransportRegistry
 from cosmos_rl.utils.report.wandb_logger import (
     is_wandb_available,
     log_wandb,
@@ -850,102 +842,54 @@ class PolicyStatusManager:
 
         discarded_count = len(rollouts) - len(filtered_rollouts)
         if discarded_count > 0 and getattr(self, "_nccl_cleanup_enabled", False):
-            self._publish_nccl_cleanup_for_discarded(rollouts, filtered_rollouts)
+            self._publish_payload_transport_cleanup(rollouts, filtered_rollouts)
 
         return filtered_rollouts
 
-    def _publish_nccl_cleanup_for_discarded(
+    def _publish_payload_transport_cleanup(
         self,
         rollouts: List[Rollout],
         filtered: List[Rollout],
     ) -> None:
-        """Publish Redis cleanup for discarded NCCL-bearing rollouts.
+        """Delegate per-transport cleanup dispatch to the registry.
 
-        When NCCL payload transfer is enabled, rollout completions are
-        prefixed with ``nccl:``.  If such rollouts are discarded as outdated,
-        the rollout worker still holds GPU buffers for the pending NCCL send.
-        Publishing a cleanup message lets the worker release them immediately.
+        The grouping/dispatch logic lives in
+        :meth:`PayloadTransportRegistry.handle_discarded`.  This wrapper
+        only resolves the controller's Redis client and preserves the
+        ``_nccl_cleanup_enabled`` "first-detection" flag flip so the
+        existing log behavior is unchanged.
 
-        This is a no-op when no discarded rollouts use NCCL transfer.
+        NOTE: ``_nccl_cleanup_enabled`` carries a known cold-start
+        gating bug introduced in commit 55745c: ``filter_outdated_rollouts``
+        only invokes this method when the flag is already True, but the
+        flag is only flipped True from inside this method, so cleanup
+        is unreachable on cold start.  This refactor preserves the
+        existing behavior; the bug fix is tracked as a separate MR.
         """
-        kept_ids = {id(r) for r in filtered}
-        nccl_transfer_ids: list[str] = []
-        for rollout in rollouts:
-            if id(rollout) in kept_ids:
-                continue
-            completion = getattr(rollout, "completion", None)
-            if isinstance(completion, str) and completion.startswith(
-                NCCL_COMPLETION_PREFIX
-            ):
-                nccl_transfer_ids.append(completion[len(NCCL_COMPLETION_PREFIX) :])
-
-        if not nccl_transfer_ids:
-            return
-
-        if not self._nccl_cleanup_enabled:
+        redis_client = self._resolve_cleanup_redis_client()
+        published = PayloadTransportRegistry.handle_discarded(
+            rollouts,
+            filtered,
+            config=self.config,
+            redis_client=redis_client,
+        )
+        if published and not self._nccl_cleanup_enabled:
             self._nccl_cleanup_enabled = True
             logger.info(
-                "[Controller] Detected nccl:-prefixed rollouts; "
-                "NCCL cleanup publishing is now active."
+                "[Controller] Detected payload-transport-prefixed rollouts; "
+                "transport cleanup publishing is now active."
             )
 
+    def _resolve_cleanup_redis_client(self) -> Any:
+        """Return the controller's Redis client (or None) for cleanup."""
         redis_handler = getattr(self, "redis_handler", None)
         if redis_handler is None:
-            return
-        redis_client = None
+            return None
         if hasattr(redis_handler, "redis_clients") and redis_handler.redis_clients:
-            redis_client = redis_handler.redis_clients[0]
-        elif hasattr(redis_handler, "redis_client"):
-            redis_client = redis_handler.redis_client
-        if redis_client is None:
-            return
-
-        experiment_name = "default"
-        try:
-            experiment_name = self.config.logging.experiment_name
-        except AttributeError:
-            pass
-        job_id = os.environ.get("SLURM_JOB_ID", "test")
-        prefix = build_nccl_prefix(experiment_name=experiment_name, job_id=job_id)
-
-        num_rollout_replicas = None
-        try:
-            num_rollout_replicas = self.config.rollout.parallelism.n_init_replicas
-        except AttributeError:
-            pass
-
-        published = 0
-        max_retries = 3
-        for transfer_id in nccl_transfer_ids:
-            try:
-                rollout_indices = build_transfer_rollout_candidates(
-                    transfer_id=transfer_id,
-                    num_rollout_replicas=num_rollout_replicas,
-                )
-                for rollout_idx in rollout_indices:
-                    channel = build_cleanup_channel(
-                        build_rollout_prefix(prefix, rollout_idx)
-                    )
-                    payload = json.dumps({"transfer_id": transfer_id})
-                    for attempt in range(max_retries):
-                        try:
-                            redis_client.publish(channel, payload)
-                            break
-                        except Exception:
-                            if attempt == max_retries - 1:
-                                raise
-                            time.sleep(0.1 * (attempt + 1))
-                published += 1
-            except Exception as e:
-                logger.debug(
-                    f"[Controller] Failed to publish NCCL cleanup for "
-                    f"transfer {transfer_id[:32]}: {e}"
-                )
-        if published > 0:
-            logger.debug(
-                f"[Controller] Published NCCL cleanup for {published}/"
-                f"{len(nccl_transfer_ids)} discarded transfers"
-            )
+            return redis_handler.redis_clients[0]
+        if hasattr(redis_handler, "redis_client"):
+            return redis_handler.redis_client
+        return None
 
     def sft_report_summary(
         self,

--- a/cosmos_rl/utils/nccl_transfer_protocol.py
+++ b/cosmos_rl/utils/nccl_transfer_protocol.py
@@ -13,118 +13,35 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Redis channel naming protocol for NCCL-based payload transfer.
+"""Backward-compatibility shim.
 
-Background
-----------
-By default, Cosmos-RL transfers rollout completion payloads (token IDs,
-log-probs, etc.) from rollout workers to the controller via Redis streams.
-For workloads with large payloads — such as VLA policies that produce
-high-dimensional action tensors — the Redis path becomes a bottleneck.
-
-**NCCL payload transfer** is an opt-in alternative where the payload
-tensors are sent directly between GPUs using NCCL point-to-point
-operations.  Redis is still used as the *control plane*: rollout workers
-publish transfer requests, the controller acknowledges them, and cleanup
-messages are sent when stale transfers are discarded.
-
-How it works
-------------
-1. A data packer that supports NCCL transfer (e.g. ``TensorDataPacker``)
-   exposes a ``redis_client`` attribute.  ``CommMixin.init_data_packer``
-   injects the worker's live Redis connection into the packer after
-   creation.  The packer then calls ``post_redis_injection()`` to
-   complete any deferred setup (e.g. establishing NCCL communicators).
-
-2. Rollout completions transferred via NCCL have their ``completion``
-   field prefixed with ``nccl:`` followed by a transfer ID.
-
-3. When the controller discards outdated rollouts
-   (``PolicyStatusManager.filter_outdated_rollouts``), it publishes
-   cleanup messages for any ``nccl:``-prefixed completions so the
-   rollout worker can release the associated GPU buffers immediately.
-
-Enabling
---------
-Set ``[custom].nccl_payload_transfer = true`` in the experiment config.
-The data packer must support this feature (see ``BaseDataPacker`` docs).
-
-Redis key convention
---------------------
-All keys are scoped by ``{namespace}:{experiment_name}:{slurm_job_id}``
-so multiple jobs sharing a Redis instance do not collide.
+The contents of this module moved to
+:mod:`cosmos_rl.utils.payload_transport.nccl` as part of the
+payload-transport registry refactor.  This file re-exports the public
+names so existing imports continue to work; new code should import from
+``cosmos_rl.utils.payload_transport.nccl`` directly.
 """
 
-from __future__ import annotations
+from cosmos_rl.utils.payload_transport.nccl import (
+    NCCL_COMPLETION_PREFIX,
+    NCCL_REDIS_NAMESPACE,
+    NcclPayloadTransport,
+    build_cleanup_channel,
+    build_nccl_prefix,
+    build_request_channel,
+    build_rollout_prefix,
+    build_transfer_rollout_candidates,
+    parse_transfer_rollout_idx,
+)
 
-import numbers
-from typing import Any, Optional
-
-NCCL_REDIS_NAMESPACE = "cosmos_rl"
-
-NCCL_COMPLETION_PREFIX = "nccl:"
-
-
-def build_nccl_prefix(*, experiment_name: str, job_id: str) -> str:
-    """Root prefix for all NCCL transfer Redis keys."""
-    return f"{NCCL_REDIS_NAMESPACE}:{experiment_name}:{job_id}"
-
-
-def build_rollout_prefix(prefix: str, rollout_idx: int) -> str:
-    """Per-rollout-replica prefix."""
-    return f"{prefix}:rollout_comm:{rollout_idx}"
-
-
-def build_cleanup_channel(prefix: str) -> str:
-    """Pub/sub channel for cleanup messages."""
-    return f"{prefix}:nccl_cleanup"
-
-
-def build_request_channel(prefix: str) -> str:
-    """Pub/sub channel for transfer requests."""
-    return f"{prefix}:nccl_req"
-
-
-def parse_transfer_rollout_idx(transfer_id: str) -> int:
-    """Extract the rollout index encoded in the transfer ID prefix."""
-    if ":" not in transfer_id:
-        return -1
-    prefix = transfer_id.split(":", maxsplit=1)[0]
-    try:
-        return int(prefix)
-    except ValueError:
-        return -1
-
-
-def build_transfer_rollout_candidates(
-    *,
-    transfer_id: str,
-    num_rollout_replicas: Optional[int] = None,
-) -> list[int]:
-    """Return the canonical rollout index encoded in ``transfer_id``, if valid."""
-    normalized = _coerce_nonnegative_int(num_rollout_replicas)
-    parsed_prefix = parse_transfer_rollout_idx(transfer_id)
-    if parsed_prefix < 0:
-        return []
-    if normalized is not None and parsed_prefix >= normalized:
-        return []
-    return [parsed_prefix]
-
-
-def _coerce_nonnegative_int(value: Any) -> Optional[int]:
-    if value is None:
-        return None
-    if isinstance(value, bool):
-        return None
-    if isinstance(value, numbers.Integral):
-        coerced = int(value)
-    elif isinstance(value, str):
-        try:
-            coerced = int(value)
-        except ValueError:
-            return None
-    else:
-        return None
-    if coerced < 0:
-        return None
-    return coerced
+__all__ = [
+    "NCCL_COMPLETION_PREFIX",
+    "NCCL_REDIS_NAMESPACE",
+    "NcclPayloadTransport",
+    "build_cleanup_channel",
+    "build_nccl_prefix",
+    "build_request_channel",
+    "build_rollout_prefix",
+    "build_transfer_rollout_candidates",
+    "parse_transfer_rollout_idx",
+]

--- a/cosmos_rl/utils/payload_transport/__init__.py
+++ b/cosmos_rl/utils/payload_transport/__init__.py
@@ -1,0 +1,97 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Pluggable payload-transport backends.
+
+By default Cosmos-RL ships rollout completion payloads (token IDs,
+log-probs, reward tensors, …) from rollout workers to the controller via
+**Redis streams**.  For workloads with large payloads, two opt-in
+backends bypass Redis on the data plane:
+
+* **NCCL** — point-to-point GPU sends; Redis still carries control
+  metadata.  See :mod:`cosmos_rl.utils.payload_transport.nccl`.
+* **UCXX** — RDMA / shared-memory zero-copy transfer (added in a
+  follow-up MR).  See ``cosmos_rl.utils.payload_transport.ucxx``.
+
+Selecting a backend
+-------------------
+
+The active backend is read from the experiment config's ``[custom]``
+section using :func:`get_payload_transfer_mode`:
+
+.. code-block:: toml
+
+    # Preferred (string) form:
+    [custom]
+    payload_transfer = "nccl"           # one of "redis", "nccl", "ucxx"
+
+    # Deprecated boolean alias (still honored):
+    [custom]
+    nccl_payload_transfer = true        # equivalent to payload_transfer = "nccl"
+
+The default is ``"redis"`` when neither key is present.
+
+Registering backends
+--------------------
+
+Each backend registers itself with :class:`PayloadTransportRegistry` at
+import time:
+
+.. code-block:: python
+
+    from cosmos_rl.utils.payload_transport import (
+        PayloadTransport, PayloadTransportRegistry,
+    )
+
+    class MyTransport(PayloadTransport):
+        name = "my_transport"
+        completion_prefix = "mytx:"
+        ...
+
+    PayloadTransportRegistry.register(MyTransport)
+
+Cosmos-RL ships ``redis`` (no-op default) and ``nccl`` registered out of
+the box.  ``ucxx`` registers itself when imported.
+"""
+
+from cosmos_rl.utils.payload_transport.registry import (
+    DEFAULT_TRANSFER_MODE,
+    LEGACY_NCCL_KEY,
+    PAYLOAD_TRANSFER_KEY,
+    PayloadTransport,
+    PayloadTransportRegistry,
+    RedisEndpoint,
+    get_payload_transfer_mode,
+    is_payload_transfer_mode_explicit,
+)
+
+# Importing the NCCL submodule registers the backend as a side effect.
+from cosmos_rl.utils.payload_transport import nccl  # noqa: F401
+
+# Redis is the implicit no-op default — it has no side-effects to wire
+# up here, but registering a sentinel keeps lookup uniform.
+PayloadTransportRegistry.register_default_redis()
+
+
+__all__ = [
+    "DEFAULT_TRANSFER_MODE",
+    "LEGACY_NCCL_KEY",
+    "PAYLOAD_TRANSFER_KEY",
+    "PayloadTransport",
+    "PayloadTransportRegistry",
+    "RedisEndpoint",
+    "get_payload_transfer_mode",
+    "is_payload_transfer_mode_explicit",
+]

--- a/cosmos_rl/utils/payload_transport/nccl.py
+++ b/cosmos_rl/utils/payload_transport/nccl.py
@@ -1,0 +1,320 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""NCCL payload-transport backend.
+
+Background
+----------
+By default, Cosmos-RL transfers rollout completion payloads (token IDs,
+log-probs, etc.) from rollout workers to the controller via Redis
+streams.  For workloads with large payloads — such as VLA policies that
+produce high-dimensional action tensors — the Redis path becomes a
+bottleneck.
+
+**NCCL payload transfer** is an opt-in alternative where the payload
+tensors are sent directly between GPUs using NCCL point-to-point
+operations.  Redis is still used as the *control plane*: rollout workers
+publish transfer requests, the controller acknowledges them, and cleanup
+messages are sent when stale transfers are discarded.
+
+How it works
+------------
+1. A data packer that supports NCCL transfer (e.g.
+   ``TensorDataPacker`` in downstream user code) exposes a
+   ``redis_client`` attribute.  ``CommMixin.init_data_packer``
+   injects the worker's live Redis connection into the packer after
+   creation.  The packer then calls ``post_redis_injection()`` to
+   complete any deferred setup (e.g. establishing NCCL communicators).
+
+2. Rollout completions transferred via NCCL have their ``completion``
+   field prefixed with ``nccl:`` followed by a transfer ID.
+
+3. When the controller discards outdated rollouts
+   (``PolicyStatusManager.filter_outdated_rollouts``), it dispatches
+   to :meth:`NcclPayloadTransport.publish_cleanup_for_discarded`
+   (via the registry) so the rollout worker can release the associated
+   GPU buffers immediately.
+
+Enabling
+--------
+Set ``[custom].payload_transfer = "nccl"`` in the experiment config.
+The legacy ``[custom].nccl_payload_transfer = true`` boolean still works
+as a deprecated alias.  The data packer must support this feature
+(see ``BaseDataPacker`` docs in the user guide).
+
+Redis key convention
+--------------------
+All keys are scoped by ``{namespace}:{experiment_name}:{slurm_job_id}``
+so multiple jobs sharing a Redis instance do not collide.
+"""
+
+from __future__ import annotations
+
+import json
+import numbers
+import os
+import time
+from typing import Any, List, Optional
+
+from cosmos_rl.utils.logging import logger
+from cosmos_rl.utils.payload_transport.registry import (
+    PayloadTransport,
+    PayloadTransportRegistry,
+    RedisEndpoint,
+)
+
+try:
+    import redis as _redis_lib
+except ImportError:  # pragma: no cover - exercised only on systems w/o redis
+    _redis_lib = None
+
+
+# ---------------------------------------------------------------------------
+# Wire-protocol constants and key builders
+# ---------------------------------------------------------------------------
+
+NCCL_REDIS_NAMESPACE = "cosmos_rl"
+
+NCCL_COMPLETION_PREFIX = "nccl:"
+
+
+def build_nccl_prefix(*, experiment_name: str, job_id: str) -> str:
+    """Root prefix for all NCCL transfer Redis keys."""
+    return f"{NCCL_REDIS_NAMESPACE}:{experiment_name}:{job_id}"
+
+
+def build_rollout_prefix(prefix: str, rollout_idx: int) -> str:
+    """Per-rollout-replica prefix."""
+    return f"{prefix}:rollout_comm:{rollout_idx}"
+
+
+def build_cleanup_channel(prefix: str) -> str:
+    """Pub/sub channel for cleanup messages."""
+    return f"{prefix}:nccl_cleanup"
+
+
+def build_request_channel(prefix: str) -> str:
+    """Pub/sub channel for transfer requests."""
+    return f"{prefix}:nccl_req"
+
+
+def parse_transfer_rollout_idx(transfer_id: str) -> int:
+    """Extract the rollout index encoded in the transfer ID prefix."""
+    if ":" not in transfer_id:
+        return -1
+    prefix = transfer_id.split(":", maxsplit=1)[0]
+    try:
+        return int(prefix)
+    except ValueError:
+        return -1
+
+
+def build_transfer_rollout_candidates(
+    *,
+    transfer_id: str,
+    num_rollout_replicas: Optional[int] = None,
+) -> List[int]:
+    """Return the canonical rollout index encoded in ``transfer_id``, if valid."""
+    normalized = _coerce_nonnegative_int(num_rollout_replicas)
+    parsed_prefix = parse_transfer_rollout_idx(transfer_id)
+    if parsed_prefix < 0:
+        return []
+    if normalized is not None and parsed_prefix >= normalized:
+        return []
+    return [parsed_prefix]
+
+
+def _coerce_nonnegative_int(value: Any) -> Optional[int]:
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, numbers.Integral):
+        coerced = int(value)
+    elif isinstance(value, str):
+        try:
+            coerced = int(value)
+        except ValueError:
+            return None
+    else:
+        return None
+    if coerced < 0:
+        return None
+    return coerced
+
+
+# ---------------------------------------------------------------------------
+# Backend
+# ---------------------------------------------------------------------------
+
+
+class NcclPayloadTransport(PayloadTransport):
+    """NCCL-based payload-transport backend.
+
+    Identifies its rollouts by the ``nccl:`` completion prefix and
+    publishes cleanup messages on the ``nccl_cleanup`` pub/sub channel
+    when the controller discards rollouts.
+    """
+
+    name = "nccl"
+    completion_prefix = NCCL_COMPLETION_PREFIX
+
+    # ------------------------------------------------------------------
+    # Backward-compat surface for PR #670 / commit 55745c.
+    #
+    # NCCL-aware data packers (notably Yuxiao's ``PolicyDataPacker`` and
+    # any subclass mirroring that pattern) carry an instance attribute
+    # ``redis_client`` initialized to ``None`` and an optional method
+    # ``post_redis_injection()`` that completes deferred setup once the
+    # client is wired in.  The contract that downstream code depends on
+    # is, in this exact order:
+    #
+    #   1. ``packer.redis_client`` is assigned a live ``redis.Redis``
+    #      whose ``ping()`` succeeds.
+    #   2. ``packer.post_redis_injection()`` is called (if defined).
+    #
+    # This contract used to live inline in
+    # ``CommMixin._inject_redis_into_data_packers``.  When you change
+    # the assignment-then-hook order or the ping behavior here, expect
+    # downstream NCCL packer breakage and grep for ``post_redis_injection``
+    # to find affected forks.
+    # ------------------------------------------------------------------
+    def attach_data_packer(
+        self,
+        packer: Any,
+        *,
+        config: Any,
+        device: Any = None,
+        redis_endpoint: Optional[RedisEndpoint] = None,
+    ) -> None:
+        if not hasattr(packer, "redis_client"):
+            return  # not an NCCL-aware packer
+        if redis_endpoint is None:
+            logger.warning(
+                "[NcclPayloadTransport] No Redis endpoint provided; "
+                "cannot attach NCCL data packer"
+            )
+            return
+        if _redis_lib is None:
+            logger.warning(
+                "[NcclPayloadTransport] redis package not installed; "
+                "cannot attach NCCL data packer"
+            )
+            return
+        try:
+            client = _redis_lib.Redis(
+                host=redis_endpoint.host,
+                port=redis_endpoint.port,
+                db=redis_endpoint.db,
+                decode_responses=True,
+            )
+            client.ping()
+        except Exception as exc:
+            logger.warning(
+                f"[NcclPayloadTransport] Redis ping failed at "
+                f"{redis_endpoint.host}:{redis_endpoint.port}/{redis_endpoint.db}: "
+                f"{exc}; skipping NCCL packer attach"
+            )
+            return
+
+        # Step 1: assign client. Downstream code reads this attribute
+        # directly; assignment must complete before step 2.
+        packer.redis_client = client
+
+        # Step 2: call the post-injection hook so the packer can do any
+        # deferred setup (NCCL communicator wiring, channel subscription,
+        # etc.) that depends on the live client.
+        hook = getattr(packer, "post_redis_injection", None)
+        if callable(hook):
+            try:
+                hook()
+            except Exception as exc:
+                # Hook errors are logged but not re-raised so a buggy
+                # downstream packer cannot kill worker init.
+                logger.warning(
+                    f"[NcclPayloadTransport] post_redis_injection raised "
+                    f"{type(exc).__name__}: {exc}; continuing"
+                )
+
+    def publish_cleanup_for_discarded(
+        self,
+        *,
+        transfer_ids: List[str],
+        config: Any,
+        redis_client: Any,
+    ) -> int:
+        if not transfer_ids:
+            return 0
+        if redis_client is None:
+            return 0
+
+        experiment_name = "default"
+        try:
+            experiment_name = config.logging.experiment_name
+        except AttributeError:
+            pass
+        job_id = os.environ.get("SLURM_JOB_ID", "test")
+        prefix = build_nccl_prefix(experiment_name=experiment_name, job_id=job_id)
+
+        num_rollout_replicas: Optional[int] = None
+        try:
+            num_rollout_replicas = config.rollout.parallelism.n_init_replicas
+        except AttributeError:
+            pass
+
+        published = 0
+        max_retries = 3
+        for transfer_id in transfer_ids:
+            try:
+                rollout_indices = build_transfer_rollout_candidates(
+                    transfer_id=transfer_id,
+                    num_rollout_replicas=num_rollout_replicas,
+                )
+                for rollout_idx in rollout_indices:
+                    channel = build_cleanup_channel(
+                        build_rollout_prefix(prefix, rollout_idx)
+                    )
+                    payload = json.dumps({"transfer_id": transfer_id})
+                    for attempt in range(max_retries):
+                        try:
+                            redis_client.publish(channel, payload)
+                            break
+                        except Exception:
+                            if attempt == max_retries - 1:
+                                raise
+                            time.sleep(0.1 * (attempt + 1))
+                published += 1
+            except Exception as e:
+                logger.warning(
+                    f"[NcclPayloadTransport] Failed to publish cleanup for "
+                    f"transfer_id={transfer_id}: {e}"
+                )
+        return published
+
+
+PayloadTransportRegistry.register_class(NcclPayloadTransport)
+
+
+__all__ = [
+    "NCCL_COMPLETION_PREFIX",
+    "NCCL_REDIS_NAMESPACE",
+    "NcclPayloadTransport",
+    "build_cleanup_channel",
+    "build_nccl_prefix",
+    "build_request_channel",
+    "build_rollout_prefix",
+    "build_transfer_rollout_candidates",
+    "parse_transfer_rollout_idx",
+]

--- a/cosmos_rl/utils/payload_transport/registry.py
+++ b/cosmos_rl/utils/payload_transport/registry.py
@@ -1,0 +1,410 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Payload-transport ABC + registry shared by all backends."""
+
+from __future__ import annotations
+
+from abc import ABC
+from typing import Any, Dict, Iterable, List, NamedTuple, Optional, Type
+
+from cosmos_rl.utils.logging import logger
+
+
+# Canonical TOML keys read from the experiment ``[custom]`` section.
+PAYLOAD_TRANSFER_KEY = "payload_transfer"  # preferred string form
+LEGACY_NCCL_KEY = "nccl_payload_transfer"  # deprecated boolean alias
+
+# Active backend when neither key is present.
+DEFAULT_TRANSFER_MODE = "redis"
+
+
+class RedisEndpoint(NamedTuple):
+    """Connection coordinates for a Redis server.
+
+    Passed to :meth:`PayloadTransport.attach_data_packer` so backends
+    that need a Redis control plane (notably NCCL) can construct their
+    own client without re-deriving the endpoint.
+    """
+
+    host: str
+    port: int
+    db: int = 0
+
+
+class PayloadTransport(ABC):
+    """Abstract base class for payload-transport backends.
+
+    Subclasses encapsulate everything cosmos-rl's controller and worker
+    code need to know about a non-default transport:
+
+    * ``name``: backend identifier matched against the
+      ``payload_transfer`` config string.
+    * ``completion_prefix``: optional sentinel prefix attached to the
+      ``completion`` field of rollouts that travel via this transport.
+      ``None`` for the implicit Redis default and for transports that do
+      not participate in controller-side discard cleanup.
+    * :meth:`attach_data_packer`: worker-side hook invoked by
+      ``CommMixin._attach_payload_transport`` once per data packer to
+      give the backend a chance to wire transport-specific state into
+      the packer (e.g. inject a Redis client, allocate ring buffers,
+      start prefetch threads).
+    * :meth:`publish_cleanup_for_discarded`: controller-side hook
+      invoked when outdated rollouts that bear :attr:`completion_prefix`
+      are discarded so the backend can release any reserved resources.
+
+    Both hooks have safe no-op defaults; backends override only what
+    they need.
+    """
+
+    name: str = ""
+    completion_prefix: Optional[str] = None
+
+    # ------------------------------------------------------------------
+    # Worker-side hooks
+    # ------------------------------------------------------------------
+
+    def attach_data_packer(
+        self,
+        packer: Any,
+        *,
+        config: Any,
+        device: Any = None,
+        redis_endpoint: Optional[RedisEndpoint] = None,
+    ) -> None:
+        """Worker-side hook to wire transport state into a data packer.
+
+        Called once per data packer from
+        ``CommMixin._attach_payload_transport`` after the packer has
+        been created and ``setup()`` has been invoked.  Default: no-op
+        (Redis-default transport, and any other transport that needs no
+        per-packer state).
+
+        Args:
+            packer: The data packer instance to attach to.
+            config: The cosmos-rl
+                :class:`~cosmos_rl.policy.config.Config` for this run.
+            device: Optional torch device (or device-like) the packer
+                will run on.  Useful for transports that pre-allocate
+                GPU memory (e.g. UCXX prefetch buffers).
+            redis_endpoint: Optional :class:`RedisEndpoint` describing
+                the worker's Redis connection.  Transports that need a
+                Redis control plane (NCCL) construct their own client
+                from this; transports that do not (UCXX, redis default)
+                ignore it.
+        """
+
+    # ------------------------------------------------------------------
+    # Controller-side hooks
+    # ------------------------------------------------------------------
+
+    def publish_cleanup_for_discarded(
+        self,
+        *,
+        transfer_ids: List[str],
+        config: Any,
+        redis_client: Any,
+    ) -> int:
+        """Publish cleanup messages for discarded rollouts.
+
+        Default: no-op returning ``0``.  Override only when the
+        transport holds resources on the producer side that the
+        controller must signal to release (e.g. NCCL's pinned GPU
+        send buffers).  Transports that auto-recycle on the producer
+        side (UCXX SHM ring buffers, Redis streams) inherit the no-op.
+
+        Args:
+            transfer_ids: List of opaque transport-side transfer ids
+                extracted from discarded rollouts (with
+                :attr:`completion_prefix` already stripped).
+            config: The cosmos-rl :class:`~cosmos_rl.policy.config.Config`.
+            redis_client: A connected Redis client.
+
+        Returns:
+            Number of cleanup messages successfully published.
+        """
+        return 0
+
+
+class _RedisDefaultTransport(PayloadTransport):
+    """Sentinel transport for the implicit Redis default.
+
+    Redis is the data plane *and* the control plane for the default
+    transfer path — there is nothing extra to publish on cleanup, and
+    no per-packer attachment is needed.  Inherits the no-op defaults
+    for both :meth:`attach_data_packer` and
+    :meth:`publish_cleanup_for_discarded`.
+    """
+
+    name = "redis"
+    completion_prefix = None
+
+
+class PayloadTransportRegistry:
+    """Singleton-style registry for :class:`PayloadTransport` backends.
+
+    Backends register at import time (typically in their submodule's
+    top-level body).  Two lookup helpers are provided:
+
+    * :meth:`get` — look up a single backend by name (raises if not
+      registered, since misconfiguration should fail loudly).
+    * :meth:`active_for_completion` — given a completion string,
+      return the matching backend by ``completion_prefix``.  Used by the
+      controller to dispatch cleanup for rollouts it discards.
+    """
+
+    _registry: Dict[str, PayloadTransport] = {}
+
+    @classmethod
+    def register(cls, transport: PayloadTransport) -> None:
+        if not transport.name:
+            raise ValueError("PayloadTransport must declare a non-empty name attribute")
+        existing = cls._registry.get(transport.name)
+        if existing is not None and existing is not transport:
+            logger.debug(
+                f"PayloadTransport '{transport.name}' re-registered; "
+                "replacing previous instance"
+            )
+        cls._registry[transport.name] = transport
+
+    @classmethod
+    def register_class(cls, transport_cls: Type[PayloadTransport]) -> None:
+        """Convenience: instantiate ``transport_cls`` with no args and register."""
+        cls.register(transport_cls())
+
+    @classmethod
+    def register_default_redis(cls) -> None:
+        """Idempotently register the implicit Redis sentinel."""
+        if "redis" not in cls._registry:
+            cls._registry["redis"] = _RedisDefaultTransport()
+
+    @classmethod
+    def get(cls, name: str) -> PayloadTransport:
+        try:
+            return cls._registry[name]
+        except KeyError as e:
+            raise KeyError(
+                f"PayloadTransport '{name}' is not registered. "
+                f"Available: {sorted(cls._registry)}"
+            ) from e
+
+    @classmethod
+    def get_optional(cls, name: str) -> Optional[PayloadTransport]:
+        return cls._registry.get(name)
+
+    @classmethod
+    def all_with_completion_prefix(cls) -> Iterable[PayloadTransport]:
+        """Iterate over registered backends that mark their completions."""
+        for transport in cls._registry.values():
+            if transport.completion_prefix:
+                yield transport
+
+    @classmethod
+    def active_for_completion(cls, completion: Any) -> Optional[PayloadTransport]:
+        """Return the backend whose ``completion_prefix`` matches ``completion``.
+
+        Returns ``None`` for non-string completions, completions without
+        a registered prefix, or when no backend has a prefix attribute.
+        """
+        if not isinstance(completion, str):
+            return None
+        for transport in cls.all_with_completion_prefix():
+            if completion.startswith(transport.completion_prefix):
+                return transport
+        return None
+
+    @classmethod
+    def reset(cls) -> None:
+        """Wipe the registry.  Useful for tests."""
+        cls._registry.clear()
+
+    @classmethod
+    def handle_discarded(
+        cls,
+        rollouts: List[Any],
+        filtered: List[Any],
+        *,
+        config: Any,
+        redis_client: Any,
+    ) -> int:
+        """Centralized controller-side cleanup dispatch for discards.
+
+        Replaces the inline grouping logic that previously lived in
+        ``PolicyStatusManager._publish_payload_transport_cleanup``.
+        Identifies which discarded rollouts (those in ``rollouts`` but
+        not in ``filtered``) belong to which transport via
+        :meth:`active_for_completion`, then invokes each matched
+        transport's :meth:`PayloadTransport.publish_cleanup_for_discarded`.
+
+        Transports with ``completion_prefix=None`` (e.g. UCXX, the
+        default Redis transport) are skipped automatically because
+        :meth:`active_for_completion` only matches non-None prefixes.
+
+        Failures in one transport are isolated — the remaining
+        transports still get a chance to publish cleanup.
+
+        Args:
+            rollouts: All rollouts considered for filtering this batch.
+            filtered: Subset of ``rollouts`` that survived filtering.
+                Rollouts in ``rollouts`` but not in ``filtered`` are the
+                "discarded" set this method publishes cleanup for.
+            config: The cosmos-rl
+                :class:`~cosmos_rl.policy.config.Config` for the run.
+            redis_client: A connected Redis client used by transports
+                whose cleanup channel rides on Redis pub/sub.  Pass
+                ``None`` for transports that do not need it.
+
+        Returns:
+            Total number of cleanup messages successfully published
+            across all transports.  Returns ``0`` if there are no
+            discards or no rollouts match a registered prefix.
+        """
+        if not rollouts or len(filtered) == len(rollouts):
+            return 0
+
+        kept_ids = {id(r) for r in filtered}
+        per_transport: Dict[PayloadTransport, List[str]] = {}
+        for rollout in rollouts:
+            if id(rollout) in kept_ids:
+                continue
+            completion = getattr(rollout, "completion", None)
+            transport = cls.active_for_completion(completion)
+            if transport is None:
+                continue
+            transfer_id = completion[len(transport.completion_prefix) :]
+            per_transport.setdefault(transport, []).append(transfer_id)
+
+        if not per_transport:
+            return 0
+
+        total_published = 0
+        for transport, transfer_ids in per_transport.items():
+            try:
+                published = transport.publish_cleanup_for_discarded(
+                    transfer_ids=transfer_ids,
+                    config=config,
+                    redis_client=redis_client,
+                )
+            except Exception as exc:
+                # Isolate failures: a buggy/unresponsive transport
+                # should not prevent other transports from publishing
+                # cleanup for their own discards.
+                logger.debug(
+                    f"[PayloadTransportRegistry] {transport.name} cleanup "
+                    f"raised {type(exc).__name__}: {exc}"
+                )
+                continue
+            if published:
+                total_published += published
+                logger.debug(
+                    f"[PayloadTransportRegistry] Published {transport.name} "
+                    f"cleanup for {published}/{len(transfer_ids)} discarded transfers"
+                )
+
+        return total_published
+
+
+# ---------------------------------------------------------------------------
+# Config-side helpers
+# ---------------------------------------------------------------------------
+
+
+def get_payload_transfer_mode(config: Any) -> str:
+    """Return the active payload-transfer mode for ``config``.
+
+    Resolution order:
+
+    1. ``config.custom.payload_transfer`` (string).  Authoritative when
+       set.  Validated against the registry; misspellings fail fast.
+    2. ``config.custom.nccl_payload_transfer`` (boolean).  **Deprecated**
+       alias retained for backward compatibility — ``True`` resolves to
+       ``"nccl"``, ``False`` to the default.
+    3. :data:`DEFAULT_TRANSFER_MODE` (``"redis"``).
+
+    Args:
+        config: A cosmos-rl :class:`~cosmos_rl.policy.config.Config`-like
+            object whose ``custom`` attribute is a mapping.
+
+    Returns:
+        The resolved transport name.
+    """
+    custom = getattr(config, "custom", None) or {}
+    try:
+        explicit = custom.get(PAYLOAD_TRANSFER_KEY)
+    except AttributeError:
+        explicit = None
+
+    if isinstance(explicit, str) and explicit:
+        normalized = explicit.strip().lower()
+        if PayloadTransportRegistry.get_optional(normalized) is None:
+            raise ValueError(
+                f"[custom].{PAYLOAD_TRANSFER_KEY}={explicit!r} is not a "
+                f"registered payload transport. Available: "
+                f"{sorted(PayloadTransportRegistry._registry)}"
+            )
+        return normalized
+
+    try:
+        legacy = custom.get(LEGACY_NCCL_KEY)
+    except AttributeError:
+        legacy = None
+
+    if legacy:
+        logger.warning(
+            f"[custom].{LEGACY_NCCL_KEY} is deprecated; use "
+            f'[custom].{PAYLOAD_TRANSFER_KEY} = "nccl" instead.'
+        )
+        return "nccl"
+
+    return DEFAULT_TRANSFER_MODE
+
+
+def is_payload_transfer_mode_explicit(config: Any) -> bool:
+    """Return True iff the user explicitly selected a transport in config.
+
+    "Explicit" means either ``[custom].payload_transfer = "<name>"`` or
+    the legacy ``[custom].nccl_payload_transfer = true`` is set.  When
+    neither is present, :func:`get_payload_transfer_mode` falls back to
+    :data:`DEFAULT_TRANSFER_MODE` and this function returns ``False``.
+
+    Used by ``CommMixin._attach_payload_transport`` to decide whether
+    a transport-attach failure should be fatal (user opted in and
+    expects it to work) or merely a warning (transport happened to be
+    registered passively).
+    """
+    custom = getattr(config, "custom", None) or {}
+    try:
+        explicit = custom.get(PAYLOAD_TRANSFER_KEY)
+    except AttributeError:
+        explicit = None
+    if isinstance(explicit, str) and explicit.strip():
+        return True
+    try:
+        legacy = custom.get(LEGACY_NCCL_KEY)
+    except AttributeError:
+        legacy = None
+    return bool(legacy)
+
+
+__all__ = [
+    "DEFAULT_TRANSFER_MODE",
+    "LEGACY_NCCL_KEY",
+    "PAYLOAD_TRANSFER_KEY",
+    "PayloadTransport",
+    "PayloadTransportRegistry",
+    "RedisEndpoint",
+    "get_payload_transfer_mode",
+    "is_payload_transfer_mode_explicit",
+]

--- a/tests/test_comm_base_attach.py
+++ b/tests/test_comm_base_attach.py
@@ -1,0 +1,335 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Regression tests for the 55745c NCCL packer contract through the
+unified ``CommMixin._attach_payload_transport`` integration path.
+
+These tests exist as a separate file (rather than in
+``test_payload_transport.py``) because they exercise the full call
+path from ``CommMixin`` -> ``PayloadTransportRegistry`` ->
+``NcclPayloadTransport.attach_data_packer`` -> packer state.  They
+guard against breaking downstream NCCL packers (notably Yuxiao's
+``PolicyDataPacker``) when refactoring the data-packer attachment
+flow.
+"""
+
+import unittest
+from types import SimpleNamespace
+from unittest import mock
+
+from cosmos_rl.comm.base import CommMixin
+from cosmos_rl.utils.payload_transport import (
+    PAYLOAD_TRANSFER_KEY,
+    PayloadTransportRegistry,
+)
+
+
+class _NcclAwarePacker:
+    """Mirrors the 55745c contract.
+
+    Note ``redis_client`` starts None; ``post_redis_injection`` records
+    what value was set on the instance at the moment the hook ran so
+    tests can assert the assignment-then-hook order.
+    """
+
+    def __init__(self):
+        self.redis_client = None
+        self.post_called = False
+        self.client_at_post_call = None
+
+    def post_redis_injection(self):
+        self.client_at_post_call = self.redis_client
+        self.post_called = True
+
+
+class _NoOpPacker:
+    """Packer with no ``redis_client`` attribute -- attach must skip it."""
+
+
+class _FakeRedis:
+    def __init__(self, *, ping_raises=None):
+        self._ping_raises = ping_raises
+        self.pinged = False
+
+    def ping(self):
+        self.pinged = True
+        if self._ping_raises is not None:
+            raise self._ping_raises
+        return True
+
+
+class _FakeRedisFactory:
+    def __init__(self, fake):
+        self.fake = fake
+        self.calls = []
+
+    def __call__(self, **kwargs):
+        self.calls.append(kwargs)
+        return self.fake
+
+
+class _CommHarness(CommMixin):
+    """Minimal CommMixin host that bypasses init_data_packer machinery.
+
+    The full ``init_data_packer`` flow requires heavy dependencies
+    (transformers, model configs, distributed state) that these tests
+    do not need to exercise.  This harness attaches the packer(s) and
+    a minimal ``config`` directly so we can call
+    ``_attach_payload_transport`` in isolation.
+    """
+
+    def __init__(self, *, mode, data_packer, val_data_packer=None):
+        self.role = "test_role"
+        self.config = SimpleNamespace(custom={PAYLOAD_TRANSFER_KEY: mode})
+        self.data_packer = data_packer
+        if val_data_packer is not None:
+            self.val_data_packer = val_data_packer
+
+    # No real Redis controller; ``_build_redis_endpoint`` will fall
+    # back to a synthetic localhost endpoint, which the patched
+    # ``_redis_lib`` factory accepts.
+
+
+class TestAttachPayloadTransportContract(unittest.TestCase):
+    """Full-integration regression guards for the 55745c contract."""
+
+    def _patch_nccl_redis(self, fake_factory):
+        return mock.patch(
+            "cosmos_rl.utils.payload_transport.nccl._redis_lib",
+            SimpleNamespace(Redis=fake_factory),
+        )
+
+    def test_assignment_then_hook_order_via_attach(self):
+        # Drives the full integration: CommMixin -> registry -> NCCL
+        # transport -> packer.  Asserts the assignment-then-hook order
+        # that downstream NCCL packers depend on (PR #670, 55745c).
+        packer = _NcclAwarePacker()
+        fake = _FakeRedis()
+        factory = _FakeRedisFactory(fake)
+        harness = _CommHarness(mode="nccl", data_packer=packer)
+        with self._patch_nccl_redis(factory):
+            harness._attach_payload_transport()
+        self.assertIs(packer.redis_client, fake)
+        self.assertTrue(packer.post_called)
+        # Order assertion: the hook saw the assigned client.
+        self.assertIs(packer.client_at_post_call, fake)
+
+    def test_ping_failure_leaves_packer_unchanged(self):
+        # If Redis ping fails, the packer must not be left in a half-
+        # configured state (assigned client without a working ping).
+        packer = _NcclAwarePacker()
+        fake = _FakeRedis(ping_raises=ConnectionError("nope"))
+        factory = _FakeRedisFactory(fake)
+        harness = _CommHarness(mode="nccl", data_packer=packer)
+        with self._patch_nccl_redis(factory):
+            harness._attach_payload_transport()
+        self.assertIsNone(packer.redis_client)
+        self.assertFalse(packer.post_called)
+
+    def test_non_redis_aware_packer_untouched(self):
+        # Packers that don't expose a redis_client attribute must not
+        # be modified by the attach flow.
+        packer = _NoOpPacker()
+        fake = _FakeRedis()
+        factory = _FakeRedisFactory(fake)
+        harness = _CommHarness(mode="nccl", data_packer=packer)
+        with self._patch_nccl_redis(factory):
+            harness._attach_payload_transport()
+        self.assertFalse(hasattr(packer, "redis_client"))
+        # No client construction was attempted (NCCL attach skipped early).
+        self.assertEqual(factory.calls, [])
+
+    def test_deprecation_shim_routes_through_attach(self):
+        # _inject_redis_into_data_packers must remain a one-line shim
+        # that produces the same observable outcome as the new entry
+        # point.  Downstream forks may still call this name.
+        packer = _NcclAwarePacker()
+        fake = _FakeRedis()
+        factory = _FakeRedisFactory(fake)
+        harness = _CommHarness(mode="nccl", data_packer=packer)
+        with self._patch_nccl_redis(factory):
+            harness._inject_redis_into_data_packers()
+        self.assertIs(packer.redis_client, fake)
+        self.assertTrue(packer.post_called)
+
+    def test_explicit_mode_with_failing_attach_raises(self):
+        # explicit_fatal failure policy: when the user explicitly sets
+        # payload_transfer in config and the transport's attach raises
+        # ImportError/RuntimeError, the failure must propagate.
+        class _ExplodingTransport:
+            name = "_test_explode"
+            completion_prefix = None
+
+            def attach_data_packer(self, packer, **kwargs):
+                raise RuntimeError("attach exploded")
+
+        explode = _ExplodingTransport()
+        try:
+            PayloadTransportRegistry.register(explode)
+            packer = _NoOpPacker()
+            harness = _CommHarness(mode="_test_explode", data_packer=packer)
+            with self.assertRaises(RuntimeError):
+                harness._attach_payload_transport()
+        finally:
+            PayloadTransportRegistry._registry.pop("_test_explode", None)
+
+    def test_inferred_mode_with_failing_attach_warns(self):
+        # When the active mode came from the default fallback (NOT
+        # user-explicit), an attach failure must be logged-and-swallowed
+        # rather than re-raised.  This is the warn-and-continue branch
+        # of the explicit_fatal policy.
+        class _SneakyTransport:
+            """Reuses a default-resolved name ("redis") to ensure the
+            mode is inferred, not explicit, from the harness config."""
+
+            name = "redis"
+            completion_prefix = None
+            attach_calls = 0
+
+            def attach_data_packer(self, packer, **kwargs):
+                type(self).attach_calls += 1
+                raise RuntimeError("attach exploded but should be swallowed")
+
+        original = PayloadTransportRegistry._registry.get("redis")
+        try:
+            PayloadTransportRegistry._registry["redis"] = _SneakyTransport()
+            # Build a harness whose config does NOT explicitly set
+            # payload_transfer -- triggers the inferred-mode branch.
+            harness = _CommHarness(mode=None, data_packer=_NoOpPacker())
+            harness.config = SimpleNamespace(custom={})  # no explicit key
+            # Must NOT raise even though attach raised.
+            harness._attach_payload_transport()
+            self.assertEqual(_SneakyTransport.attach_calls, 1)
+        finally:
+            if original is not None:
+                PayloadTransportRegistry._registry["redis"] = original
+            else:
+                PayloadTransportRegistry._registry.pop("redis", None)
+
+    def test_attach_visits_val_data_packer_when_distinct(self):
+        # Both data packer and val_data_packer must receive the attach
+        # call when they are distinct instances.
+        train = _NcclAwarePacker()
+        val = _NcclAwarePacker()
+        fake = _FakeRedis()
+        factory = _FakeRedisFactory(fake)
+        harness = _CommHarness(mode="nccl", data_packer=train, val_data_packer=val)
+        with self._patch_nccl_redis(factory):
+            harness._attach_payload_transport()
+        self.assertIs(train.redis_client, fake)
+        self.assertIs(val.redis_client, fake)
+        self.assertTrue(train.post_called)
+        self.assertTrue(val.post_called)
+
+    def test_attach_skips_val_data_packer_when_same_object(self):
+        # Avoid double-attaching when val_data_packer is the same
+        # instance as data_packer.
+        shared = _NcclAwarePacker()
+        fake = _FakeRedis()
+        factory = _FakeRedisFactory(fake)
+        harness = _CommHarness(mode="nccl", data_packer=shared, val_data_packer=shared)
+        with self._patch_nccl_redis(factory):
+            harness._attach_payload_transport()
+        # post_redis_injection should fire exactly once even though both
+        # slots point at the same object.
+        self.assertIs(shared.redis_client, fake)
+        # Sanity: factory was invoked exactly once for the shared packer.
+        self.assertEqual(len(factory.calls), 1)
+
+
+class TestOpportunisticRedisInjection(unittest.TestCase):
+    """The non-NCCL compat fallback in ``_attach_payload_transport``.
+
+    Compatibility surface (2): pre-55745c convention allowed downstream
+    packers to receive a Redis client even when NCCL was not selected.
+    The fallback preserves that for the redis-default mode while
+    explicitly skipping NCCL mode (to avoid double-injection).
+    """
+
+    def _patch_comm_redis(self, fake_factory):
+        return mock.patch(
+            "cosmos_rl.comm.base._redis_lib",
+            SimpleNamespace(Redis=fake_factory),
+        )
+
+    def test_fires_for_redis_default_mode(self):
+        packer = _NcclAwarePacker()
+        fake = _FakeRedis()
+        factory = _FakeRedisFactory(fake)
+        # Mode = "redis" (default).  Attach is no-op for the default
+        # transport, so the only path that can wire redis_client is the
+        # opportunistic fallback.
+        harness = _CommHarness(mode="redis", data_packer=packer)
+        with self._patch_comm_redis(factory):
+            harness._attach_payload_transport()
+        self.assertIs(packer.redis_client, fake)
+        self.assertTrue(packer.post_called)
+
+    def test_skipped_for_nccl_mode_to_avoid_double_inject(self):
+        # In NCCL mode the NCCL transport's attach is responsible for
+        # the assignment.  The opportunistic fallback must NOT also
+        # fire, otherwise downstream packers see two different clients
+        # depending on which call wins.
+        packer = _NcclAwarePacker()
+
+        # Track all client constructions across both code paths so we
+        # can assert exactly one client was made.
+        all_calls = []
+
+        def _factory(**kwargs):
+            all_calls.append(kwargs)
+            return _FakeRedis()
+
+        with (
+            mock.patch(
+                "cosmos_rl.utils.payload_transport.nccl._redis_lib",
+                SimpleNamespace(Redis=_factory),
+            ),
+            mock.patch(
+                "cosmos_rl.comm.base._redis_lib",
+                SimpleNamespace(Redis=_factory),
+            ),
+        ):
+            harness = _CommHarness(mode="nccl", data_packer=packer)
+            harness._attach_payload_transport()
+        # Exactly one client construction (NCCL's), not two.
+        self.assertEqual(len(all_calls), 1)
+
+    def test_skipped_when_packer_already_has_client(self):
+        # If something else already wired in a client, the
+        # opportunistic fallback must not stomp on it.
+        sentinel = object()
+
+        class _PreWiredPacker:
+            def __init__(self):
+                self.redis_client = sentinel
+                self.post_called = False
+
+            def post_redis_injection(self):
+                self.post_called = True
+
+        packer = _PreWiredPacker()
+        fake = _FakeRedis()
+        factory = _FakeRedisFactory(fake)
+        harness = _CommHarness(mode="redis", data_packer=packer)
+        with self._patch_comm_redis(factory):
+            harness._attach_payload_transport()
+        # Pre-existing client preserved, no replacement.
+        self.assertIs(packer.redis_client, sentinel)
+        self.assertFalse(packer.post_called)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_payload_transport.py
+++ b/tests/test_payload_transport.py
@@ -1,0 +1,577 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the payload-transport registry refactor (MR3a).
+
+These tests validate:
+
+1. The default Redis backend and the new NCCL backend are registered
+   out of the box.
+2. ``get_payload_transfer_mode`` honors both the new
+   ``[custom].payload_transfer`` string and the deprecated
+   ``[custom].nccl_payload_transfer`` boolean.
+3. The legacy ``cosmos_rl.utils.nccl_transfer_protocol`` module still
+   re-exports the public names so external importers do not break.
+4. The unified worker-side hook ``PayloadTransport.attach_data_packer``
+   preserves the 55745c contract for NCCL-aware data packers (assign
+   ``redis_client`` then call ``post_redis_injection``) and degrades
+   safely on Redis ping failure.
+5. The unified controller-side dispatch
+   ``PayloadTransportRegistry.handle_discarded`` partitions discards
+   correctly by completion prefix, isolates per-transport failures,
+   and skips transports with ``completion_prefix=None``.
+"""
+
+import unittest
+from types import SimpleNamespace
+from unittest import mock
+
+from cosmos_rl.utils.payload_transport import (
+    PAYLOAD_TRANSFER_KEY,
+    LEGACY_NCCL_KEY,
+    PayloadTransport,
+    PayloadTransportRegistry,
+    RedisEndpoint,
+    get_payload_transfer_mode,
+    is_payload_transfer_mode_explicit,
+)
+from cosmos_rl.utils.payload_transport.nccl import (
+    NCCL_COMPLETION_PREFIX,
+    NcclPayloadTransport,
+    build_cleanup_channel,
+    build_nccl_prefix,
+    build_rollout_prefix,
+    build_transfer_rollout_candidates,
+)
+
+
+class TestRegistryBootstrap(unittest.TestCase):
+    def test_default_redis_registered(self):
+        transport = PayloadTransportRegistry.get("redis")
+        self.assertIsInstance(transport, PayloadTransport)
+        self.assertEqual(transport.name, "redis")
+        self.assertIsNone(transport.completion_prefix)
+
+    def test_nccl_registered(self):
+        transport = PayloadTransportRegistry.get("nccl")
+        self.assertIsInstance(transport, NcclPayloadTransport)
+        self.assertEqual(transport.completion_prefix, NCCL_COMPLETION_PREFIX)
+
+    def test_unknown_lookup_raises(self):
+        with self.assertRaises(KeyError):
+            PayloadTransportRegistry.get("definitely_not_registered")
+
+    def test_get_optional_returns_none_for_unknown(self):
+        self.assertIsNone(
+            PayloadTransportRegistry.get_optional("definitely_not_registered")
+        )
+
+    def test_active_for_completion_matches_nccl_prefix(self):
+        transport = PayloadTransportRegistry.active_for_completion("nccl:0:abcdef")
+        self.assertIsInstance(transport, NcclPayloadTransport)
+
+    def test_active_for_completion_returns_none_for_plain_text(self):
+        self.assertIsNone(PayloadTransportRegistry.active_for_completion("hello world"))
+
+    def test_active_for_completion_rejects_non_string(self):
+        self.assertIsNone(PayloadTransportRegistry.active_for_completion(None))
+        self.assertIsNone(PayloadTransportRegistry.active_for_completion(42))
+
+
+class TestGetPayloadTransferMode(unittest.TestCase):
+    def test_default_when_custom_empty(self):
+        config = SimpleNamespace(custom={})
+        self.assertEqual(get_payload_transfer_mode(config), "redis")
+
+    def test_default_when_custom_missing(self):
+        config = SimpleNamespace()
+        self.assertEqual(get_payload_transfer_mode(config), "redis")
+
+    def test_string_form_redis(self):
+        config = SimpleNamespace(custom={PAYLOAD_TRANSFER_KEY: "redis"})
+        self.assertEqual(get_payload_transfer_mode(config), "redis")
+
+    def test_string_form_nccl(self):
+        config = SimpleNamespace(custom={PAYLOAD_TRANSFER_KEY: "nccl"})
+        self.assertEqual(get_payload_transfer_mode(config), "nccl")
+
+    def test_string_form_normalized(self):
+        # Capitalization / whitespace shouldn't matter -- normalization
+        # avoids spurious config-error noise.
+        config = SimpleNamespace(custom={PAYLOAD_TRANSFER_KEY: "  NCCL  "})
+        self.assertEqual(get_payload_transfer_mode(config), "nccl")
+
+    def test_legacy_boolean_resolves_to_nccl(self):
+        config = SimpleNamespace(custom={LEGACY_NCCL_KEY: True})
+        self.assertEqual(get_payload_transfer_mode(config), "nccl")
+
+    def test_legacy_boolean_false_falls_back_to_default(self):
+        config = SimpleNamespace(custom={LEGACY_NCCL_KEY: False})
+        self.assertEqual(get_payload_transfer_mode(config), "redis")
+
+    def test_string_form_takes_precedence_over_legacy(self):
+        # If both are set, the explicit string form wins.
+        config = SimpleNamespace(
+            custom={
+                PAYLOAD_TRANSFER_KEY: "redis",
+                LEGACY_NCCL_KEY: True,
+            }
+        )
+        self.assertEqual(get_payload_transfer_mode(config), "redis")
+
+    def test_unknown_string_raises(self):
+        config = SimpleNamespace(custom={PAYLOAD_TRANSFER_KEY: "carrier_pigeon"})
+        with self.assertRaises(ValueError):
+            get_payload_transfer_mode(config)
+
+
+class TestNcclProtocolHelpers(unittest.TestCase):
+    """Lightweight regression tests for the NCCL protocol helpers."""
+
+    def test_build_nccl_prefix(self):
+        self.assertEqual(
+            build_nccl_prefix(experiment_name="exp", job_id="42"),
+            "cosmos_rl:exp:42",
+        )
+
+    def test_build_rollout_prefix_and_channels(self):
+        prefix = build_nccl_prefix(experiment_name="exp", job_id="42")
+        rprefix = build_rollout_prefix(prefix, 7)
+        self.assertEqual(rprefix, "cosmos_rl:exp:42:rollout_comm:7")
+        self.assertEqual(
+            build_cleanup_channel(rprefix),
+            "cosmos_rl:exp:42:rollout_comm:7:nccl_cleanup",
+        )
+
+    def test_build_transfer_rollout_candidates_valid(self):
+        ids = build_transfer_rollout_candidates(
+            transfer_id="3:abcdef", num_rollout_replicas=4
+        )
+        self.assertEqual(ids, [3])
+
+    def test_build_transfer_rollout_candidates_out_of_range(self):
+        ids = build_transfer_rollout_candidates(
+            transfer_id="9:abcdef", num_rollout_replicas=4
+        )
+        self.assertEqual(ids, [])
+
+    def test_build_transfer_rollout_candidates_invalid(self):
+        ids = build_transfer_rollout_candidates(transfer_id="garbage")
+        self.assertEqual(ids, [])
+
+
+class TestNcclTransportPublishCleanup(unittest.TestCase):
+    class _FakeRedis:
+        def __init__(self):
+            self.published = []
+
+        def publish(self, channel, payload):
+            self.published.append((channel, payload))
+
+    def test_publish_cleanup_routes_to_correct_channel(self):
+        transport = NcclPayloadTransport()
+        redis = self._FakeRedis()
+        config = SimpleNamespace(
+            logging=SimpleNamespace(experiment_name="exp"),
+            rollout=SimpleNamespace(parallelism=SimpleNamespace(n_init_replicas=4)),
+        )
+        n = transport.publish_cleanup_for_discarded(
+            transfer_ids=["2:abc", "3:def"],
+            config=config,
+            redis_client=redis,
+        )
+        self.assertEqual(n, 2)
+        # Two transfer ids → two messages, one per replica index.
+        self.assertEqual(len(redis.published), 2)
+        channels = {ch for ch, _ in redis.published}
+        self.assertIn("cosmos_rl:exp:test:rollout_comm:2:nccl_cleanup", channels)
+        self.assertIn("cosmos_rl:exp:test:rollout_comm:3:nccl_cleanup", channels)
+
+    def test_publish_cleanup_no_redis_is_safe(self):
+        transport = NcclPayloadTransport()
+        n = transport.publish_cleanup_for_discarded(
+            transfer_ids=["0:abc"], config=SimpleNamespace(), redis_client=None
+        )
+        self.assertEqual(n, 0)
+
+    def test_publish_cleanup_empty_list_skips_redis(self):
+        transport = NcclPayloadTransport()
+        redis = self._FakeRedis()
+        n = transport.publish_cleanup_for_discarded(
+            transfer_ids=[], config=SimpleNamespace(), redis_client=redis
+        )
+        self.assertEqual(n, 0)
+        self.assertEqual(redis.published, [])
+
+
+class TestBackwardCompatShim(unittest.TestCase):
+    def test_legacy_module_reexports(self):
+        # ``cosmos_rl.utils.nccl_transfer_protocol`` was renamed to
+        # ``cosmos_rl.utils.payload_transport.nccl`` -- the old path
+        # must continue to work for existing importers.
+        import cosmos_rl.utils.nccl_transfer_protocol as legacy
+
+        self.assertEqual(legacy.NCCL_COMPLETION_PREFIX, "nccl:")
+        self.assertEqual(
+            legacy.build_nccl_prefix(experiment_name="exp", job_id="42"),
+            "cosmos_rl:exp:42",
+        )
+        # Same class instance is reachable through both paths.
+        self.assertIs(legacy.NcclPayloadTransport, NcclPayloadTransport)
+
+
+# ---------------------------------------------------------------------------
+# MR3a unification tests
+# ---------------------------------------------------------------------------
+
+
+class _FakeRedis:
+    """Minimal redis.Redis substitute that records ping/publish calls."""
+
+    def __init__(self, *, ping_raises=None):
+        self._ping_raises = ping_raises
+        self.pinged = False
+        self.published = []
+
+    def ping(self):
+        self.pinged = True
+        if self._ping_raises is not None:
+            raise self._ping_raises
+        return True
+
+    def publish(self, channel, payload):
+        self.published.append((channel, payload))
+
+
+class _FakeRedisFactory:
+    """Stand-in for ``redis.Redis`` that returns a configured fake."""
+
+    def __init__(self, fake):
+        self.fake = fake
+        self.calls = []
+
+    def __call__(self, **kwargs):
+        self.calls.append(kwargs)
+        return self.fake
+
+
+class _NcclAwarePacker:
+    """Mirrors the 55745c contract: redis_client + post_redis_injection."""
+
+    def __init__(self):
+        self.redis_client = None
+        self.post_called = False
+        self.client_at_post_call = None
+
+    def post_redis_injection(self):
+        # Capture state at hook time to assert the assignment-then-hook
+        # ordering in tests.
+        self.client_at_post_call = self.redis_client
+        self.post_called = True
+
+
+class _NoOpPacker:
+    """Packer with no redis_client attribute -- attach must be a no-op."""
+
+
+class TestNcclAttachDataPacker(unittest.TestCase):
+    """Regression guards for the 55745c NCCL packer contract."""
+
+    def setUp(self):
+        self.endpoint = RedisEndpoint(host="r.example", port=6380, db=2)
+        self.config = SimpleNamespace(custom={})
+        self.transport = NcclPayloadTransport()
+
+    def _patch_redis_lib(self, fake_factory):
+        return mock.patch(
+            "cosmos_rl.utils.payload_transport.nccl._redis_lib",
+            SimpleNamespace(Redis=fake_factory),
+        )
+
+    def test_attach_assigns_redis_client_then_calls_post_hook(self):
+        # Regression guard for the 55745c contract: assignment must
+        # complete before post_redis_injection() is called.
+        packer = _NcclAwarePacker()
+        fake = _FakeRedis()
+        factory = _FakeRedisFactory(fake)
+        with self._patch_redis_lib(factory):
+            self.transport.attach_data_packer(
+                packer,
+                config=self.config,
+                redis_endpoint=self.endpoint,
+            )
+        self.assertIs(packer.redis_client, fake)
+        self.assertTrue(packer.post_called)
+        # Most important assertion: the hook ran AFTER assignment.
+        self.assertIs(packer.client_at_post_call, fake)
+        # Endpoint was passed through.
+        self.assertEqual(factory.calls[0]["host"], "r.example")
+        self.assertEqual(factory.calls[0]["port"], 6380)
+        self.assertEqual(factory.calls[0]["db"], 2)
+        # decode_responses is True for parity with pre-55745c behavior.
+        self.assertTrue(factory.calls[0]["decode_responses"])
+
+    def test_attach_skips_when_no_redis_attr(self):
+        # Non-NCCL-aware packer is not modified.
+        packer = _NoOpPacker()
+        fake = _FakeRedis()
+        factory = _FakeRedisFactory(fake)
+        with self._patch_redis_lib(factory):
+            self.transport.attach_data_packer(
+                packer,
+                config=self.config,
+                redis_endpoint=self.endpoint,
+            )
+        self.assertFalse(hasattr(packer, "redis_client"))
+        # No client construction attempted.
+        self.assertEqual(factory.calls, [])
+
+    def test_attach_skips_on_ping_failure(self):
+        # Ping failure must NOT crash and must NOT mutate the packer.
+        packer = _NcclAwarePacker()
+        fake = _FakeRedis(ping_raises=ConnectionError("nope"))
+        factory = _FakeRedisFactory(fake)
+        with self._patch_redis_lib(factory):
+            self.transport.attach_data_packer(
+                packer,
+                config=self.config,
+                redis_endpoint=self.endpoint,
+            )
+        self.assertIsNone(packer.redis_client)
+        self.assertFalse(packer.post_called)
+
+    def test_attach_no_endpoint_is_safe(self):
+        packer = _NcclAwarePacker()
+        self.transport.attach_data_packer(
+            packer, config=self.config, redis_endpoint=None
+        )
+        self.assertIsNone(packer.redis_client)
+
+    def test_attach_no_redis_lib_is_safe(self):
+        packer = _NcclAwarePacker()
+        with mock.patch("cosmos_rl.utils.payload_transport.nccl._redis_lib", None):
+            self.transport.attach_data_packer(
+                packer, config=self.config, redis_endpoint=self.endpoint
+            )
+        self.assertIsNone(packer.redis_client)
+
+    def test_attach_post_hook_exception_is_logged_not_raised(self):
+        class _BadPacker:
+            def __init__(self):
+                self.redis_client = None
+
+            def post_redis_injection(self):
+                raise RuntimeError("boom in hook")
+
+        packer = _BadPacker()
+        fake = _FakeRedis()
+        factory = _FakeRedisFactory(fake)
+        with self._patch_redis_lib(factory):
+            # Must NOT raise -- a buggy downstream hook cannot kill init.
+            self.transport.attach_data_packer(
+                packer, config=self.config, redis_endpoint=self.endpoint
+            )
+        # Client is still assigned (assignment happens before the hook).
+        self.assertIs(packer.redis_client, fake)
+
+
+class TestHandleDiscarded(unittest.TestCase):
+    """Centralized controller-side cleanup dispatch."""
+
+    def test_returns_zero_for_no_discards(self):
+        rollouts = [SimpleNamespace(completion="nccl:0:abc")]
+        published = PayloadTransportRegistry.handle_discarded(
+            rollouts,
+            rollouts,  # nothing filtered out
+            config=SimpleNamespace(),
+            redis_client=_FakeRedis(),
+        )
+        self.assertEqual(published, 0)
+
+    def test_returns_zero_for_empty_rollouts(self):
+        published = PayloadTransportRegistry.handle_discarded(
+            [], [], config=SimpleNamespace(), redis_client=_FakeRedis()
+        )
+        self.assertEqual(published, 0)
+
+    def test_partitions_discards_by_completion_prefix(self):
+        # Two discarded NCCL rollouts plus one untracked discard.
+        rollouts = [
+            SimpleNamespace(completion="nccl:0:keep"),
+            SimpleNamespace(completion="nccl:0:drop1"),
+            SimpleNamespace(completion="nccl:1:drop2"),
+            SimpleNamespace(completion="plaintext-discard"),
+        ]
+        filtered = [rollouts[0]]  # only the first survives
+        config = SimpleNamespace(
+            logging=SimpleNamespace(experiment_name="exp"),
+            rollout=SimpleNamespace(parallelism=SimpleNamespace(n_init_replicas=4)),
+        )
+        redis = _FakeRedis()
+        published = PayloadTransportRegistry.handle_discarded(
+            rollouts, filtered, config=config, redis_client=redis
+        )
+        # NCCL routes 2 discards (its prefix matches 2 entries).  Plain
+        # text gets no transport, so it's silently ignored.
+        self.assertEqual(published, 2)
+        self.assertEqual(len(redis.published), 2)
+
+    def test_skips_transports_with_none_completion_prefix(self):
+        # Register a transport with completion_prefix=None and one
+        # discard whose completion is a dict (UCXX-style).  Neither
+        # should match; published should be zero.
+        class _NoPrefixTransport(PayloadTransport):
+            name = "noprefix"
+            completion_prefix = None
+
+            def __init__(self):
+                self.called = False
+
+            def publish_cleanup_for_discarded(self, **kwargs):
+                self.called = True
+                return 5  # would be counted if it were reached
+
+        np_transport = _NoPrefixTransport()
+        try:
+            PayloadTransportRegistry.register(np_transport)
+            rollouts = [
+                SimpleNamespace(completion="keep"),
+                SimpleNamespace(completion={"_ucxx": True, "_slot": 3}),
+            ]
+            published = PayloadTransportRegistry.handle_discarded(
+                rollouts,
+                [rollouts[0]],
+                config=SimpleNamespace(),
+                redis_client=_FakeRedis(),
+            )
+            self.assertEqual(published, 0)
+            self.assertFalse(np_transport.called)
+        finally:
+            # Clean up to avoid contaminating other tests.
+            PayloadTransportRegistry._registry.pop("noprefix", None)
+
+    def test_continues_after_per_transport_failure(self):
+        # Register a "broken" prefix that always raises; ensure NCCL
+        # still gets a chance to publish for its own discards.
+        class _BoomTransport(PayloadTransport):
+            name = "boom"
+            completion_prefix = "boom:"
+
+            def publish_cleanup_for_discarded(self, **kwargs):
+                raise RuntimeError("simulated transport failure")
+
+        boom = _BoomTransport()
+        try:
+            PayloadTransportRegistry.register(boom)
+            rollouts = [
+                SimpleNamespace(completion="nccl:0:abc"),
+                SimpleNamespace(completion="boom:99"),
+            ]
+            config = SimpleNamespace(
+                logging=SimpleNamespace(experiment_name="exp"),
+                rollout=SimpleNamespace(parallelism=SimpleNamespace(n_init_replicas=4)),
+            )
+            redis = _FakeRedis()
+            published = PayloadTransportRegistry.handle_discarded(
+                rollouts, [], config=config, redis_client=redis
+            )
+            # NCCL's one discard still got published; boom failed cleanly.
+            self.assertEqual(published, 1)
+            self.assertEqual(len(redis.published), 1)
+        finally:
+            PayloadTransportRegistry._registry.pop("boom", None)
+
+
+class TestRegistryHygiene(unittest.TestCase):
+    def test_register_class_validates_name(self):
+        class _Empty(PayloadTransport):
+            name = ""
+
+        with self.assertRaises(ValueError):
+            PayloadTransportRegistry.register_class(_Empty)
+
+    def test_register_validates_name(self):
+        class _Empty(PayloadTransport):
+            name = ""
+
+        with self.assertRaises(ValueError):
+            PayloadTransportRegistry.register(_Empty())
+
+    def test_re_registration_replaces_instance(self):
+        class _T(PayloadTransport):
+            name = "_test_re_reg"
+
+        a = _T()
+        b = _T()
+        try:
+            PayloadTransportRegistry.register(a)
+            self.assertIs(PayloadTransportRegistry.get("_test_re_reg"), a)
+            PayloadTransportRegistry.register(b)
+            self.assertIs(PayloadTransportRegistry.get("_test_re_reg"), b)
+        finally:
+            PayloadTransportRegistry._registry.pop("_test_re_reg", None)
+
+
+class TestIsPayloadTransferModeExplicit(unittest.TestCase):
+    def test_default_is_not_explicit(self):
+        # Default fallback to "redis" is NOT explicit.
+        self.assertFalse(is_payload_transfer_mode_explicit(SimpleNamespace(custom={})))
+        self.assertFalse(is_payload_transfer_mode_explicit(SimpleNamespace()))
+
+    def test_string_form_is_explicit(self):
+        config = SimpleNamespace(custom={PAYLOAD_TRANSFER_KEY: "nccl"})
+        self.assertTrue(is_payload_transfer_mode_explicit(config))
+
+    def test_legacy_boolean_is_explicit(self):
+        config = SimpleNamespace(custom={LEGACY_NCCL_KEY: True})
+        self.assertTrue(is_payload_transfer_mode_explicit(config))
+
+    def test_legacy_boolean_false_is_not_explicit(self):
+        config = SimpleNamespace(custom={LEGACY_NCCL_KEY: False})
+        self.assertFalse(is_payload_transfer_mode_explicit(config))
+
+    def test_empty_string_is_not_explicit(self):
+        config = SimpleNamespace(custom={PAYLOAD_TRANSFER_KEY: "   "})
+        self.assertFalse(is_payload_transfer_mode_explicit(config))
+
+
+class TestPayloadTransportDefaults(unittest.TestCase):
+    def test_default_attach_is_noop(self):
+        # Default base-class attach must not raise on any packer shape.
+        class _T(PayloadTransport):
+            name = "_default_attach"
+
+        t = _T()
+        # Should silently no-op for arbitrary packers.
+        t.attach_data_packer(object(), config=SimpleNamespace())
+        t.attach_data_packer(_NcclAwarePacker(), config=SimpleNamespace())
+
+    def test_default_publish_cleanup_returns_zero(self):
+        class _T(PayloadTransport):
+            name = "_default_publish"
+
+        t = _T()
+        self.assertEqual(
+            t.publish_cleanup_for_discarded(
+                transfer_ids=["a", "b"],
+                config=SimpleNamespace(),
+                redis_client=_FakeRedis(),
+            ),
+            0,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Generalizes the NCCL payload-transfer protocol into a backend registry under cosmos_rl/utils/payload_transport/ so additional transports (UCXX in a follow-up MR) can be added without touching the controller.

Surface:
* PayloadTransport ABC: name + optional completion_prefix + prepare_data_packer (worker-side) + publish_cleanup_for_discarded (controller-side).
* PayloadTransportRegistry: register / get / active_for_completion. Redis is registered as the implicit default; NCCL registers itself on import via cosmos_rl/utils/payload_transport/nccl.py.
* get_payload_transfer_mode(config): reads [custom].payload_transfer string ("redis"|"nccl"|"ucxx"), with [custom].nccl_payload_transfer boolean kept as a deprecated alias that resolves to "nccl".

Migration:
* All NCCL Redis-protocol constants and key builders move to cosmos_rl/utils/payload_transport/nccl.py; the existing cosmos_rl.utils.nccl_transfer_protocol module is now a re-export shim so external importers continue to work.
* dispatcher/status.py's filter_outdated_rollouts no longer hardcodes the "nccl:" prefix; it groups discarded rollouts by the transport whose completion_prefix matches and delegates publishing to each backend.  The function rename _publish_nccl_cleanup_for_discarded -> _publish_payload_transport_cleanup is internal-only.

No behavior change: the same Redis channels, same payloads, and the same enable-on-detection semantics; only the dispatch indirection is new.  Tests cover registry bootstrap, mode resolution (string + deprecated boolean + invalid value), NCCL protocol helpers, the NcclPayloadTransport.publish_cleanup_for_discarded happy path, and the backward-compat shim.