### PR TITLE
feat: extension hooks + tensor data packer for non-LLM RL workloads

### DIFF
--- a/cosmos_rl/comm/base.py
+++ b/cosmos_rl/comm/base.py
@@ -38,7 +38,8 @@ import cosmos_rl.utils.constant as constant
 import cosmos_rl.utils.distributed as dist_utils
 from cosmos_rl.dispatcher.protocol import MESH_NAMES
 import cosmos_rl.utils.util as util
-from transformers import AutoConfig
+from transformers import AutoConfig  # noqa: F401  re-exported for downstream importers
+from cosmos_rl.utils.model_config import load_model_config
 import multiprocessing as mp
 from cosmos_rl.dispatcher.api.client import APIClient
 from cosmos_rl.colocated.api_client import ColocatedAPIClient
@@ -111,8 +112,13 @@ class CommMixin:
         val_data_packer: Optional[Union[BaseDataPacker, Callable]] = None,
     ):
         if not self.config.policy.is_diffusers:
-            hf_config = util.retry(AutoConfig.from_pretrained)(
-                self.config.policy.model_name_or_path, trust_remote_code=True
+            # Routes through the model_config registry so non-HF model paths
+            # (e.g. Gymnasium MLP described by a local TOML) resolve via
+            # ``register_local_model_config`` before falling back to
+            # ``AutoConfig.from_pretrained``.  Default flow for HF repo ids
+            # / standard local HF dirs is unchanged.
+            hf_config = util.retry(load_model_config)(
+                self.config.policy.model_name_or_path
             )
             is_vlm = getattr(hf_config, "vision_config", None) is not None
             model_type = hf_config.model_type

--- a/cosmos_rl/dispatcher/data/packer/tensor_data_packer.py
+++ b/cosmos_rl/dispatcher/data/packer/tensor_data_packer.py
@@ -1,0 +1,245 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""``TensorDataPacker`` — a generic data packer for non-text (e.g.
+Gymnasium) RL trajectories.
+
+Cosmos-RL's default ``DataPacker`` assumes the rollout output is text
+that requires tokenization.  For RL workloads where the rollout produces
+tensor trajectories (observations, actions, rewards, terminated /
+truncated flags, episode length), this packer handles the
+rollout↔trainer plumbing without invoking a real tokenizer.
+
+It is a thin, transport-agnostic base class:
+
+* :meth:`get_rollout_input` simply forwards the dataset sample (which
+  for gym-style tasks typically carries seed / initial-condition
+  metadata).
+* :meth:`get_policy_input` accepts a trajectory dict and passes it
+  through unchanged so the trainer can consume the tensors directly.
+* :meth:`policy_collate_fn` returns the list of per-episode dicts
+  unchanged; collation across episodes is left to the trainer because
+  RL trajectories typically have variable lengths and the trainer
+  knows the right batching/padding strategy for its algorithm.
+
+Subclasses can override :meth:`get_rollout_output` /
+:meth:`get_policy_input` to add transport-specific behavior (e.g.
+inserting a UCXX reference dict in place of the raw tensors and
+materializing it on the policy side).
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+from cosmos_rl.dispatcher.data.packer.base import BaseDataPacker
+from cosmos_rl.policy.config import Config
+from cosmos_rl.utils.logging import logger
+
+
+# Canonical field names used by ``TensorDataPacker``-compatible
+# trajectories.  Subclasses and rollout engines should agree on these
+# keys so the analyzer / trainer can introspect trajectories uniformly.
+OBSERVATIONS = "observations"
+ACTIONS = "actions"
+REWARDS = "rewards"
+TERMINATED = "terminated"
+TRUNCATED = "truncated"
+EPISODE_LENGTH = "episode_length"
+
+TRAJECTORY_KEYS = (
+    OBSERVATIONS,
+    ACTIONS,
+    REWARDS,
+    TERMINATED,
+    TRUNCATED,
+    EPISODE_LENGTH,
+)
+
+
+class TensorDataPacker(BaseDataPacker):
+    """Generic non-text data packer for tensor trajectories.
+
+    Cosmos-RL invokes the data packer in three phases:
+
+    1. Rollout setup — :meth:`get_rollout_input` converts a dataset
+       sample to the input the rollout engine consumes.  For Gymnasium
+       tasks this is typically the seed / initial-condition dict.
+    2. Rollout output — :meth:`get_rollout_output` post-processes the
+       trajectory dicts produced by the rollout engine.  The default
+       implementation is a passthrough; subclasses can replace
+       ``completions`` with reference handles (e.g. UCXX slot ids) and
+       resolve them on the policy side.
+    3. Policy input — :meth:`get_policy_input` converts each rollout
+       output to the trainer's per-episode payload.  The default
+       implementation passes the trajectory dict through unchanged so
+       the trainer sees the same shape it produced.
+
+    Subclassing pattern::
+
+        class MyDataPacker(TensorDataPacker):
+            def get_rollout_input(self, sample, **kwargs):
+                # e.g. parse JSON initial conditions
+                return {"prompt": sample.get("prompt", "{}")}
+    """
+
+    # The base ``BaseDataPacker`` interface signals "no tokenizer
+    # required" simply by inheriting from BaseDataPacker (rather than
+    # the LLM-flavored ``DataPacker``).  ``setup`` therefore stays
+    # minimal.
+    def setup(self, config: Config, *args, **kwargs) -> None:
+        super().setup(config, *args, **kwargs)
+        logger.info(
+            f"[TensorDataPacker] {type(self).__name__} setup complete "
+            "(no tokenizer required for tensor RL)"
+        )
+
+    # ------------------------------------------------------------------
+    # Rollout-side hooks
+    # ------------------------------------------------------------------
+
+    def get_rollout_input(
+        self,
+        item: Any,
+        **kwargs,
+    ) -> Any:
+        """Convert a dataset sample to rollout-engine input.
+
+        Default: passthrough.  Override to e.g. parse a JSON ``prompt``
+        field carrying initial conditions for a Gymnasium env.
+        """
+        return item
+
+    def rollout_collate_fn(self, items: List[Any]) -> List[Any]:
+        # The dispatcher passes mini-batches of rollout inputs; the
+        # default behavior of preserving the list works fine for tensor
+        # tasks since the rollout engine can iterate per-episode.
+        return items
+
+    def get_rollout_output(
+        self,
+        completions: List[Any],
+        completed_conversations: List[Any],
+        logprobs: List[Any],
+        token_ids: List[Any],
+        **kwargs,
+    ):
+        """Post-process rollout outputs.
+
+        For tensor trajectories, ``completions`` is the list of
+        per-episode trajectory dicts produced by the rollout engine.
+        We pass them through unchanged.  Subclasses that swap the
+        completions for transport handles (e.g. UCXX references) should
+        override this method.
+        """
+        return (
+            completions,
+            completed_conversations,
+            logprobs,
+            token_ids,
+            kwargs,
+        )
+
+    # ------------------------------------------------------------------
+    # Policy-side hooks
+    # ------------------------------------------------------------------
+
+    def get_policy_input(
+        self,
+        sample: Any = None,
+        rollout_output: Optional[Any] = None,
+        n_ignore_prefix_tokens: int = 0,
+        **kwargs,
+    ) -> Any:
+        """Return the per-episode payload the trainer consumes.
+
+        The default implementation assumes ``rollout_output`` is already
+        a trajectory dict produced by the rollout engine.  Subclasses
+        may resolve transport-side references here (e.g. fetch tensors
+        over UCXX) before returning.
+        """
+        return rollout_output
+
+    def policy_compute_max_len(self, processed_samples: List[Any]) -> int:
+        """Maximum trajectory length across the mini-batch.
+
+        Falls back to ``1`` when episode-length metadata is unavailable
+        — this value is only used to pre-allocate buffers, so a
+        conservative answer is safe.
+        """
+        max_len = 1
+        for item in processed_samples:
+            if not isinstance(item, dict):
+                continue
+            ep_len = item.get(EPISODE_LENGTH)
+            if ep_len is None:
+                obs = item.get(OBSERVATIONS)
+                if hasattr(obs, "shape") and len(obs.shape) > 0:
+                    ep_len = int(obs.shape[0])
+            if ep_len is None:
+                continue
+            if hasattr(ep_len, "item"):
+                try:
+                    ep_len = int(ep_len.item())
+                except Exception:
+                    continue
+            try:
+                ep_len = int(ep_len)
+            except (TypeError, ValueError):
+                continue
+            if ep_len > max_len:
+                max_len = ep_len
+        return max_len
+
+    def policy_collate_fn(
+        self,
+        processed_samples: List[Any],
+        computed_max_len: int,
+    ) -> Dict[str, Any]:
+        """Return the per-episode list as-is.
+
+        RL trajectories are typically variable-length and ragged
+        across episodes; the trainer is the right place to decide
+        whether to concatenate (policy gradient with returns) or
+        pad-and-stack (Q-learning with mini-batches).  Returning the
+        list keeps the data packer transport- and algorithm-agnostic.
+        """
+        return {"trajectories": processed_samples}
+
+    # ------------------------------------------------------------------
+    # Convenience helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def is_trajectory(value: Any) -> bool:
+        """Return True if ``value`` looks like a tensor trajectory dict.
+
+        Used by transport-aware subclasses (and the analyzer) to detect
+        whether to apply tensor-specific handling.  A trajectory is a
+        dict that contains at least ``observations`` and ``actions``.
+        """
+        return isinstance(value, dict) and OBSERVATIONS in value and ACTIONS in value
+
+
+__all__ = [
+    "ACTIONS",
+    "EPISODE_LENGTH",
+    "OBSERVATIONS",
+    "REWARDS",
+    "TERMINATED",
+    "TRAJECTORY_KEYS",
+    "TRUNCATED",
+    "TensorDataPacker",
+]

--- a/cosmos_rl/policy/model/base.py
+++ b/cosmos_rl/policy/model/base.py
@@ -24,6 +24,7 @@ from cosmos_rl.utils.constant import COSMOS_HF_MODEL_TYPES
 import torch
 from transformers import AutoConfig
 from cosmos_rl.utils.diffusers_utils import diffusers_config_fn
+from cosmos_rl.utils.model_config import load_model_config
 
 from cosmos_rl.dispatcher.data.packer import BaseDataPacker
 import collections
@@ -600,9 +601,12 @@ class ModelRegistry:
         for k, v in hf_config_args.items():
             logger.info(f"Set hf config args {k} to {v}")
 
-        hf_config = util.retry(AutoConfig.from_pretrained)(
-            model_name_or_path, trust_remote_code=True, **hf_config_args
-        )
+        # Routes through the model_config registry first so non-HF model
+        # paths (e.g. a Gymnasium MLP described by a local TOML registered
+        # via ``register_local_model_config``) resolve before the default
+        # ``AutoConfig.from_pretrained`` fallback.  HF repo ids / standard
+        # local HF dirs hit the fallback exactly as before.
+        hf_config = util.retry(load_model_config)(model_name_or_path, **hf_config_args)
         aux_loss_coeff = config.policy.aux_loss_coeff
         if aux_loss_coeff > 0.0 and "aux_loss_coeff" not in hf_config:
             hf_config.aux_loss_coeff = aux_loss_coeff
@@ -1063,3 +1067,66 @@ class WeightMapper(ABC):
         """
         tmp_recv_tensor = recv_tensor.to(tensor_view.dtype)
         tensor_view.copy_(tmp_recv_tensor)
+
+
+class IdentityWeightMapper(WeightMapper):
+    """A trivial :class:`WeightMapper` for single-rank, non-sharded models.
+
+    The default :class:`WeightMapper` machinery is built around HuggingFace
+    causal-LM conventions: parameter renaming, fused-KV splitting,
+    expert-stacking for MoE, etc.  Small RL policies (an MLP for a
+    Gymnasium task, for instance) need none of that -- every parameter has
+    the same name on the policy and rollout sides, and there is no
+    tensor-parallel splitting because the world size is typically 1.
+
+    Behavior:
+
+    * Policy -> HF and rollout -> HF name maps are identity.
+    * No parameter splitting (returns the input ``(name, tensor)``
+      unchanged in a single-element list).
+    * Inherits every other hook from the base class as-is, which is
+      correct for an MLP-sized model that lives entirely on rank 0.
+
+    The constructor accepts ``hf_config=None`` so callers that haven't
+    set up a HuggingFace config (the typical Gymnasium case) can still
+    instantiate the mapper without contortions.
+
+    Usage::
+
+        from cosmos_rl.policy.model.base import (
+            IdentityWeightMapper,
+            ModelRegistry,
+        )
+
+        class GymMLP(BaseModel):
+            @staticmethod
+            def supported_model_types():
+                return ["gym_mlp"]
+            ...
+
+        ModelRegistry.register_model(GymMLP, IdentityWeightMapper)
+    """
+
+    def __init__(self, hf_config: Optional["AutoConfig"] = None):
+        # Skip the parent constructor: it logs the wrong backend and
+        # assumes ``hf_config`` is non-None.  We replicate the minimum
+        # state ourselves.
+        self.config = hf_config
+        self.backend = "vllm"
+        logger.info(
+            f"[{type(self).__name__}] Initialized identity weight mapper "
+            "(non-sharded RL policy)"
+        )
+
+    def policy_map_local_key_to_hf_key(self, name: str) -> str:
+        return name
+
+    def rollout_map_local_key_to_hf_key(self, name: str) -> str:
+        return name
+
+    def rollout_split_local_key_n_param_to_hf_key_n_param(
+        self,
+        param_name: str,
+        param: torch.Tensor,
+    ) -> List[Tuple[str, torch.Tensor]]:
+        return [(self.rollout_map_local_key_to_hf_key(param_name), param)]

--- a/cosmos_rl/utils/model_config.py
+++ b/cosmos_rl/utils/model_config.py
@@ -1,0 +1,136 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Pluggable model-config loader for non-HuggingFace local model paths.
+
+The default cosmos-rl flow assumes ``policy.model_name_or_path`` is a
+HuggingFace repo id or a local directory containing a ``config.json``.
+Non-text RL workloads (e.g. Gymnasium-based tasks with a small MLP
+policy) often want to point cosmos-rl at a local TOML/YAML file
+describing the architecture instead.
+
+This module provides:
+
+* :func:`register_local_model_config` — register a (predicate, factory)
+  pair so callers can produce a HuggingFace-compatible
+  :class:`~transformers.PretrainedConfig` from a non-HF path.
+* :func:`load_model_config` — central entrypoint that consults the
+  registry first and falls back to
+  :meth:`transformers.AutoConfig.from_pretrained` otherwise.
+
+Existing cosmos-rl call sites that directly invoke
+``AutoConfig.from_pretrained`` continue to work unchanged.  New code (and
+the next round of upstream migrations) should prefer
+:func:`load_model_config` so non-HF model paths route through the
+registry.
+
+Example
+-------
+
+.. code-block:: python
+
+    from transformers import PretrainedConfig
+    from cosmos_rl.utils.model_config import (
+        register_local_model_config,
+        load_model_config,
+    )
+
+    class GymPolicyConfig(PretrainedConfig):
+        model_type = "gym_policy"
+
+    register_local_model_config(
+        predicate=lambda path: path.endswith(".toml"),
+        factory=lambda path: GymPolicyConfig.from_dict(_parse_toml(path)),
+    )
+
+    cfg = load_model_config("/path/to/cartpole_mlp.toml")
+    assert cfg.model_type == "gym_policy"
+"""
+
+from __future__ import annotations
+
+from typing import Any, Callable, List, Tuple
+
+from transformers import AutoConfig, PretrainedConfig
+
+from cosmos_rl.utils.logging import logger
+
+
+_CUSTOM_MODEL_CONFIG_LOADERS: List[
+    Tuple[Callable[[str], bool], Callable[[str], PretrainedConfig]]
+] = []
+
+
+def register_local_model_config(
+    predicate: Callable[[str], bool],
+    factory: Callable[[str], PretrainedConfig],
+) -> None:
+    """Register a custom model-config factory.
+
+    Predicates are evaluated in registration order; the first one that
+    returns truthy for ``model_name_or_path`` wins, and its factory
+    produces the :class:`~transformers.PretrainedConfig` instance.
+    """
+    _CUSTOM_MODEL_CONFIG_LOADERS.append((predicate, factory))
+
+
+def clear_local_model_configs() -> None:
+    """Remove all registered local-model-config factories.  Useful for tests."""
+    _CUSTOM_MODEL_CONFIG_LOADERS.clear()
+
+
+def load_model_config(
+    model_name_or_path: str,
+    **auto_config_kwargs: Any,
+) -> PretrainedConfig:
+    """Load a model config, preferring the local-model-config registry.
+
+    Args:
+        model_name_or_path: HuggingFace repo id, local model directory,
+            or any path matched by a registered custom predicate.
+        **auto_config_kwargs: Forwarded to
+            :meth:`transformers.AutoConfig.from_pretrained` when no
+            custom loader matches.  Always passes
+            ``trust_remote_code=True`` by default for parity with
+            existing cosmos-rl call sites.
+
+    Returns:
+        A :class:`PretrainedConfig` instance with a meaningful
+        ``model_type`` attribute that downstream registries
+        (``WeightMapperRegistry``, ``ModelRegistry``) can key on.
+    """
+    for predicate, factory in _CUSTOM_MODEL_CONFIG_LOADERS:
+        try:
+            matched = bool(predicate(model_name_or_path))
+        except Exception as e:
+            logger.warning(
+                f"Local model-config predicate raised for {model_name_or_path}: {e}; skipping"
+            )
+            continue
+        if matched:
+            logger.info(
+                f"Model config for {model_name_or_path} resolved via registered local loader"
+            )
+            return factory(model_name_or_path)
+
+    auto_config_kwargs.setdefault("trust_remote_code", True)
+    return AutoConfig.from_pretrained(model_name_or_path, **auto_config_kwargs)
+
+
+__all__ = [
+    "clear_local_model_configs",
+    "load_model_config",
+    "register_local_model_config",
+]

--- a/cosmos_rl/utils/network_util.py
+++ b/cosmos_rl/utils/network_util.py
@@ -20,7 +20,7 @@ import fcntl
 import struct
 import array
 import os
-from typing import Any, Callable, List, Union
+from typing import Any, Callable, List, Optional, Union
 
 from cosmos_rl.utils.constant import COSMOS_HTTP_RETRY_CONFIG
 from cosmos_rl.utils.logging import logger
@@ -285,17 +285,45 @@ def find_available_port(start_port, max_port=65536):
     raise RuntimeError("No available port found in the specified range.")
 
 
+def _redis_legacy_skip_tls_port() -> bool:
+    """Return True when ``COSMOS_REDIS_NO_TLS`` is set in the environment.
+
+    Set this on hosts running Redis < 6.0 (which does not understand the
+    ``tls-port`` directive at all and refuses to start when the line is
+    present).  Cosmos-RL does not enable TLS by itself, so dropping the
+    directive is functionally a no-op apart from compatibility.
+    """
+    value = os.environ.get("COSMOS_REDIS_NO_TLS", "").strip().lower()
+    return value not in ("", "0", "false", "no")
+
+
 def write_redis_config(
-    port, logfile, file_path="/opt/redis_config.conf", custom_config=None
+    port,
+    logfile,
+    file_path="/opt/redis_config.conf",
+    custom_config=None,
+    *,
+    skip_tls_port: Optional[bool] = None,
 ):
     """
     Write the redis config file.
     redis_config_path: the path to the redis config file.
     port: the port for Redis to listen on.
     logfile: the logfile for Redis.
+    skip_tls_port: when True, omit the ``tls-port`` directive entirely
+        for compatibility with Redis < 6.0.  When None (default), the
+        ``COSMOS_REDIS_NO_TLS`` environment variable controls behavior.
 
     return the actual path of the redis config file.
     """
+    if skip_tls_port is None:
+        skip_tls_port = _redis_legacy_skip_tls_port()
+
+    if skip_tls_port:
+        tls_block = "# tls-port directive omitted (COSMOS_REDIS_NO_TLS set / Redis 5.x)"
+    else:
+        tls_block = "# Disable TLS by setting the tls-port to 0\ntls-port 0"
+
     config_content = f"""# Redis configuration file example for insecure connections
 
 # Bind to all network interfaces (use with caution)
@@ -304,8 +332,7 @@ bind 0.0.0.0
 # Set the port for Redis to listen on (default is {port})
 port {port}
 
-# Disable TLS by setting the tls-port to 0
-tls-port 0
+{tls_block}
 
 # Disable authentication by commenting out the requirepass directive
 # requirepass yourpassword

--- a/cosmos_rl/utils/no_op_tokenizer.py
+++ b/cosmos_rl/utils/no_op_tokenizer.py
@@ -1,0 +1,165 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tokenizer-shaped object for non-text (e.g. tensor / Gymnasium) RL tasks.
+
+Cosmos-RL's data-packer / controller code paths assume a HuggingFace
+tokenizer is available even for tasks where the rollout output is not
+text (e.g. trajectory tensors from a ``gymnasium.Env``).  Rather than
+forcing every non-LLM caller to monkey-patch ``setup_tokenizer``, this
+module ships a minimal duck-typed object that satisfies the few tokenizer
+methods cosmos-rl actually calls during non-text RL.
+
+It is designed to be returned from a custom tokenizer loader registered
+via :func:`cosmos_rl.utils.util.register_tokenizer_loader`:
+
+.. code-block:: python
+
+    from cosmos_rl.utils.util import register_tokenizer_loader
+    from cosmos_rl.utils.no_op_tokenizer import NoOpTokenizer
+
+    register_tokenizer_loader(
+        predicate=lambda path: path.endswith(".toml"),
+        loader=lambda path: NoOpTokenizer(),
+    )
+
+The object only implements the methods that are reached on the non-text
+code path; calling tokenization-specific methods (e.g. ``batch_decode``)
+returns empty/identity results that should never be used by a correctly
+configured non-text trainer.
+"""
+
+from __future__ import annotations
+
+from typing import Any, List
+
+import torch
+
+
+# Field name used by tensor data packers to record the (already-known)
+# trajectory length.  Kept here so the tokenizer can derive a stand-in
+# ``input_ids`` length without importing the data-packer module.
+_EPISODE_LENGTH_KEY = "episode_length"
+
+
+def _episode_length(item: Any) -> int:
+    """Best-effort extraction of an episode length from a trajectory dict
+    or scalar tensor.  Returns ``1`` for unknown / unparseable inputs."""
+    if isinstance(item, dict):
+        value = item.get(_EPISODE_LENGTH_KEY)
+        if value is None:
+            return 1
+        if hasattr(value, "item"):
+            try:
+                return max(1, int(value.item()))
+            except Exception:
+                return 1
+        try:
+            return max(1, int(value))
+        except (TypeError, ValueError):
+            return 1
+    return 1
+
+
+class _BatchEncoding:
+    """A minimal stand-in for :class:`transformers.BatchEncoding`.
+
+    Provides ``input_ids`` and ``attention_mask`` as zero tensors of the
+    requested length so downstream code that only inspects shapes (e.g.
+    completion-length statistics) operates correctly.
+    """
+
+    def __init__(self, length: int):
+        self.input_ids = torch.zeros((1, length), dtype=torch.long)
+        self.attention_mask = torch.ones((1, length), dtype=torch.long)
+
+    def __getitem__(self, key: str) -> torch.Tensor:
+        return getattr(self, key)
+
+    def keys(self) -> List[str]:
+        return ["input_ids", "attention_mask"]
+
+
+class NoOpTokenizer:
+    """A duck-typed tokenizer for non-text RL tasks.
+
+    Satisfies the subset of the HuggingFace tokenizer interface that
+    cosmos-rl actually invokes when the model is not text-based:
+
+    * Standard token-id / token attributes (``eos_token_id``,
+      ``pad_token_id``, etc.) so config validation does not crash.
+    * :meth:`encode` returns a list of zeros sized by the trajectory's
+      ``episode_length`` field, allowing completion-length statistics
+      to be computed correctly.
+    * ``__call__`` returns a :class:`_BatchEncoding`-shaped object.
+    * :meth:`decode` / :meth:`batch_decode` return empty strings (no
+      real text to render).
+
+    Attributes are kept on the instance (not the class) so multiple
+    callers can independently mutate them without surprising each other.
+    """
+
+    def __init__(
+        self,
+        *,
+        vocab_size: int = 4,
+        model_max_length: int = 512,
+    ):
+        self.eos_token = "</s>"
+        self.eos_token_id = 0
+        self.bos_token = "<s>"
+        self.bos_token_id = 1
+        self.pad_token = "<pad>"
+        self.pad_token_id = 2
+        self.unk_token = "<unk>"
+        self.unk_token_id = 3
+        self.vocab_size = vocab_size
+        self.model_max_length = model_max_length
+
+    def encode(self, item: Any, **_kwargs) -> List[int]:
+        """Return a list of zero token-ids sized by ``episode_length``.
+
+        For trajectory dicts, this lets the controller compute meaningful
+        ``completion_length`` statistics without real tokenization.  For
+        plain strings (e.g. an empty completion placeholder), returns a
+        single-element list.
+        """
+        if isinstance(item, dict):
+            return [0] * _episode_length(item)
+        return [0]
+
+    def decode(self, _token_ids, **_kwargs) -> str:
+        return ""
+
+    def batch_decode(self, batches, **_kwargs) -> List[str]:
+        try:
+            return [""] * len(batches)
+        except TypeError:
+            return [""]
+
+    def __call__(self, item: Any, **_kwargs) -> _BatchEncoding:
+        return _BatchEncoding(_episode_length(item))
+
+    def convert_tokens_to_ids(self, _tokens) -> List[int]:
+        return []
+
+    def convert_ids_to_tokens(self, _ids) -> List[str]:
+        return []
+
+    def __repr__(self) -> str:
+        return "NoOpTokenizer(for non-text RL tasks)"
+
+
+__all__ = ["NoOpTokenizer"]

--- a/cosmos_rl/utils/util.py
+++ b/cosmos_rl/utils/util.py
@@ -38,7 +38,7 @@ from collections import OrderedDict
 from functools import wraps
 from msgpack import ExtType
 from tqdm import tqdm
-from typing import List, Tuple, Dict, Any, Optional, Union
+from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 import torch
 import pynvml
 from contextlib import contextmanager
@@ -1275,8 +1275,68 @@ def replace_with_liger_equivalents(root: torch.nn.Module, config: CosmosConfig) 
                     replace_child(name, child, new_lm_head, root)
 
 
+# Custom tokenizer-loader registry.  Each entry is a (predicate, loader)
+# pair; predicates are evaluated in registration order, and the first
+# predicate that matches ``model_name_or_path`` wins.  This lets non-text
+# RL workloads (e.g. Gymnasium-based tasks with local .toml model
+# configs) plug in a NoOpTokenizer without monkey-patching.
+_CUSTOM_TOKENIZER_LOADERS: List[Tuple[Callable[[str], bool], Callable[[str], Any]]] = []
+
+
+def register_tokenizer_loader(
+    predicate: Callable[[str], bool],
+    loader: Callable[[str], Any],
+) -> None:
+    """Register a custom tokenizer loader.
+
+    ``setup_tokenizer`` consults the registry first; the first predicate
+    that returns truthy for the incoming ``model_name_or_path`` is
+    selected and its loader is invoked to produce the tokenizer.  If no
+    predicate matches, the default HuggingFace path is taken.
+
+    Typical usage from a non-LLM RL entrypoint::
+
+        from cosmos_rl.utils.util import register_tokenizer_loader
+        from cosmos_rl.utils.no_op_tokenizer import NoOpTokenizer
+
+        register_tokenizer_loader(
+            predicate=lambda p: p.endswith(".toml"),
+            loader=lambda p: NoOpTokenizer(),
+        )
+
+    Args:
+        predicate: Callable that receives ``model_name_or_path`` and
+            returns ``True`` if this loader should handle it.
+        loader: Callable that receives ``model_name_or_path`` and
+            returns a tokenizer-shaped object.
+    """
+    _CUSTOM_TOKENIZER_LOADERS.append((predicate, loader))
+
+
+def clear_tokenizer_loaders() -> None:
+    """Remove all registered custom tokenizer loaders.  Useful for tests."""
+    _CUSTOM_TOKENIZER_LOADERS.clear()
+
+
 @functools.lru_cache(maxsize=None)
 def setup_tokenizer(model_name_or_path: str) -> AutoTokenizer:
+    # Registry first so non-text RL workloads can short-circuit the
+    # HuggingFace path.  Loaders raising on a non-match should fall back
+    # gracefully to the default path.
+    for predicate, loader in _CUSTOM_TOKENIZER_LOADERS:
+        try:
+            matched = bool(predicate(model_name_or_path))
+        except Exception as e:
+            logger.warning(
+                f"Tokenizer loader predicate raised for {model_name_or_path}: {e}; skipping"
+            )
+            continue
+        if matched:
+            logger.info(
+                f"Tokenizer for {model_name_or_path} resolved via registered custom loader"
+            )
+            return loader(model_name_or_path)
+
     tokenizer = retry(AutoTokenizer.from_pretrained)(
         model_name_or_path,
         trust_remote_code=True,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -116,8 +116,14 @@ rl = [
     "flash-attn>=2.8.3",
 ]
 
+# Lightweight extra for non-LLM RL workloads (e.g. Gymnasium-based
+# Classic Control demos); avoids dragging in vllm / flash-attn.
+gym = [
+    "gymnasium>=0.29",
+]
+
 all = [
-    "cosmos_rl[wfm,vla,rl]",
+    "cosmos_rl[wfm,vla,rl,gym]",
 ]
 
 [tool.uv.sources]

--- a/tests/test_gym_api.py
+++ b/tests/test_gym_api.py
@@ -1,0 +1,290 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the Gym API extension surface (MR2)."""
+
+import os
+import tempfile
+import unittest
+
+import torch
+
+from cosmos_rl.dispatcher.data.packer.tensor_data_packer import (
+    ACTIONS,
+    EPISODE_LENGTH,
+    OBSERVATIONS,
+    REWARDS,
+    TensorDataPacker,
+)
+from cosmos_rl.utils.network_util import write_redis_config
+from cosmos_rl.utils.no_op_tokenizer import NoOpTokenizer
+
+
+class TestNoOpTokenizer(unittest.TestCase):
+    def test_standard_attributes_present(self):
+        tok = NoOpTokenizer()
+        for attr in [
+            "eos_token_id",
+            "pad_token_id",
+            "bos_token_id",
+            "unk_token_id",
+            "vocab_size",
+            "model_max_length",
+        ]:
+            self.assertTrue(hasattr(tok, attr), f"missing {attr}")
+
+    def test_encode_uses_episode_length(self):
+        tok = NoOpTokenizer()
+        ids = tok.encode({"episode_length": 7})
+        self.assertEqual(len(ids), 7)
+        self.assertTrue(all(i == 0 for i in ids))
+
+    def test_encode_unknown_input_returns_singleton(self):
+        tok = NoOpTokenizer()
+        self.assertEqual(tok.encode("hello"), [0])
+        self.assertEqual(tok.encode(123), [0])
+
+    def test_call_returns_batch_encoding_shape(self):
+        tok = NoOpTokenizer()
+        out = tok({"episode_length": 5})
+        self.assertEqual(out.input_ids.shape, (1, 5))
+        self.assertEqual(out.attention_mask.shape, (1, 5))
+        self.assertEqual(out["input_ids"].shape, (1, 5))
+        self.assertIn("input_ids", out.keys())
+
+    def test_decode_returns_empty(self):
+        tok = NoOpTokenizer()
+        self.assertEqual(tok.decode([0, 1, 2]), "")
+        self.assertEqual(tok.batch_decode([[0], [1], [2]]), ["", "", ""])
+
+    def test_episode_length_from_tensor(self):
+        # Scalar tensors should also work -- common when the rollout
+        # engine emits trajectories with torch.tensor(ep_len) fields.
+        tok = NoOpTokenizer()
+        out = tok({"episode_length": torch.tensor(4)})
+        self.assertEqual(out.input_ids.shape, (1, 4))
+
+
+class TestRegisterTokenizerLoader(unittest.TestCase):
+    def setUp(self):
+        # Lazy-import inside the test methods themselves to avoid pulling
+        # the heavy cosmos_rl.utils.util module at collection time.
+        from cosmos_rl.utils import util
+
+        self.util = util
+        util.clear_tokenizer_loaders()
+        # ``setup_tokenizer`` is ``functools.lru_cache``-wrapped, so
+        # cached results from previous tests would otherwise leak.
+        util.setup_tokenizer.cache_clear()
+
+    def tearDown(self):
+        self.util.clear_tokenizer_loaders()
+        self.util.setup_tokenizer.cache_clear()
+
+    def test_predicate_match_short_circuits_hf(self):
+        sentinel = NoOpTokenizer()
+
+        self.util.register_tokenizer_loader(
+            predicate=lambda p: p.endswith(".toml"),
+            loader=lambda p: sentinel,
+        )
+
+        result = self.util.setup_tokenizer("/tmp/example.toml")
+        self.assertIs(result, sentinel)
+
+    def test_predicate_miss_falls_back(self):
+        # No predicate matches -- the function should attempt the HF
+        # path.  Use a path that AutoTokenizer cannot resolve and
+        # expect a non-NoOp failure mode (i.e. an exception from
+        # AutoTokenizer / network), confirming we did not short-circuit.
+        self.util.register_tokenizer_loader(
+            predicate=lambda p: p.startswith("never_matches://"),
+            loader=lambda p: NoOpTokenizer(),
+        )
+        with self.assertRaises(Exception):
+            self.util.setup_tokenizer("/this/path/definitely/does/not/exist")
+
+
+class TestWriteRedisConfigTlsSkip(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.NamedTemporaryFile(mode="w", suffix=".conf", delete=False)
+        self.tmp.close()
+        self._saved_env = os.environ.pop("COSMOS_REDIS_NO_TLS", None)
+
+    def tearDown(self):
+        os.unlink(self.tmp.name)
+        if self._saved_env is not None:
+            os.environ["COSMOS_REDIS_NO_TLS"] = self._saved_env
+        else:
+            os.environ.pop("COSMOS_REDIS_NO_TLS", None)
+
+    def test_default_emits_tls_port(self):
+        write_redis_config(12800, "/tmp/r.log", file_path=self.tmp.name)
+        with open(self.tmp.name) as f:
+            content = f.read()
+        self.assertIn("tls-port 0", content)
+
+    def test_skip_via_kwarg(self):
+        write_redis_config(
+            12800, "/tmp/r.log", file_path=self.tmp.name, skip_tls_port=True
+        )
+        with open(self.tmp.name) as f:
+            content = f.read()
+        # Header comment is fine, but the actual directive must be gone.
+        self.assertNotIn("\ntls-port", content)
+
+    def test_skip_via_env(self):
+        os.environ["COSMOS_REDIS_NO_TLS"] = "1"
+        write_redis_config(12800, "/tmp/r.log", file_path=self.tmp.name)
+        with open(self.tmp.name) as f:
+            content = f.read()
+        self.assertNotIn("\ntls-port", content)
+
+    def test_env_falsey_keeps_default(self):
+        os.environ["COSMOS_REDIS_NO_TLS"] = "0"
+        write_redis_config(12800, "/tmp/r.log", file_path=self.tmp.name)
+        with open(self.tmp.name) as f:
+            content = f.read()
+        self.assertIn("tls-port 0", content)
+
+
+class TestModelConfigRegistry(unittest.TestCase):
+    def setUp(self):
+        from cosmos_rl.utils import model_config
+
+        self.model_config = model_config
+        model_config.clear_local_model_configs()
+
+    def tearDown(self):
+        self.model_config.clear_local_model_configs()
+
+    def test_matching_predicate_returns_factory_result(self):
+        from transformers import PretrainedConfig
+
+        class GymCfg(PretrainedConfig):
+            model_type = "gym_mlp"
+
+        self.model_config.register_local_model_config(
+            predicate=lambda p: p.endswith(".toml"),
+            factory=lambda p: GymCfg(),
+        )
+        cfg = self.model_config.load_model_config("/tmp/cartpole.toml")
+        self.assertEqual(cfg.model_type, "gym_mlp")
+
+    def test_non_matching_falls_back_to_auto_config(self):
+        # No predicate registered; expect AutoConfig to attempt and
+        # raise on a missing path.
+        with self.assertRaises(Exception):
+            self.model_config.load_model_config("/this/path/definitely/does/not/exist")
+
+
+class _ConcreteTensorPacker(TensorDataPacker):
+    """Minimal subclass to exercise the abstract surface.  No overrides
+    needed since the base class's defaults are already concrete for
+    tensor trajectories."""
+
+
+def _make_traj(length: int) -> dict:
+    return {
+        OBSERVATIONS: torch.zeros((length, 4)),
+        ACTIONS: torch.zeros((length,), dtype=torch.long),
+        REWARDS: torch.ones((length,)),
+        EPISODE_LENGTH: torch.tensor(length),
+    }
+
+
+class TestTensorDataPacker(unittest.TestCase):
+    def test_get_rollout_input_passthrough(self):
+        p = _ConcreteTensorPacker()
+        sample = {"prompt": '{"seed": 1}'}
+        self.assertEqual(p.get_rollout_input(sample), sample)
+
+    def test_policy_compute_max_len_uses_episode_length(self):
+        p = _ConcreteTensorPacker()
+        traj = [_make_traj(3), _make_traj(8), _make_traj(5)]
+        self.assertEqual(p.policy_compute_max_len(traj), 8)
+
+    def test_policy_compute_max_len_falls_back_to_obs_shape(self):
+        # Drop the episode_length field so the packer must look at the
+        # observation shape.
+        p = _ConcreteTensorPacker()
+        traj = _make_traj(7)
+        del traj[EPISODE_LENGTH]
+        self.assertEqual(p.policy_compute_max_len([traj]), 7)
+
+    def test_policy_collate_fn_keeps_trajectories(self):
+        p = _ConcreteTensorPacker()
+        traj = [_make_traj(3), _make_traj(8)]
+        out = p.policy_collate_fn(traj, computed_max_len=8)
+        self.assertEqual(out["trajectories"], traj)
+
+    def test_get_rollout_output_passthrough(self):
+        p = _ConcreteTensorPacker()
+        completions = [_make_traj(2)]
+        out = p.get_rollout_output(completions, [], [], [])
+        self.assertIs(out[0], completions)
+
+    def test_is_trajectory_detects_dict_shape(self):
+        self.assertTrue(TensorDataPacker.is_trajectory(_make_traj(4)))
+        self.assertFalse(TensorDataPacker.is_trajectory({"prompt": "x"}))
+        self.assertFalse(TensorDataPacker.is_trajectory("not a dict"))
+
+
+# IdentityWeightMapper now lives in ``cosmos_rl.policy.model.base`` (moved
+# in the second review round of #677 -- it was previously its own module).
+# The base module's package __init__.py transitively imports diffusers, so
+# we still skip cleanly when the optional ``diffusers`` extra is not
+# installed -- a test-harness limitation; the mapper itself does not depend
+# on diffusers and works fine in a real cosmos-rl environment.
+try:
+    from cosmos_rl.policy.model.base import IdentityWeightMapper
+
+    _IDENTITY_WEIGHT_MAPPER_IMPORTABLE = True
+    _IDENTITY_WEIGHT_MAPPER_SKIP_REASON = ""
+except ImportError as _e:  # noqa: BLE001
+    IdentityWeightMapper = None  # type: ignore[assignment]
+    _IDENTITY_WEIGHT_MAPPER_IMPORTABLE = False
+    _IDENTITY_WEIGHT_MAPPER_SKIP_REASON = (
+        f"cosmos_rl.policy.model package not importable in this env "
+        f"(missing optional dep: {_e}). The mapper itself does not depend "
+        f"on diffusers; this is a harness-only limitation."
+    )
+
+
+@unittest.skipUnless(
+    _IDENTITY_WEIGHT_MAPPER_IMPORTABLE, _IDENTITY_WEIGHT_MAPPER_SKIP_REASON
+)
+class TestIdentityWeightMapper(unittest.TestCase):
+    def test_constructable_without_hf_config(self):
+        mapper = IdentityWeightMapper()
+        self.assertEqual(
+            mapper.policy_map_local_key_to_hf_key("fc.weight"), "fc.weight"
+        )
+        self.assertEqual(
+            mapper.rollout_map_local_key_to_hf_key("fc.weight"), "fc.weight"
+        )
+
+    def test_no_split(self):
+        mapper = IdentityWeightMapper()
+        t = torch.zeros((4, 4))
+        out = mapper.rollout_split_local_key_n_param_to_hf_key_n_param("a.b", t)
+        self.assertEqual(len(out), 1)
+        name, tensor = out[0]
+        self.assertEqual(name, "a.b")
+        self.assertIs(tensor, t)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Introduces the upstream surface that lets non-text RL tasks (e.g. Gymnasium-based Classic Control) drive the cosmos-rl pipeline without monkey-patching:

* cosmos_rl.utils.util.register_tokenizer_loader(): predicate-keyed registry consulted before the default HuggingFace AutoTokenizer path.
* cosmos_rl.utils.no_op_tokenizer.NoOpTokenizer: duck-typed tokenizer shim sized by trajectory ``episode_length`` for completion-length statistics.
* cosmos_rl.utils.network_util.write_redis_config(skip_tls_port=...): optional skip of the ``tls-port`` directive (Redis < 6.0 compatibility) controlled by kwarg or COSMOS_REDIS_NO_TLS env var.
* cosmos_rl.utils.model_config.{register_local_model_config, load_model_config}: pluggable model-config loader for non-HF paths; falls back to AutoConfig.from_pretrained when no predicate matches.
* cosmos_rl.dispatcher.data.packer.tensor_data_packer.TensorDataPacker: generic non-text data packer with canonical trajectory field names.
* cosmos_rl.policy.model.identity_weight_mapper.IdentityWeightMapper: one-line WeightMapper drop-in for single-rank, non-sharded MLP-sized RL policies.

A new ``gym`` extra (``pip install cosmos_rl[gym]``) pulls in ``gymnasium`` for non-LLM workloads without dragging in vllm / flash-attn.

Tests cover the new registries, the redis TLS skip env/kwarg, the TensorDataPacker collation contract, and the IdentityWeightMapper identity behavior.