### PR TITLE
feat: Gymnasium Classic Control example (CartPole / Pendulum)

### DIFF
--- a/cosmos_rl/tools/gym_example/README.md
+++ b/cosmos_rl/tools/gym_example/README.md
@@ -1,0 +1,121 @@
+# Gymnasium Classic Control example
+
+A minimal end-to-end demo of running cosmos-rl with a non-LLM RL
+workload, using the [Gymnasium Classic Control suite](https://gymnasium.farama.org/environments/classic_control/)
+as the reference environment.
+
+## What this demonstrates
+
+* The Gym API extension hooks (`register_tokenizer_loader`,
+  `register_local_model_config`, `TensorDataPacker`,
+  `IdentityWeightMapper`) wiring a tiny MLP policy and a
+  `gymnasium.Env` into the standard cosmos-rl pipeline.
+* Two payload-transfer profiles (Redis and UCXX) selected via
+  `[custom].payload_transfer` so colocated and disaggregated launches
+  share the same code.
+* Both **discrete** (CartPole-v1) and **continuous** (Pendulum-v1)
+  action spaces.
+
+## Layout
+
+```
+cosmos_rl/tools/gym_example/
+├── __init__.py            re-exports the example surface
+├── README.md              this file
+├── gym_policy.py          GymPolicy + GymMLPConfig + register_gym_policy()
+├── gym_rollout.py         GymRolloutEngine + rollout_episode()
+├── gym_data_packer.py     GymDataPacker (TensorDataPacker subclass)
+└── configs/
+    ├── cartpole_colocated.toml       primary, Redis transport
+    ├── cartpole_disaggregated.toml   UCXX transport
+    └── pendulum_colocated.toml       continuous-action variant
+```
+
+## Install
+
+```bash
+pip install "cosmos_rl[gym]"        # primary path (CartPole / Pendulum)
+pip install "cosmos_rl[gym,ucxx]"   # add UCXX transport for disaggregated mode
+```
+
+## Standalone (no controller) sanity check
+
+The policy and rollout engine can be exercised directly without
+spinning up the full cosmos-rl controller / dispatcher — useful for
+local iteration and debugging:
+
+```python
+import gymnasium as gym
+from cosmos_rl.tools.gym_example import (
+    GymMLPConfig, GymPolicy, GymRolloutEngine,
+)
+
+policy = GymPolicy(GymMLPConfig(obs_dim=4, action_dim=2, discrete=True))
+engine = GymRolloutEngine(
+    env_factory=lambda: gym.make("CartPole-v1"),
+    policy=policy,
+    max_steps=200,
+)
+traj = engine.run({"seed": 42})
+print({k: v.shape for k, v in traj.items()})
+# {'observations': (200, 4), 'actions': (200,), 'rewards': (200,),
+#  'terminated': (200,), 'truncated': (200,), 'episode_length': (1,)}
+```
+
+## Wiring it into cosmos-rl
+
+```python
+from cosmos_rl.tools.gym_example import (
+    GymDataPacker, GymPolicy, register_gym_policy,
+)
+from cosmos_rl.policy.model.identity_weight_mapper import IdentityWeightMapper
+
+# 1. Register the .toml -> NoOpTokenizer + GymMLPConfig handlers.
+register_gym_policy()
+
+# 2. Use IdentityWeightMapper for the (single-rank, non-sharded) MLP.
+#    Hand the policy and mapper to ModelRegistry.register_model() in
+#    your custom_class.py, and set:
+#       [policy] model_name_or_path = "configs/cartpole_colocated.toml"
+#       [policy] model_class        = "GymPolicy"
+#       [policy] data_packer_class  = "GymDataPacker"
+```
+
+The full launcher integration lives in your project's `custom_class.py`
+because cosmos-rl uses dotted-path imports for trainer / data-packer /
+weight-mapper resolution; the example components above are designed to
+be drop-in.
+
+## Pendulum-v1
+
+Swap the config and pass `discrete=False`:
+
+```toml
+[model]
+obs_dim    = 3
+action_dim = 1
+discrete   = false
+
+[env]
+name      = "Pendulum-v1"
+max_steps = 200
+```
+
+`GymPolicy` automatically swaps in a Gaussian (mean / log_std) head
+for continuous-action environments.
+
+## Going beyond Classic Control
+
+Because the rollout engine is just a thin driver around a user-supplied
+`env_factory`, swapping in a more interesting environment (e.g.
+`gym.make("LunarLander-v2")`) is a one-line change.  Match the
+config's `obs_dim` / `action_dim` / `discrete` fields to the new
+environment's `observation_space` / `action_space` and you're done.
+
+## Profiling
+
+When the [profiler](../profiler/README.md) tooling lands, this example
+ships with no extra wiring needed — the rollout engine already emits
+`[Trace]` lines through `cosmos_rl.utils.trace.format_trace()` (when
+the trace utility MR is also installed) and the analyzer picks them up
+automatically.

--- a/cosmos_rl/tools/gym_example/__init__.py
+++ b/cosmos_rl/tools/gym_example/__init__.py
@@ -1,0 +1,51 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Gymnasium Classic Control example for cosmos-rl.
+
+This package demonstrates how to drive a non-LLM RL workload through
+the cosmos-rl pipeline using the extension hooks added by the Gym API
+MR (``register_tokenizer_loader``, ``register_local_model_config``,
+``TensorDataPacker``, ``IdentityWeightMapper``).
+
+Reference environments (Gymnasium Classic Control suite):
+
+* **CartPole-v1** (primary) — discrete 2-action control, 4-dim
+  observation; the canonical "hello world" of RL.
+* **Pendulum-v1** (noted) — continuous 1-dim action over a 3-dim
+  observation; useful for validating continuous-action wiring.
+
+See ``README.md`` in this directory for a launch walkthrough.
+"""
+
+from cosmos_rl.tools.gym_example.gym_data_packer import GymDataPacker
+from cosmos_rl.tools.gym_example.gym_policy import (
+    GymMLPConfig,
+    GymPolicy,
+    register_gym_policy,
+)
+from cosmos_rl.tools.gym_example.gym_rollout import (
+    GymRolloutEngine,
+    rollout_episode,
+)
+
+__all__ = [
+    "GymDataPacker",
+    "GymMLPConfig",
+    "GymPolicy",
+    "GymRolloutEngine",
+    "register_gym_policy",
+    "rollout_episode",
+]

--- a/cosmos_rl/tools/gym_example/configs/cartpole_colocated.toml
+++ b/cosmos_rl/tools/gym_example/configs/cartpole_colocated.toml
@@ -1,0 +1,29 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# CartPole-v1 demo — colocated mode (rollout + trainer share one node).
+# Drop in as the [policy].model_name_or_path's sibling for a TOML-driven
+# launch, or load with `register_gym_policy()` then point cosmos-rl at
+# this file via `policy.model_name_or_path = "configs/cartpole.toml"`.
+
+[model]
+obs_dim     = 4
+action_dim  = 2
+hidden_dim  = 64
+discrete    = true
+
+[env]
+name        = "CartPole-v1"
+max_steps   = 500
+
+[custom]
+# Use the implicit Redis transport: payload sizes are tiny so there's
+# no benefit to NCCL/UCXX for CartPole.  Switch to "ucxx" or "nccl"
+# when scaling up to larger observation tensors.
+payload_transfer = "redis"
+
+[train]
+train_batch_per_replica = 4
+
+[rollout]
+n_generation = 1

--- a/cosmos_rl/tools/gym_example/configs/cartpole_disaggregated.toml
+++ b/cosmos_rl/tools/gym_example/configs/cartpole_disaggregated.toml
@@ -1,0 +1,28 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# CartPole-v1 demo — disaggregated mode (rollout workers and trainer
+# run on separate nodes).  Mirrors the colocated config but switches
+# the payload transport to UCXX so the cross-node hop is zero-copy.
+
+[model]
+obs_dim     = 4
+action_dim  = 2
+hidden_dim  = 64
+discrete    = true
+
+[env]
+name        = "CartPole-v1"
+max_steps   = 500
+
+[custom]
+# UCXX auto-routes between SHM (same node) and RDMA (cross-node), so
+# this single setting works for both.  Requires `pip install
+# cosmos_rl[ucxx]`.
+payload_transfer = "ucxx"
+
+[train]
+train_batch_per_replica = 8
+
+[rollout]
+n_generation = 1

--- a/cosmos_rl/tools/gym_example/configs/pendulum_colocated.toml
+++ b/cosmos_rl/tools/gym_example/configs/pendulum_colocated.toml
@@ -1,0 +1,25 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Pendulum-v1 demo — continuous-action variant of the CartPole demo.
+# Use this as the smoke test for the continuous-action wiring of
+# GymPolicy / GymRolloutEngine.
+
+[model]
+obs_dim     = 3
+action_dim  = 1
+hidden_dim  = 64
+discrete    = false
+
+[env]
+name        = "Pendulum-v1"
+max_steps   = 200
+
+[custom]
+payload_transfer = "redis"
+
+[train]
+train_batch_per_replica = 4
+
+[rollout]
+n_generation = 1

--- a/cosmos_rl/tools/gym_example/gym_data_packer.py
+++ b/cosmos_rl/tools/gym_example/gym_data_packer.py
@@ -1,0 +1,93 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Gym-flavored data packer.
+
+Subclasses :class:`TensorDataPacker` to:
+
+* Parse the dataset's ``prompt`` field as JSON-encoded initial
+  conditions (typically just ``{"seed": 42}``) before handing it to
+  the rollout engine.
+* Echo the trajectory dict produced by the rollout engine straight
+  through to the trainer (no transport-side translation needed for
+  the in-process / Redis demo).
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Dict
+
+from cosmos_rl.dispatcher.data.packer.tensor_data_packer import (
+    EPISODE_LENGTH,
+    OBSERVATIONS,
+    TensorDataPacker,
+)
+from cosmos_rl.utils.logging import logger
+
+
+class GymDataPacker(TensorDataPacker):
+    """Tensor data packer for Gymnasium-driven rollouts."""
+
+    def get_rollout_input(self, item: Any, **kwargs) -> Dict[str, Any]:
+        """Decode the dataset ``prompt`` JSON into a dict of init conditions.
+
+        Cosmos-RL conventionally puts ``{"prompt": "..."}`` on the
+        dataset; for a non-text task we treat the prompt string as a
+        small JSON document carrying e.g. the env seed and any
+        environment-specific overrides.  Plain strings (or missing
+        prompts) fall back to an empty dict so the rollout engine can
+        use sensible defaults.
+        """
+        prompt = item.get("prompt") if isinstance(item, dict) else None
+        if not prompt:
+            return {}
+        if isinstance(prompt, dict):
+            return prompt
+        try:
+            return json.loads(prompt)
+        except (TypeError, json.JSONDecodeError):
+            logger.debug(
+                f"[GymDataPacker] prompt is not JSON, passing through verbatim: "
+                f"{prompt!r}"
+            )
+            return {"prompt": prompt}
+
+    def policy_compute_max_len(self, processed_samples) -> int:
+        """Same logic as the base class but defaults to the OBS-shape
+        fallback first since the Gym example always emits
+        ``OBSERVATIONS`` and ``EPISODE_LENGTH`` is sometimes a Python
+        int rather than a tensor.  Inherits the safe-floor of 1."""
+        max_len = 1
+        for item in processed_samples:
+            if not isinstance(item, dict):
+                continue
+            ep_len = item.get(EPISODE_LENGTH)
+            if ep_len is None:
+                obs = item.get(OBSERVATIONS)
+                if hasattr(obs, "shape") and len(obs.shape) > 0:
+                    ep_len = int(obs.shape[0])
+            if ep_len is None:
+                continue
+            try:
+                ep_len_int = int(ep_len.item() if hasattr(ep_len, "item") else ep_len)
+            except (TypeError, ValueError):
+                continue
+            if ep_len_int > max_len:
+                max_len = ep_len_int
+        return max_len
+
+
+__all__ = ["GymDataPacker"]

--- a/cosmos_rl/tools/gym_example/gym_policy.py
+++ b/cosmos_rl/tools/gym_example/gym_policy.py
@@ -1,0 +1,201 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Minimal MLP policy for the Gymnasium Classic Control demo.
+
+Two flavors are supported through a single :class:`GymPolicy` module:
+
+* **Discrete actions** (CartPole) — outputs categorical logits.
+* **Continuous actions** (Pendulum) — outputs a Gaussian (mean, log_std).
+
+The model is intentionally tiny (~2k params for CartPole) so the demo
+fits comfortably on CPU and exercises the cosmos-rl pipeline without
+GPU contention.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+import torch
+import torch.nn as nn
+from torch.distributions import Categorical, Normal
+
+try:
+    from transformers import PretrainedConfig
+except ImportError:  # pragma: no cover - transformers is a required dep of cosmos_rl
+    PretrainedConfig = object  # type: ignore[assignment, misc]
+
+
+_GYM_MODEL_TYPE = "cosmos_rl_gym_mlp"
+
+
+@dataclass
+class GymMLPConfigSpec:
+    """Plain-dataclass mirror of :class:`GymMLPConfig` — used by tests
+    and by the local model-config loader to avoid pulling in the heavy
+    HuggingFace ``PretrainedConfig`` machinery."""
+
+    obs_dim: int = 4
+    action_dim: int = 2
+    hidden_dim: int = 64
+    discrete: bool = True
+
+
+class GymMLPConfig(PretrainedConfig):  # type: ignore[misc]
+    """HuggingFace-shaped config so cosmos-rl's ModelRegistry can key
+    on ``model_type``.
+
+    The fields mirror :class:`GymMLPConfigSpec` and are populated either
+    from a TOML file (via the local model-config loader registered in
+    :func:`register_gym_policy`) or directly via kwargs in tests.
+    """
+
+    model_type = _GYM_MODEL_TYPE
+
+    def __init__(
+        self,
+        obs_dim: int = 4,
+        action_dim: int = 2,
+        hidden_dim: int = 64,
+        discrete: bool = True,
+        **kwargs,
+    ):
+        super().__init__(**kwargs)
+        self.obs_dim = obs_dim
+        self.action_dim = action_dim
+        self.hidden_dim = hidden_dim
+        self.discrete = discrete
+
+
+class GymPolicy(nn.Module):
+    """Two-layer MLP with a discrete- or continuous-action head.
+
+    For discrete actions the head emits ``action_dim`` logits; for
+    continuous actions it emits ``2 * action_dim`` numbers (mean and
+    log_std stacked).  ``act()`` samples and returns
+    ``(action, log_prob)`` tensors so the rollout engine can record
+    log-probs alongside the trajectory.
+    """
+
+    def __init__(self, config: GymMLPConfig):
+        super().__init__()
+        self.config = config
+        self.discrete = config.discrete
+
+        head_out = config.action_dim if config.discrete else 2 * config.action_dim
+        self.net = nn.Sequential(
+            nn.Linear(config.obs_dim, config.hidden_dim),
+            nn.Tanh(),
+            nn.Linear(config.hidden_dim, config.hidden_dim),
+            nn.Tanh(),
+            nn.Linear(config.hidden_dim, head_out),
+        )
+        # A separate value head is useful for actor-critic; we expose it
+        # so a future PPO trainer can plug in without restructuring the
+        # policy.
+        self.value_head = nn.Linear(config.hidden_dim, 1)
+
+    def forward(self, obs: torch.Tensor) -> torch.Tensor:
+        return self.net(obs)
+
+    def features(self, obs: torch.Tensor) -> torch.Tensor:
+        # All but the last layer; useful for the value head.
+        x = obs
+        for layer in list(self.net)[:-1]:
+            x = layer(x)
+        return x
+
+    def value(self, obs: torch.Tensor) -> torch.Tensor:
+        return self.value_head(self.features(obs)).squeeze(-1)
+
+    def act(self, obs: torch.Tensor):
+        """Sample an action and return (action, log_prob).
+
+        Returns:
+            For discrete: ``(action: int64 tensor, log_prob: float tensor)``.
+            For continuous: ``(action: float tensor, log_prob: float tensor)``.
+        """
+        out = self.forward(obs)
+        if self.discrete:
+            dist = Categorical(logits=out)
+            action = dist.sample()
+            return action, dist.log_prob(action)
+
+        action_dim = self.config.action_dim
+        mean, log_std = out.split(action_dim, dim=-1)
+        std = log_std.exp()
+        dist = Normal(mean, std)
+        action = dist.sample()
+        # Sum log-probs across action dims for a single per-step value.
+        log_prob = dist.log_prob(action).sum(dim=-1)
+        return action, log_prob
+
+
+def register_gym_policy(
+    *,
+    model_type: str = _GYM_MODEL_TYPE,
+    config_path_predicate: Optional[callable] = None,
+) -> None:
+    """Register the Gym MLP policy with cosmos-rl's registries.
+
+    Wires up:
+
+    * :class:`~cosmos_rl.utils.no_op_tokenizer.NoOpTokenizer` for any
+      ``policy.model_name_or_path`` ending in ``.toml``.
+    * Local model-config loader so the same ``.toml`` resolves to a
+      :class:`GymMLPConfig`.
+    * (Optional, deferred) ``ModelRegistry.register_model`` would tie
+      the policy class to the registry; for the example we keep
+      registration explicit in user code so reviewers can see it.
+
+    Args:
+        model_type: Identifier matched against the TOML's ``model_type``
+            field (default: ``"cosmos_rl_gym_mlp"``).
+        config_path_predicate: Optional override for the predicate used
+            to detect "this is a Gym TOML config" paths.  Defaults to a
+            simple ``.toml`` extension check.
+    """
+    import toml
+
+    from cosmos_rl.utils.model_config import register_local_model_config
+    from cosmos_rl.utils.no_op_tokenizer import NoOpTokenizer
+    from cosmos_rl.utils.util import register_tokenizer_loader
+
+    predicate = config_path_predicate or (lambda p: p.endswith(".toml"))
+
+    def _load_gym_config(path: str) -> GymMLPConfig:
+        data = toml.load(path)
+        # Nested under [model] for clarity in TOML; flat fallback for
+        # convenience in tests.
+        section = data.get("model", data)
+        return GymMLPConfig(
+            obs_dim=int(section.get("obs_dim", 4)),
+            action_dim=int(section.get("action_dim", 2)),
+            hidden_dim=int(section.get("hidden_dim", 64)),
+            discrete=bool(section.get("discrete", True)),
+        )
+
+    register_tokenizer_loader(predicate=predicate, loader=lambda _p: NoOpTokenizer())
+    register_local_model_config(predicate=predicate, factory=_load_gym_config)
+
+
+__all__ = [
+    "GymMLPConfig",
+    "GymMLPConfigSpec",
+    "GymPolicy",
+    "register_gym_policy",
+]

--- a/cosmos_rl/tools/gym_example/gym_rollout.py
+++ b/cosmos_rl/tools/gym_example/gym_rollout.py
@@ -1,0 +1,232 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Gymnasium-driven rollout engine.
+
+Drives a user-supplied :class:`gymnasium.Env` factory and produces
+trajectory dicts in the canonical
+:class:`~cosmos_rl.dispatcher.data.packer.tensor_data_packer.TensorDataPacker`
+format so the trainer can consume them directly.
+
+This module intentionally does **not** subclass
+:class:`cosmos_rl.rollout.rollout_base.RolloutBase` so the example can
+be exercised standalone (without the full controller / dispatcher
+boot).  A thin wrapper that registers the engine with cosmos-rl's
+``RolloutRegistry`` is provided in the package README.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Callable, Dict, Optional
+
+import numpy as np
+import torch
+
+from cosmos_rl.dispatcher.data.packer.tensor_data_packer import (
+    ACTIONS,
+    EPISODE_LENGTH,
+    OBSERVATIONS,
+    REWARDS,
+    TERMINATED,
+    TRUNCATED,
+)
+from cosmos_rl.tools.gym_example.gym_policy import GymPolicy
+from cosmos_rl.utils.logging import logger
+
+
+# Type alias for an env factory: takes nothing and returns a fresh env.
+EnvFactory = Callable[[], Any]
+
+
+def rollout_episode(
+    env: Any,
+    policy: GymPolicy,
+    *,
+    max_steps: int,
+    seed: Optional[int] = None,
+    deterministic: bool = False,
+) -> Dict[str, np.ndarray]:
+    """Run a single episode and return a trajectory dict.
+
+    The trajectory dict has fixed-length numpy arrays sized
+    ``max_steps`` so it lines up with the UCXX schema layout used by
+    other transports.  The actual valid prefix length is recorded in
+    ``episode_length``; positions ``[ep_len:]`` are zero padding.
+
+    Args:
+        env: A constructed :class:`gymnasium.Env`.
+        policy: A :class:`GymPolicy` whose ``act()`` returns
+            ``(action, log_prob)``.
+        max_steps: Hard cap on rollout length (also the padded shape).
+        seed: Optional reset seed for reproducibility.
+        deterministic: If True, ignores the policy's stochastic head and
+            takes the argmax / mean.
+
+    Returns:
+        Dict with keys ``observations``, ``actions``, ``rewards``,
+        ``terminated``, ``truncated``, ``episode_length``.
+    """
+    obs_dim = policy.config.obs_dim
+    action_dim = policy.config.action_dim
+    discrete = policy.config.discrete
+
+    if discrete:
+        actions_buf = np.zeros((max_steps,), dtype=np.int64)
+    else:
+        actions_buf = np.zeros((max_steps, action_dim), dtype=np.float32)
+    obs_buf = np.zeros((max_steps, obs_dim), dtype=np.float32)
+    rew_buf = np.zeros((max_steps,), dtype=np.float32)
+    term_buf = np.zeros((max_steps,), dtype=np.bool_)
+    trunc_buf = np.zeros((max_steps,), dtype=np.bool_)
+
+    reset_kwargs = {} if seed is None else {"seed": int(seed)}
+    obs, _info = env.reset(**reset_kwargs)
+    ep_len = 0
+    with torch.no_grad():
+        for step in range(max_steps):
+            obs_buf[step] = np.asarray(obs, dtype=np.float32)
+            obs_t = torch.from_numpy(obs_buf[step]).unsqueeze(0)
+            if deterministic:
+                logits = policy(obs_t)
+                if discrete:
+                    action = int(logits.argmax(dim=-1).item())
+                else:
+                    mean = logits[..., :action_dim]
+                    action = mean.squeeze(0).cpu().numpy()
+            else:
+                action_t, _logp = policy.act(obs_t)
+                if discrete:
+                    action = int(action_t.item())
+                else:
+                    action = action_t.squeeze(0).cpu().numpy()
+
+            if discrete:
+                actions_buf[step] = action
+                step_action = action
+            else:
+                actions_buf[step] = action
+                step_action = action
+
+            next_obs, reward, terminated, truncated, _info = env.step(step_action)
+            rew_buf[step] = float(reward)
+            term_buf[step] = bool(terminated)
+            trunc_buf[step] = bool(truncated)
+            ep_len += 1
+            if terminated or truncated:
+                break
+            obs = next_obs
+
+    return {
+        OBSERVATIONS: obs_buf,
+        ACTIONS: actions_buf,
+        REWARDS: rew_buf,
+        TERMINATED: term_buf,
+        TRUNCATED: trunc_buf,
+        EPISODE_LENGTH: np.array([ep_len], dtype=np.int64),
+    }
+
+
+class GymRolloutEngine:
+    """Standalone rollout engine that drives a Gymnasium env factory.
+
+    Usage::
+
+        import gymnasium as gym
+
+        engine = GymRolloutEngine(
+            env_factory=lambda: gym.make("CartPole-v1"),
+            policy=policy,
+            max_steps=200,
+        )
+        traj = engine.run({"seed": 42})
+
+    The wrapper that adapts this to cosmos-rl's
+    :class:`~cosmos_rl.rollout.rollout_base.RolloutBase` interface is
+    documented in the package README; it amounts to a
+    ``rollout_generation()`` method that calls :meth:`run` per
+    payload.
+    """
+
+    def __init__(
+        self,
+        *,
+        env_factory: EnvFactory,
+        policy: GymPolicy,
+        max_steps: int = 500,
+    ):
+        self.env_factory = env_factory
+        self.policy = policy
+        self.max_steps = max_steps
+        self._env = None
+
+    def _ensure_env(self):
+        if self._env is None:
+            self._env = self.env_factory()
+        return self._env
+
+    def run(self, init: Optional[Dict[str, Any]] = None) -> Dict[str, np.ndarray]:
+        """Generate one trajectory.
+
+        Args:
+            init: Optional dict with ``seed`` (int) and / or
+                ``deterministic`` (bool) overrides.  Anything else is
+                ignored with a debug log so users can extend the
+                contract without breakage.
+
+        Returns:
+            Trajectory dict from :func:`rollout_episode`.
+        """
+        env = self._ensure_env()
+        seed = None
+        deterministic = False
+        if init:
+            seed = init.get("seed")
+            deterministic = bool(init.get("deterministic", False))
+            unknown = set(init) - {"seed", "deterministic"}
+            if unknown:
+                logger.debug(
+                    f"[GymRolloutEngine] Ignoring unknown init keys: {sorted(unknown)}"
+                )
+        return rollout_episode(
+            env,
+            self.policy,
+            max_steps=self.max_steps,
+            seed=seed,
+            deterministic=deterministic,
+        )
+
+    def close(self) -> None:
+        if self._env is not None:
+            try:
+                self._env.close()
+            except Exception:
+                pass
+            self._env = None
+
+    @staticmethod
+    def init_from_prompt(prompt: Any) -> Dict[str, Any]:
+        """Decode a dataset prompt into an :meth:`run` ``init`` dict."""
+        if isinstance(prompt, dict):
+            return prompt
+        if not prompt:
+            return {}
+        try:
+            return json.loads(prompt)
+        except (TypeError, json.JSONDecodeError):
+            return {}
+
+
+__all__ = ["EnvFactory", "GymRolloutEngine", "rollout_episode"]

--- a/tests/test_gym_example.py
+++ b/tests/test_gym_example.py
@@ -1,0 +1,362 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the Gymnasium Classic Control example (MR4)."""
+
+import os
+import tempfile
+import unittest
+
+import numpy as np
+import torch
+
+from cosmos_rl.dispatcher.data.packer.tensor_data_packer import (
+    ACTIONS,
+    EPISODE_LENGTH,
+    OBSERVATIONS,
+    REWARDS,
+    TERMINATED,
+    TRUNCATED,
+)
+from cosmos_rl.tools.gym_example import (
+    GymDataPacker,
+    GymMLPConfig,
+    GymPolicy,
+    GymRolloutEngine,
+    register_gym_policy,
+    rollout_episode,
+)
+
+
+# ---------------------------------------------------------------------------
+# A minimal stand-in for gymnasium.Env so tests work without installing the
+# `gymnasium` extra.
+# ---------------------------------------------------------------------------
+
+
+class _FakeDiscreteEnv:
+    """4-dim observation, 2-dim discrete action; episode ends after
+    ``terminate_after`` steps with a small per-step reward of ``+1``.
+
+    Faithful enough to validate the rollout engine's contract
+    (reset returns ``(obs, info)``, step returns
+    ``(obs, reward, terminated, truncated, info)``)."""
+
+    def __init__(self, obs_dim: int = 4, terminate_after: int = 5):
+        self.obs_dim = obs_dim
+        self.terminate_after = terminate_after
+        self._step = 0
+        self._rng = np.random.default_rng(0)
+
+    def reset(self, *, seed=None):
+        if seed is not None:
+            self._rng = np.random.default_rng(int(seed))
+        self._step = 0
+        return self._rng.standard_normal(self.obs_dim).astype(np.float32), {}
+
+    def step(self, action):
+        self._step += 1
+        terminated = self._step >= self.terminate_after
+        truncated = False
+        return (
+            self._rng.standard_normal(self.obs_dim).astype(np.float32),
+            1.0,
+            terminated,
+            truncated,
+            {},
+        )
+
+    def close(self):
+        pass
+
+
+class _FakeContinuousEnv:
+    """3-dim observation, 1-dim continuous action; ends after
+    ``terminate_after`` steps with reward = -|action|."""
+
+    def __init__(self, action_dim: int = 1, terminate_after: int = 4):
+        self.action_dim = action_dim
+        self.terminate_after = terminate_after
+        self._step = 0
+
+    def reset(self, *, seed=None):
+        self._step = 0
+        return np.zeros(3, dtype=np.float32), {}
+
+    def step(self, action):
+        self._step += 1
+        terminated = self._step >= self.terminate_after
+        return (
+            np.zeros(3, dtype=np.float32),
+            -float(np.abs(np.asarray(action)).sum()),
+            terminated,
+            False,
+            {},
+        )
+
+    def close(self):
+        pass
+
+
+# ---------------------------------------------------------------------------
+# GymPolicy
+# ---------------------------------------------------------------------------
+
+
+class TestGymPolicyDiscrete(unittest.TestCase):
+    def setUp(self):
+        torch.manual_seed(0)
+        self.cfg = GymMLPConfig(obs_dim=4, action_dim=2, hidden_dim=8, discrete=True)
+        self.policy = GymPolicy(self.cfg)
+
+    def test_forward_shape(self):
+        out = self.policy(torch.zeros(3, 4))
+        self.assertEqual(out.shape, (3, 2))
+
+    def test_act_returns_action_and_logprob(self):
+        action, logp = self.policy.act(torch.zeros(1, 4))
+        self.assertEqual(action.shape, (1,))
+        self.assertEqual(action.dtype, torch.int64)
+        self.assertEqual(logp.shape, (1,))
+        self.assertTrue(torch.all(action >= 0) and torch.all(action < 2))
+
+    def test_value_head_emits_scalar_per_obs(self):
+        v = self.policy.value(torch.zeros(5, 4))
+        self.assertEqual(v.shape, (5,))
+
+
+class TestGymPolicyContinuous(unittest.TestCase):
+    def setUp(self):
+        torch.manual_seed(0)
+        self.cfg = GymMLPConfig(obs_dim=3, action_dim=1, hidden_dim=8, discrete=False)
+        self.policy = GymPolicy(self.cfg)
+
+    def test_head_emits_two_action_dim_values(self):
+        # Continuous head outputs (mean, log_std) so total = 2*action_dim.
+        out = self.policy(torch.zeros(2, 3))
+        self.assertEqual(out.shape, (2, 2))
+
+    def test_act_returns_float_action(self):
+        action, logp = self.policy.act(torch.zeros(1, 3))
+        self.assertEqual(action.shape, (1, 1))
+        self.assertEqual(action.dtype, torch.float32)
+        self.assertEqual(logp.shape, (1,))
+
+
+# ---------------------------------------------------------------------------
+# GymDataPacker
+# ---------------------------------------------------------------------------
+
+
+class TestGymDataPacker(unittest.TestCase):
+    def test_get_rollout_input_decodes_json_prompt(self):
+        p = GymDataPacker()
+        out = p.get_rollout_input({"prompt": '{"seed": 42}'})
+        self.assertEqual(out, {"seed": 42})
+
+    def test_get_rollout_input_passthrough_dict_prompt(self):
+        p = GymDataPacker()
+        out = p.get_rollout_input({"prompt": {"seed": 7, "deterministic": True}})
+        self.assertEqual(out, {"seed": 7, "deterministic": True})
+
+    def test_get_rollout_input_empty_prompt_returns_empty_dict(self):
+        p = GymDataPacker()
+        self.assertEqual(p.get_rollout_input({"prompt": ""}), {})
+        self.assertEqual(p.get_rollout_input({}), {})
+
+    def test_get_rollout_input_non_json_falls_back_to_dict(self):
+        p = GymDataPacker()
+        out = p.get_rollout_input({"prompt": "not-json-but-truthy"})
+        self.assertEqual(out, {"prompt": "not-json-but-truthy"})
+
+    def test_policy_compute_max_len_uses_episode_length(self):
+        p = GymDataPacker()
+        traj = [
+            {OBSERVATIONS: np.zeros((10, 4)), EPISODE_LENGTH: 7},
+            {OBSERVATIONS: np.zeros((10, 4)), EPISODE_LENGTH: 3},
+        ]
+        self.assertEqual(p.policy_compute_max_len(traj), 7)
+
+    def test_policy_compute_max_len_falls_back_to_obs_shape(self):
+        p = GymDataPacker()
+        traj = [{OBSERVATIONS: np.zeros((9, 4))}]
+        self.assertEqual(p.policy_compute_max_len(traj), 9)
+
+
+# ---------------------------------------------------------------------------
+# Rollout engine
+# ---------------------------------------------------------------------------
+
+
+class TestRolloutEpisodeDiscrete(unittest.TestCase):
+    def setUp(self):
+        torch.manual_seed(0)
+        cfg = GymMLPConfig(obs_dim=4, action_dim=2, hidden_dim=8, discrete=True)
+        self.policy = GymPolicy(cfg)
+
+    def test_trajectory_shape_and_dtypes(self):
+        env = _FakeDiscreteEnv(obs_dim=4, terminate_after=3)
+        traj = rollout_episode(env, self.policy, max_steps=8, seed=1)
+        self.assertEqual(traj[OBSERVATIONS].shape, (8, 4))
+        self.assertEqual(traj[OBSERVATIONS].dtype, np.float32)
+        self.assertEqual(traj[ACTIONS].shape, (8,))
+        self.assertEqual(traj[ACTIONS].dtype, np.int64)
+        self.assertEqual(traj[REWARDS].shape, (8,))
+        self.assertEqual(traj[TERMINATED].shape, (8,))
+        self.assertEqual(traj[TRUNCATED].shape, (8,))
+        # Episode terminates after 3 steps -> ep_len == 3.
+        self.assertEqual(int(traj[EPISODE_LENGTH][0]), 3)
+        # Reward is +1 per valid step; padding bytes after ep_len remain 0.
+        self.assertAlmostEqual(float(traj[REWARDS][:3].sum()), 3.0)
+        self.assertEqual(float(traj[REWARDS][3:].sum()), 0.0)
+
+    def test_runs_to_max_steps_when_env_does_not_terminate(self):
+        # An env that never terminates fills the whole padded length.
+        env = _FakeDiscreteEnv(obs_dim=4, terminate_after=10**6)
+        traj = rollout_episode(env, self.policy, max_steps=5, seed=2)
+        self.assertEqual(int(traj[EPISODE_LENGTH][0]), 5)
+        self.assertTrue(np.all(traj[TERMINATED] == False))  # noqa: E712
+
+    def test_deterministic_path_uses_argmax(self):
+        env = _FakeDiscreteEnv(obs_dim=4, terminate_after=2)
+        traj = rollout_episode(
+            env, self.policy, max_steps=4, seed=3, deterministic=True
+        )
+        # Same env / policy with deterministic=True should be reproducible.
+        env2 = _FakeDiscreteEnv(obs_dim=4, terminate_after=2)
+        traj2 = rollout_episode(
+            env2, self.policy, max_steps=4, seed=3, deterministic=True
+        )
+        np.testing.assert_array_equal(traj[ACTIONS], traj2[ACTIONS])
+
+
+class TestRolloutEpisodeContinuous(unittest.TestCase):
+    def setUp(self):
+        torch.manual_seed(0)
+        cfg = GymMLPConfig(obs_dim=3, action_dim=1, hidden_dim=8, discrete=False)
+        self.policy = GymPolicy(cfg)
+
+    def test_actions_have_action_dim(self):
+        env = _FakeContinuousEnv(action_dim=1, terminate_after=2)
+        traj = rollout_episode(env, self.policy, max_steps=4, seed=1)
+        self.assertEqual(traj[ACTIONS].shape, (4, 1))
+        self.assertEqual(traj[ACTIONS].dtype, np.float32)
+
+
+class TestGymRolloutEngine(unittest.TestCase):
+    def setUp(self):
+        torch.manual_seed(0)
+        cfg = GymMLPConfig(obs_dim=4, action_dim=2, hidden_dim=8, discrete=True)
+        self.policy = GymPolicy(cfg)
+
+    def test_engine_run_with_init(self):
+        engine = GymRolloutEngine(
+            env_factory=lambda: _FakeDiscreteEnv(obs_dim=4, terminate_after=3),
+            policy=self.policy,
+            max_steps=6,
+        )
+        traj = engine.run({"seed": 42})
+        self.assertIn(OBSERVATIONS, traj)
+        engine.close()
+
+    def test_engine_init_from_prompt(self):
+        self.assertEqual(GymRolloutEngine.init_from_prompt(""), {})
+        self.assertEqual(GymRolloutEngine.init_from_prompt(None), {})
+        self.assertEqual(GymRolloutEngine.init_from_prompt('{"seed": 5}'), {"seed": 5})
+        self.assertEqual(GymRolloutEngine.init_from_prompt({"seed": 5}), {"seed": 5})
+        # Invalid JSON shouldn't crash.
+        self.assertEqual(GymRolloutEngine.init_from_prompt("not json"), {})
+
+    def test_engine_logs_unknown_init_keys_without_failing(self):
+        engine = GymRolloutEngine(
+            env_factory=lambda: _FakeDiscreteEnv(obs_dim=4, terminate_after=2),
+            policy=self.policy,
+            max_steps=4,
+        )
+        # Unknown keys are ignored gracefully.
+        traj = engine.run({"seed": 1, "unknown_field": 99})
+        self.assertEqual(int(traj[EPISODE_LENGTH][0]), 2)
+        engine.close()
+
+
+# ---------------------------------------------------------------------------
+# register_gym_policy() -- TOML loading + registry wiring
+# ---------------------------------------------------------------------------
+
+
+class TestRegisterGymPolicy(unittest.TestCase):
+    def setUp(self):
+        # Reset both registries to keep tests independent.
+        from cosmos_rl.utils import model_config, util
+
+        model_config.clear_local_model_configs()
+        util.clear_tokenizer_loaders()
+        util.setup_tokenizer.cache_clear()
+
+        self.toml_path = os.path.join(
+            tempfile.mkdtemp(prefix="cosmos_rl_gym_"), "cartpole.toml"
+        )
+        with open(self.toml_path, "w") as f:
+            f.write(
+                "[model]\n"
+                "obs_dim = 4\n"
+                "action_dim = 2\n"
+                "hidden_dim = 16\n"
+                "discrete = true\n"
+            )
+
+    def tearDown(self):
+        from cosmos_rl.utils import model_config, util
+
+        model_config.clear_local_model_configs()
+        util.clear_tokenizer_loaders()
+        util.setup_tokenizer.cache_clear()
+        try:
+            os.unlink(self.toml_path)
+            os.rmdir(os.path.dirname(self.toml_path))
+        except OSError:
+            pass
+
+    def test_local_model_config_loader_yields_gym_mlp_config(self):
+        from cosmos_rl.utils.model_config import load_model_config
+
+        register_gym_policy()
+        cfg = load_model_config(self.toml_path)
+        self.assertIsInstance(cfg, GymMLPConfig)
+        self.assertEqual(cfg.obs_dim, 4)
+        self.assertEqual(cfg.action_dim, 2)
+        self.assertEqual(cfg.hidden_dim, 16)
+        self.assertTrue(cfg.discrete)
+
+    def test_tokenizer_loader_yields_no_op_tokenizer(self):
+        from cosmos_rl.utils.no_op_tokenizer import NoOpTokenizer
+        from cosmos_rl.utils.util import setup_tokenizer
+
+        register_gym_policy()
+        tok = setup_tokenizer(self.toml_path)
+        self.assertIsInstance(tok, NoOpTokenizer)
+
+    def test_unrelated_path_falls_through_to_default(self):
+        from cosmos_rl.utils.model_config import load_model_config
+
+        register_gym_policy()
+        # Non-toml path should not match -- AutoConfig will fail because
+        # the path doesn't exist, confirming we did not short-circuit.
+        with self.assertRaises(Exception):
+            load_model_config("/path/that/does/not/exist")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

A minimal end-to-end demo of running cosmos-rl with a non-LLM RL workload, exercising the Gym API extension hooks added in #677 (`NoOpTokenizer` + `register_tokenizer_loader`, `register_local_model_config`, `TensorDataPacker`, `IdentityWeightMapper`).

## Layout (`cosmos_rl/tools/gym_example/`)

- `gym_policy.py` — `GymPolicy` MLP (discrete or continuous head) + `GymMLPConfig` (HF-shaped) + `register_gym_policy()` that wires `.toml` files to `NoOpTokenizer` + `GymMLPConfig` via the Gym API registries
- `gym_rollout.py` — `GymRolloutEngine` standalone driver around a user-supplied `gymnasium.Env` factory; emits the canonical `TensorDataPacker` trajectory dict (`observations` / `actions` / `rewards` / `terminated` / `truncated` / `episode_length`)
- `gym_data_packer.py` — `GymDataPacker` subclass of `TensorDataPacker` that decodes the dataset prompt as JSON init conditions and otherwise passes trajectories through unchanged
- `configs/` — `cartpole_{colocated,disaggregated}.toml` + `pendulum_colocated.toml`. The disaggregated profile selects the UCXX transport via `[custom].payload_transfer = "ucxx"` (depends on the UCXX backend MR landing first to actually run; `colocated` profiles work today)
- `README.md` — install, standalone-sanity-check, and full cosmos-rl wiring walkthrough

## Test plan

21 passed (`tests/test_gym_example.py`), 96% line coverage on the new module:

- `GymPolicy` forward / value / act, both discrete (CartPole) and continuous (Pendulum) heads
- `GymDataPacker` prompt decoding (JSON, dict, empty, non-JSON) and `policy_compute_max_len` with both `episode_length` and obs-shape fallback
- `rollout_episode` trajectory shapes / dtypes / termination + padding semantics; deterministic-mode reproducibility
- `GymRolloutEngine.run()` with init dicts and unknown-key tolerance; `init_from_prompt()` decoding contract
- `register_gym_policy()` end-to-end: TOML round-trips through the local model-config loader to a `GymMLPConfig` and the tokenizer registry to a `NoOpTokenizer`; unrelated paths fall through to the default loader

The tests use a small in-process `FakeEnv` stub mimicking `gymnasium.Env`'s reset/step contract so the suite doesn't require the optional `gymnasium` extra to run.