### PR TITLE
feat: UCXX payload-transport backend (zero-copy RDMA / SHM)

### DIFF
--- a/cosmos_rl/utils/payload_transport/registry.py
+++ b/cosmos_rl/utils/payload_transport/registry.py
@@ -348,6 +348,9 @@ def get_payload_transfer_mode(config: Any) -> str:
 
     if isinstance(explicit, str) and explicit:
         normalized = explicit.strip().lower()
+        # Lazy-load known optional backends so users don't pay the import
+        # cost (or hit a missing-extra error) until they actually opt in.
+        _maybe_autoload_backend(normalized)
         if PayloadTransportRegistry.get_optional(normalized) is None:
             raise ValueError(
                 f"[custom].{PAYLOAD_TRANSFER_KEY}={explicit!r} is not a "
@@ -396,6 +399,26 @@ def is_payload_transfer_mode_explicit(config: Any) -> bool:
     except AttributeError:
         legacy = None
     return bool(legacy)
+
+
+def _maybe_autoload_backend(name: str) -> None:
+    """Best-effort import of optional backends keyed by transport name.
+
+    The default Redis and NCCL backends are imported eagerly by
+    :mod:`cosmos_rl.utils.payload_transport`; UCXX is intentionally lazy
+    because it depends on the ``ucxx-cu12`` extra.  Workloads that opt
+    in via ``payload_transfer = "ucxx"`` get the side-effect import here.
+    """
+    if PayloadTransportRegistry.get_optional(name) is not None:
+        return
+    if name == "ucxx":
+        try:
+            import cosmos_rl.utils.payload_transport.ucxx  # noqa: F401
+        except Exception as e:
+            logger.warning(
+                f"Failed to autoload UCXX payload transport: {e}. "
+                "Install with: pip install cosmos_rl[ucxx]"
+            )
 
 
 __all__ = [

--- a/cosmos_rl/utils/payload_transport/ucxx/__init__.py
+++ b/cosmos_rl/utils/payload_transport/ucxx/__init__.py
@@ -1,0 +1,103 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""UCXX-based payload transport.
+
+Architecture
+------------
+::
+
+    ┌─────────────┐    metadata (worker_ip, port, slot)    ┌─────────────┐
+    │  Rollout    │───────────────────────────────────────►│  Policy     │
+    │  Worker     │      via cosmos-rl Redis stream         │  Trainer    │
+    │             │                                        │             │
+    │             │◄══════════════════════════════════════►│             │
+    │             │         actual trajectory data         │             │
+    └─────────────┘              via UCXX                  └─────────────┘
+          │                                                      │
+    ┌─────┴─────┐                                          ┌─────┴─────┐
+    │UCXXBuffer │                                          │UCXXClient │
+    │ (server)  │                                          │ (client)  │
+    └───────────┘                                          └───────────┘
+
+Components
+----------
+
+* :class:`TensorSpec` -- fixed-shape tensor descriptor for flat schemas.
+* :class:`SharedRingBuffer` -- POSIX shared-memory ring buffer with a
+  :class:`SlotState` four-state machine (FREE → WRITING → READY →
+  READING → FREE) for inter-process coordination.
+* :class:`UCXXBuffer` -- UCXX server wrapping ``SharedRingBuffer``;
+  serves data to remote trainers via the UCXX protocol.
+* :class:`UCXXClient` -- UCXX client for trainers; pools endpoints to
+  amortize connection setup.
+* :class:`UCXXRolloutMixin` / :class:`UCXXTrainerMixin` -- mixins that
+  wire UCXX into rollout workers and trainers respectively.
+* :class:`UCXXPayloadTransport` -- registers the ``"ucxx"`` backend
+  with :class:`~cosmos_rl.utils.payload_transport.PayloadTransportRegistry`.
+
+Optional dependency
+-------------------
+
+UCXX itself (the Python binding ``ucxx-cu12`` for CUDA 12) is an
+**optional** extra; install with::
+
+    pip install cosmos_rl[ucxx]
+
+When the UCXX library is not present, :data:`UCXX_AVAILABLE` is
+``False`` and attempting to start a server / client raises
+``RuntimeError`` rather than failing at import time.  All of the
+shared-memory bits work without UCXX, so :class:`SharedRingBuffer`
+remains usable for single-node profiling / testing.
+"""
+
+from cosmos_rl.utils.payload_transport.ucxx.mixins import (
+    UCXXRolloutMixin,
+    UCXXTrainerMixin,
+)
+from cosmos_rl.utils.payload_transport.ucxx.shared_buffer import (
+    BufferConfig,
+    BufferMetrics,
+    SharedRingBuffer,
+    SlotError,
+    SlotState,
+)
+from cosmos_rl.utils.payload_transport.ucxx.tensor_spec import TensorSpec
+from cosmos_rl.utils.payload_transport.ucxx.transport import UCXXPayloadTransport
+from cosmos_rl.utils.payload_transport.ucxx.ucxx_buffer import (
+    UCXX_AVAILABLE,
+    StaleSlotError,
+    UCXXBuffer,
+    UCXXBufferConfig,
+    UCXXClient,
+)
+
+
+__all__ = [
+    "BufferConfig",
+    "BufferMetrics",
+    "SharedRingBuffer",
+    "SlotError",
+    "SlotState",
+    "StaleSlotError",
+    "TensorSpec",
+    "UCXX_AVAILABLE",
+    "UCXXBuffer",
+    "UCXXBufferConfig",
+    "UCXXClient",
+    "UCXXPayloadTransport",
+    "UCXXRolloutMixin",
+    "UCXXTrainerMixin",
+]

--- a/cosmos_rl/utils/payload_transport/ucxx/mixins.py
+++ b/cosmos_rl/utils/payload_transport/ucxx/mixins.py
@@ -1,0 +1,957 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""UCXX mixins for rollout workers and trainers.
+
+Active mixins:
+
+1. :class:`UCXXRolloutMixin` -- rollout workers: write to SharedRingBuffer
+   and serve over UCXX.
+2. :class:`UCXXDataPackerMixin` (added in a follow-up MR under
+   ``data_packer_mixin.py``) -- DataPackers: resolve UCXX pointers in
+   ``get_policy_input()`` with prefetch + double-buffering.
+
+Deprecated:
+
+3. :class:`UCXXTrainerMixin` -- kept for reference; superseded by
+   ``UCXXDataPackerMixin``.
+"""
+
+import asyncio
+import fcntl
+import queue
+import socket
+import struct
+import threading
+from pathlib import Path
+from typing import Any, Callable, Dict, List, Optional
+
+import numpy as np
+import torch
+
+from cosmos_rl.utils.logging import logger
+from cosmos_rl.utils.payload_transport.ucxx.ucxx_buffer import (
+    UCXX_AVAILABLE,
+    UCXXBuffer,
+    UCXXBufferConfig,
+    UCXXClient,
+)
+
+# Trace utility is provided by a sibling MR; fall back to a wall-clock
+# stand-in when running against an older cosmos-rl that lacks it.  This
+# keeps the UCXX MR independent of the trace MR's merge order.
+try:
+    from cosmos_rl.utils.trace import get_trace_time  # type: ignore
+except ImportError:  # pragma: no cover - fallback path
+    import time as _time
+
+    def get_trace_time() -> float:  # type: ignore[no-redef]
+        return _time.perf_counter() * 1000.0
+
+
+_TRANSIENT_UCXX_ERRORS = frozenset(
+    {
+        "UCXXCanceledError",
+        "UCXXConnectionResetError",
+        "UCXXCloseError",
+        "TimeoutError",
+    }
+)
+
+_MAX_FETCH_ROUNDS = 3
+
+# Canonical trajectory field names.  Mirrored from
+# ``cosmos_rl.dispatcher.data.packer.tensor_data_packer`` so this module
+# can be imported standalone without dragging in the dispatcher.
+OBSERVATIONS = "observations"
+ACTIONS = "actions"
+REWARDS = "rewards"
+TERMINATED = "terminated"
+TRUNCATED = "truncated"
+EPISODE_LENGTH = "episode_length"
+
+
+def _get_iface_ip(iface: str) -> Optional[str]:
+    """Get IPv4 address of a network interface via ioctl."""
+    try:
+        s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        addr = fcntl.ioctl(
+            s.fileno(),
+            0x8915,  # SIOCGIFADDR
+            struct.pack("256s", iface.encode()),
+        )
+        s.close()
+        return socket.inet_ntoa(addr[20:24])
+    except OSError:
+        return None
+
+
+def _get_local_ip() -> str:
+    """Get local IP for UCXX binding, preferring RDMA interfaces.
+
+    On clusters with IB/RoCE, the hostname-resolved IP (e.g. 10.49.x.x) is on
+    the management network and unreachable over the RDMA fabric.  UCXX must
+    bind to an RDMA interface IP (e.g. 192.168.x.x on rdma0) for IB transport.
+
+    Priority:
+      1. First ``rdma*`` interface with an IPv4 address
+      2. Hostname resolution (fallback for non-IB environments)
+    """
+    # Prefer RDMA interfaces for IB-capable clusters
+    rdma_ifaces = sorted(p.name for p in Path("/sys/class/net").glob("rdma*"))
+    for iface in rdma_ifaces:
+        ip = _get_iface_ip(iface)
+        if ip:
+            logger.info(f"[UCXX] Binding to RDMA interface {iface} -> {ip}")
+            return ip
+
+    # Fallback: hostname resolution (works for non-IB setups)
+    hostname = socket.getfqdn()
+    ip = socket.gethostbyname(hostname)
+
+    # UCX may not recognise non-standard loopback addresses (e.g. 127.0.1.1
+    # from Docker hostname entries) for its shared-memory transport.  Normalise
+    # anything in the 127.x.x.x range to the canonical 127.0.0.1.
+    if ip.startswith("127.") and ip != "127.0.0.1":
+        logger.info(f"[UCXX] Hostname resolved to {ip}, normalising to 127.0.0.1")
+        ip = "127.0.0.1"
+    else:
+        logger.info(f"[UCXX] No RDMA interfaces found, using hostname -> {ip}")
+    return ip
+
+
+class UCXXRolloutMixin:
+    """
+    Mixin for rollout workers to enable UCXX-based data transfer.
+
+    Features:
+    - Writes data to SharedRingBuffer with automatic padding
+    - Starts UCXX server to serve data to trainers
+    - Auto-optimizes for local (shared memory) and remote (RDMA) access
+
+    Usage:
+        class MyWorker(UCXXRolloutMixin, BaseWorker):
+            def post_init_hook(self):
+                self.setup_ucxx(
+                    replica_id=self.replica_name,
+                    max_steps=100,
+                    obs_dim=4,
+                    action_dim=2,
+                )
+
+            def generate_rollout(self):
+                trajectory = collect_trajectory()
+                metadata = self.write_to_buffer(trajectory)
+                return metadata or trajectory
+
+            def cleanup(self):
+                self.cleanup_ucxx()
+    """
+
+    _ucxx_buffer: Optional[UCXXBuffer] = None
+    _ucxx_replica_id: str = ""
+    _ucxx_enabled: bool = False
+    _ucxx_ip: str = ""
+    _ucxx_port: int = 0
+    _ucxx_max_steps: int = 100
+    _ucxx_obs_dim: int = 4
+    _ucxx_action_dim: int = 2
+    _ucxx_packed_cpu: Optional[torch.Tensor] = None  # Pinned CPU staging buffer
+    _ucxx_tensor_offsets: Optional[Dict[str, int]] = None
+    _ucxx_entry_data_size: int = 0
+
+    def setup_ucxx(
+        self,
+        replica_id: str,
+        max_steps: int,
+        obs_dim: int,
+        action_dim: int,
+        port: int = 0,
+        config: Optional[UCXXBufferConfig] = None,
+    ) -> None:
+        """
+        Initialize UCXX buffer and server for this rollout worker.
+
+        Args:
+            replica_id: Unique identifier for this replica
+            max_steps: Maximum episode length (for padding)
+            obs_dim: Observation dimension
+            action_dim: Action dimension
+            port: Port for UCXX server (0 = auto-assign)
+            config: Optional buffer configuration
+
+        Raises:
+            RuntimeError: If UCXX is not available or setup fails
+        """
+        if not UCXX_AVAILABLE:
+            raise RuntimeError(
+                "UCXX is required for UCXXRolloutMixin. "
+                "Install with: pip install ucxx-cu12"
+            )
+
+        self._ucxx_replica_id = replica_id
+        self._ucxx_max_steps = max_steps
+        self._ucxx_obs_dim = obs_dim
+        self._ucxx_action_dim = action_dim
+
+        try:
+            # Build schema for trajectory data (required for zero-pack protocol)
+            from cosmos_rl.utils.payload_transport.ucxx.tensor_spec import (
+                TensorSpec,
+            )
+
+            schema = [
+                TensorSpec(
+                    name=OBSERVATIONS, shape=(max_steps, obs_dim), dtype=np.float32
+                ),
+                TensorSpec(
+                    name=ACTIONS, shape=(max_steps, action_dim), dtype=np.float32
+                ),
+                TensorSpec(name=REWARDS, shape=(max_steps,), dtype=np.float32),
+                TensorSpec(name=TERMINATED, shape=(max_steps,), dtype=np.bool_),
+                TensorSpec(name=TRUNCATED, shape=(max_steps,), dtype=np.bool_),
+                TensorSpec(name=EPISODE_LENGTH, shape=(1,), dtype=np.int64),
+            ]
+
+            # Create UCXX buffer with server and schema
+            buffer_config = config or UCXXBufferConfig(
+                max_entries=1000,
+                entry_size_bytes=65536,
+            )
+            buffer_config.buffer_name = f"ucxx_rollout_{replica_id}"
+            buffer_config.port = port  # Set port in config
+            buffer_config.schema = schema  # Schema required for zero-pack protocol
+
+            self._ucxx_buffer = UCXXBuffer(buffer_config)
+
+            # Pre-compute schema layout for coalesced writes
+            self._ucxx_tensor_offsets = {}
+            offset = 0
+            for spec in schema:
+                self._ucxx_tensor_offsets[spec.name] = offset
+                offset += spec.nbytes
+            self._ucxx_entry_data_size = offset
+            self._ucxx_schema = schema
+
+            # Pre-allocate pinned CPU staging buffer for bulk D2H + SHM copy.
+            # Pinned memory enables DMA and avoids per-tensor cudaMemcpy overhead.
+            self._ucxx_packed_cpu = torch.empty(
+                self._ucxx_entry_data_size, dtype=torch.uint8, pin_memory=True
+            )
+
+            # Start UCXX server
+            self._ucxx_buffer.start_server()
+            self._ucxx_ip = self._ucxx_buffer.local_ip
+            self._ucxx_port = self._ucxx_buffer.port
+
+            self._ucxx_enabled = True
+            logger.info(
+                f"[UCXXRolloutMixin] Worker '{replica_id}' ready at "
+                f"{self._ucxx_ip}:{self._ucxx_port} "
+                f"(max_steps={max_steps}, obs_dim={obs_dim}, action_dim={action_dim}, "
+                f"entry_size={self._ucxx_entry_data_size / 1e6:.1f} MB)"
+            )
+
+        except Exception as e:
+            raise RuntimeError(f"UCXX setup failed: {e}") from e
+
+    def write_to_buffer(self, trajectory: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+        """Write trajectory to buffer with padding and return metadata for UCXX fetch.
+
+        Uses a coalesced write strategy for large payloads:
+        1. Pack all schema tensors into a single contiguous GPU buffer
+        2. One bulk ``cudaMemcpy`` D2H into a pre-allocated pinned CPU buffer
+        3. One bulk ``memoryview`` copy into the SHM slot
+
+        This eliminates per-tensor Python loop overhead and reaches closer to
+        hardware bandwidth limits (PCIe for D2H, DDR for SHM).
+
+        Falls back to the per-tensor path when tensors are not on GPU.
+        """
+        if not self._ucxx_enabled or self._ucxx_buffer is None:
+            return None
+
+        try:
+            ep_len_val = trajectory.get(EPISODE_LENGTH)
+            if ep_len_val is None:
+                obs = trajectory.get(OBSERVATIONS)
+                if obs is not None:
+                    ep_len = obs.shape[0] if hasattr(obs, "shape") else len(obs)
+                else:
+                    ep_len = self._ucxx_max_steps
+            elif isinstance(ep_len_val, torch.Tensor):
+                ep_len = int(ep_len_val.item())
+            else:
+                ep_len = int(ep_len_val)
+
+            any_gpu = any(
+                isinstance(v, torch.Tensor) and v.is_cuda for v in trajectory.values()
+            )
+
+            t_gpu2cpu_start = get_trace_time()
+
+            if any_gpu and self._ucxx_packed_cpu is not None:
+                # --- Fast path: coalesced GPU → pinned CPU → SHM ----
+                device = None
+                for v in trajectory.values():
+                    if isinstance(v, torch.Tensor) and v.is_cuda:
+                        device = v.device
+                        break
+
+                gpu_packed = torch.zeros(
+                    self._ucxx_entry_data_size, dtype=torch.uint8, device=device
+                )
+
+                for spec in self._ucxx_schema:
+                    raw = trajectory.get(spec.name)
+                    if raw is None:
+                        continue
+
+                    if isinstance(raw, torch.Tensor):
+                        tensor = raw
+                    else:
+                        tensor = torch.as_tensor(raw, device=device)
+
+                    # Pad variable-length fields
+                    if spec.name in (
+                        OBSERVATIONS,
+                        ACTIONS,
+                        REWARDS,
+                        TERMINATED,
+                        TRUNCATED,
+                    ):
+                        if tensor.shape[0] < spec.shape[0]:
+                            padded = torch.zeros(
+                                spec.shape, dtype=tensor.dtype, device=device
+                            )
+                            padded[: tensor.shape[0]] = tensor
+                            tensor = padded
+                    elif spec.name == EPISODE_LENGTH:
+                        tensor = torch.tensor(
+                            [ep_len], dtype=torch.int64, device=device
+                        )
+
+                    tensor = tensor.reshape(spec.shape).contiguous()
+                    flat = tensor.view(torch.uint8).reshape(-1)
+                    off = self._ucxx_tensor_offsets[spec.name]
+                    gpu_packed[off : off + flat.numel()] = flat
+
+                # Single bulk D2H copy into pinned staging buffer
+                self._ucxx_packed_cpu.copy_(gpu_packed, non_blocking=False)
+
+                t_gpu2cpu_end = get_trace_time()
+
+                # Single bulk SHM write
+                slot = self._ucxx_buffer.write_raw(
+                    memoryview(self._ucxx_packed_cpu.numpy())
+                )
+                t_shm_end = get_trace_time()
+                total_bytes = self._ucxx_entry_data_size
+            else:
+                # --- Fallback: per-tensor CPU path (no GPU tensors) ---
+                cpu_data = {}
+                for key, value in trajectory.items():
+                    if isinstance(value, torch.Tensor):
+                        arr = value.cpu().numpy()
+                    else:
+                        arr = np.asarray(value)
+
+                    if key in (OBSERVATIONS, ACTIONS, REWARDS, TERMINATED, TRUNCATED):
+                        if len(arr.shape) > 0 and arr.shape[0] < self._ucxx_max_steps:
+                            if key == OBSERVATIONS:
+                                padded = np.zeros(
+                                    (self._ucxx_max_steps, self._ucxx_obs_dim),
+                                    dtype=arr.dtype,
+                                )
+                            elif key == ACTIONS:
+                                padded = np.zeros(
+                                    (self._ucxx_max_steps, self._ucxx_action_dim),
+                                    dtype=arr.dtype,
+                                )
+                            else:
+                                padded = np.zeros(
+                                    (self._ucxx_max_steps,), dtype=arr.dtype
+                                )
+                            padded[: arr.shape[0]] = arr
+                            arr = padded
+                    elif key == EPISODE_LENGTH:
+                        arr = np.array([ep_len], dtype=np.int64)
+
+                    cpu_data[key] = arr
+
+                t_gpu2cpu_end = get_trace_time()
+
+                slot = self._ucxx_buffer.write(cpu_data)
+                t_shm_end = get_trace_time()
+                total_bytes = sum(
+                    arr.nbytes for arr in cpu_data.values() if hasattr(arr, "nbytes")
+                )
+
+            gpu2cpu_ms = t_gpu2cpu_end - t_gpu2cpu_start
+            shm_ms = t_shm_end - t_gpu2cpu_end
+            thread_name = threading.current_thread().name
+            logger.debug(
+                f"[Trace] thread={thread_name} op=ucxx_write "
+                f"start={t_gpu2cpu_start:.1f} end={t_shm_end:.1f} "
+                f"gpu2cpu_ms={gpu2cpu_ms:.1f} shm_ms={shm_ms:.1f} "
+                f"bytes={total_bytes}"
+            )
+
+            return {
+                "_ucxx": True,
+                "_ucxx_enabled": True,
+                "_worker_ip": self._ucxx_ip,
+                "_ucxx_port": self._ucxx_port,
+                "_ports": self._ucxx_buffer.ports,
+                "_slot": slot,
+                "_buffer_handle": self._ucxx_buffer.get_handle(),
+                "_replica_id": self._ucxx_replica_id,
+                REWARDS: trajectory.get(REWARDS, torch.tensor([])).tolist(),
+                EPISODE_LENGTH: ep_len,
+            }
+        except Exception as e:
+            logger.error(f"[UCXXRolloutMixin] Write failed: {e}")
+            return None
+
+    def cleanup_ucxx(self) -> None:
+        """Clean up UCXX resources."""
+        if self._ucxx_buffer:
+            self._ucxx_buffer.stop_server()
+            self._ucxx_buffer.close()
+            self._ucxx_buffer = None
+        self._ucxx_enabled = False
+        logger.info(f"[UCXXRolloutMixin] Worker '{self._ucxx_replica_id}' cleaned up")
+
+
+class UCXXTrainerMixin:
+    """Mixin for trainers to enable UCXX-based data fetching with background prefetch.
+
+    .. deprecated::
+        Superseded by :class:`UCXXDataPackerMixin` (in ``data_packer_mixin.py``)
+        which places UCXX resolution in the DataPacker's ``get_policy_input()``
+        rather than coupling it to a specific trainer class.  Kept here for
+        backward-compatibility and reference; new code should use the mixin
+        on the DataPacker instead.
+    """
+
+    _ucxx_trainer_client: Optional[UCXXClient] = None
+    _ucxx_trainer_enabled: bool = False
+    _ucxx_trainer_device: torch.device = None
+    _ucxx_trainer_prefetch_thread: Optional[threading.Thread] = None
+    _ucxx_trainer_request_queue: Optional[queue.Queue] = None
+    _ucxx_trainer_result_queue: Optional[queue.Queue] = None
+    _ucxx_trainer_shutdown: Optional[threading.Event] = None
+    _ucxx_trainer_batch_id: int = 0
+    _ucxx_trainer_step_count: int = 0
+    _ucxx_trainer_total_ucxx: int = 0
+    _ucxx_trainer_total_fallback: int = 0
+    _ucxx_trainer_total_bytes: int = 0
+    _ucxx_trainer_total_latency_ms: float = 0.0
+    _ucxx_trainer_prefetch_timeout: float = 300.0
+    _ucxx_trainer_max_attempts: int = 2
+    _ucxx_trainer_read_timeout: float = 60.0
+    _UCXX_LOG_INTERVAL: int = 50
+
+    def setup_ucxx_trainer(
+        self,
+        device: torch.device,
+        prefetch_timeout: float = 300.0,
+        max_attempts: int = 2,
+        read_timeout: float = 60.0,
+    ) -> None:
+        """Initialize UCXX client and background prefetch thread.
+
+        All episodes for a training iteration are fetched concurrently
+        (no chunking).  Results stream to GPU via ``asyncio.as_completed``
+        so the CPU-to-GPU copy for each episode starts as soon as its
+        network read finishes.
+
+        Args:
+            device: Target GPU device for fetched tensors.
+            prefetch_timeout: Seconds to wait for prefetch results before
+                raising a timeout error.
+            max_attempts: Total attempts per remote slot read (initial +
+                retries on transient UCX errors).  Defaults to 2 to match
+                the historic "retry once" behaviour.  Set to 1 to disable
+                retries entirely.
+            read_timeout: Per-await timeout (seconds) inside a single
+                ``UCXXClient.read`` call -- bounds one ``send`` / ``recv``
+                operation, distinct from ``prefetch_timeout`` which bounds
+                a whole batch.
+        """
+        if not UCXX_AVAILABLE:
+            raise RuntimeError(
+                "UCXX is required for UCXXTrainerMixin. "
+                "Install with: pip install ucxx-cu12"
+            )
+
+        self._ucxx_trainer_device = device
+        self._ucxx_trainer_prefetch_timeout = prefetch_timeout
+        self._ucxx_trainer_max_attempts = max(1, max_attempts)
+        self._ucxx_trainer_read_timeout = read_timeout
+        self._ucxx_trainer_client = UCXXClient()
+
+        self._ucxx_trainer_request_queue = queue.Queue()
+        self._ucxx_trainer_result_queue = queue.Queue()
+        self._ucxx_trainer_shutdown = threading.Event()
+        self._ucxx_trainer_shutdown.clear()
+
+        self._ucxx_trainer_prefetch_thread = threading.Thread(
+            target=self._ucxx_trainer_prefetch_worker,
+            name="UCXXTrainerPrefetch",
+            daemon=True,
+        )
+        self._ucxx_trainer_prefetch_thread.start()
+        self._ucxx_trainer_enabled = True
+
+        logger.info(
+            f"[UCXXTrainerMixin] Initialized with device={device}, "
+            f"prefetch_timeout={prefetch_timeout}s"
+        )
+
+    def _ucxx_trainer_prefetch_worker(self) -> None:
+        """Background worker that fetches UCXX data while training runs.
+
+        All episodes for the batch are fetched concurrently.  Results
+        stream to GPU via ``asyncio.as_completed`` so the CPU→GPU copy
+        for each episode starts as soon as its network read finishes.
+        """
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+
+        try:
+            while not self._ucxx_trainer_shutdown.is_set():
+                try:
+                    batch_id, ucxx_tasks = self._ucxx_trainer_request_queue.get(
+                        timeout=0.1
+                    )
+                except queue.Empty:
+                    continue
+
+                results = {}
+                total_transfer_ms = 0.0
+                total_copy_ms = 0.0
+
+                if ucxx_tasks:
+                    targets = [
+                        f"{m.get('_worker_ip')}:{m.get('_ucxx_port')}"
+                        for _, m in ucxx_tasks
+                    ]
+                    logger.debug(
+                        f"[UCXXTrainerMixin] Batch {batch_id} targets: {targets}"
+                    )
+
+                    try:
+                        results, total_transfer_ms, total_copy_ms = (
+                            loop.run_until_complete(self._fetch_all(ucxx_tasks))
+                        )
+                    except Exception as e:
+                        error_msg = (
+                            f"{type(e).__name__}: {e}" if str(e) else type(e).__name__
+                        )
+                        logger.error(
+                            f"[UCXXTrainerMixin] Batch {batch_id} failed: {error_msg} "
+                            f"(targets: {targets})"
+                        )
+                        results = {"_error": error_msg}
+
+                self._ucxx_trainer_result_queue.put(
+                    (batch_id, results, total_transfer_ms, total_copy_ms)
+                )
+
+        except Exception as e:
+            logger.error(f"[UCXXTrainerMixin] Prefetch worker error: {e}")
+        finally:
+            loop.close()
+            logger.info("[UCXXTrainerMixin] Prefetch worker stopped")
+
+    async def _fetch_all(self, ucxx_tasks: list) -> tuple:
+        """Fetch all episodes concurrently with multi-round retry.
+
+        Each round attempts all pending episodes concurrently.  Within a
+        round, ``_read_one`` does one immediate retry (handles stale
+        endpoints).  Failed episodes are collected and retried in the next
+        round — this works because the server-side ``release_reading()``
+        transitions the slot back to READY, preserving data for re-read.
+
+        Returns ``(results_dict, transfer_ms, copy_ms)``.
+        """
+        client = self._ucxx_trainer_client
+        device = self._ucxx_trainer_device
+
+        async def _read_one(idx: int, metadata: dict):
+            """Read a single episode; return (idx, None) on failure."""
+            worker_ip = metadata.get("_worker_ip")
+            ucxx_port = metadata.get("_ucxx_port")
+            slot = metadata.get("_slot")
+            handle = metadata.get("_buffer_handle")
+            ports = metadata.get("_ports") or (
+                handle.get("ucxx_ports") if handle else None
+            )
+
+            schema = None
+            schema_info = handle.get("schema") if handle else None
+            if schema_info:
+                from cosmos_rl.utils.payload_transport.ucxx.tensor_spec import (
+                    TensorSpec,
+                )
+
+                schema = [
+                    TensorSpec(
+                        name=s["name"],
+                        shape=tuple(s["shape"]),
+                        dtype=np.dtype(s["dtype"]),
+                    )
+                    for s in schema_info
+                ]
+
+            max_attempts = max(1, self._ucxx_trainer_max_attempts)
+            read_timeout = self._ucxx_trainer_read_timeout
+            data = None
+            for attempt in range(1, max_attempts + 1):
+                try:
+                    data = await client.read(
+                        worker_ip,
+                        ucxx_port,
+                        slot,
+                        schema,
+                        ports=ports,
+                        timeout=read_timeout,
+                    )
+                    break
+                except Exception as e:
+                    if type(e).__name__ not in _TRANSIENT_UCXX_ERRORS:
+                        logger.error(
+                            f"[UCXXTrainerMixin] Non-transient error reading "
+                            f"{worker_ip}:{ucxx_port} slot={slot}: "
+                            f"{type(e).__name__}: {e}"
+                        )
+                        return idx, None
+                    if attempt == max_attempts:
+                        logger.warning(
+                            f"[UCXXTrainerMixin] All {max_attempts} attempts "
+                            f"failed for {worker_ip}:{ucxx_port} slot={slot}: "
+                            f"{type(e).__name__}: {e}"
+                        )
+                        return idx, None
+                    logger.warning(
+                        f"[UCXXTrainerMixin] Transient error reading "
+                        f"{worker_ip}:{ucxx_port} slot={slot} "
+                        f"(attempt {attempt}/{max_attempts}): "
+                        f"{type(e).__name__}, retrying"
+                    )
+            return idx, data
+
+        def _to_gpu(result: dict) -> dict:
+            gpu_data = {}
+            for key, value in result.items():
+                if hasattr(value, "shape"):
+                    gpu_data[key] = torch.from_numpy(value).to(
+                        device, non_blocking=True
+                    )
+                else:
+                    gpu_data[key] = value
+
+            ep_len_tensor = gpu_data.get(EPISODE_LENGTH)
+            if ep_len_tensor is not None:
+                ep_len = (
+                    int(ep_len_tensor.item())
+                    if ep_len_tensor.numel() == 1
+                    else int(ep_len_tensor[0].item())
+                )
+                for key in (OBSERVATIONS, ACTIONS, REWARDS, TERMINATED, TRUNCATED):
+                    if key in gpu_data and gpu_data[key].shape[0] > ep_len:
+                        gpu_data[key] = gpu_data[key][:ep_len]
+            return gpu_data
+
+        # Build metadata lookup for retries
+        meta_by_idx = {}
+        for idx, metadata in ucxx_tasks:
+            worker_ip = metadata.get("_worker_ip")
+            ucxx_port = metadata.get("_ucxx_port")
+            slot = metadata.get("_slot")
+            if not (worker_ip and ucxx_port and slot is not None):
+                continue
+            meta_by_idx[idx] = metadata
+
+        pending = list(meta_by_idx.keys())
+        batch_results: dict = {}
+        total_transfer_ms = 0.0
+        total_copy_ms = 0.0
+
+        for round_num in range(_MAX_FETCH_ROUNDS):
+            if not pending:
+                break
+
+            tasks = [_read_one(idx, meta_by_idx[idx]) for idx in pending]
+            failed = []
+
+            for coro in asyncio.as_completed(tasks):
+                t0 = get_trace_time()
+                idx, result = await coro
+                t1 = get_trace_time()
+                total_transfer_ms += t1 - t0
+
+                if result is None:
+                    failed.append(idx)
+                    continue
+
+                gpu_data = _to_gpu(result)
+                batch_results[idx] = gpu_data
+                t2 = get_trace_time()
+                total_copy_ms += t2 - t1
+
+            if failed:
+                logger.warning(
+                    f"[UCXXTrainerMixin] Fetch round {round_num + 1}/{_MAX_FETCH_ROUNDS}: "
+                    f"{len(failed)}/{len(pending)} episodes failed, "
+                    f"{'retrying' if round_num + 1 < _MAX_FETCH_ROUNDS else 'giving up'}"
+                )
+            pending = failed
+
+        if pending:
+            logger.error(
+                f"[UCXXTrainerMixin] {len(pending)} episodes failed after "
+                f"{_MAX_FETCH_ROUNDS} rounds: indices={pending}"
+            )
+
+        return batch_results, total_transfer_ms, total_copy_ms
+
+    def fetch_rollouts_ucxx(
+        self,
+        rollouts: List[Any],
+        get_completion: Callable[[Any], Dict] = lambda r: r.completion
+        if hasattr(r, "completion")
+        else r,
+    ) -> List[Dict[str, torch.Tensor]]:
+        """
+        Fetch rollout data via UCXX with background prefetch.
+
+        Args:
+            rollouts: List of rollout objects from cosmos-rl
+            get_completion: Function to extract completion dict from rollout
+
+        Returns:
+            List of trajectory dicts with tensors on device
+
+        Raises:
+            RuntimeError: If UCXX not initialized or prefetch fails
+        """
+        if not self._ucxx_trainer_enabled:
+            raise RuntimeError(
+                "UCXX trainer not initialized. Call setup_ucxx_trainer() first."
+            )
+
+        # Phase 1: Extract metadata and identify UCXX-eligible rollouts
+        items = []
+        ucxx_tasks = []
+
+        for i, rollout in enumerate(rollouts):
+            item = get_completion(rollout)
+
+            if not isinstance(item, dict):
+                # Log the first few skipped items to help debug data format issues
+                if i < 3:
+                    attrs = (
+                        [a for a in dir(item) if not a.startswith("_")][:10]
+                        if item is not None
+                        else []
+                    )
+                    logger.warning(
+                        f"[UCXXTrainerMixin] Skipping rollout {i}: "
+                        f"type={type(item).__name__}, sample_attrs={attrs}"
+                    )
+                items.append(None)
+                continue
+
+            items.append(item)
+
+            # Check if UCXX-eligible
+            if (
+                item.get("_ucxx", False)
+                and item.get("_ucxx_enabled")
+                and self._ucxx_trainer_request_queue is not None
+            ):
+                ucxx_tasks.append((i, item))
+
+        # Log Phase 1 summary
+        n_skipped = sum(1 for x in items if x is None)
+        n_ucxx = len(ucxx_tasks)
+        n_fallback = len(items) - n_skipped - n_ucxx
+        logger.debug(
+            f"[UCXXTrainerMixin] Phase 1: {len(rollouts)} rollouts -> "
+            f"{n_ucxx} UCXX, {n_fallback} fallback, {n_skipped} skipped"
+        )
+
+        # Phase 2: Submit to prefetch worker and wait
+        ucxx_results: Dict[int, Dict[str, torch.Tensor]] = {}
+        transfer_ms = 0.0
+        copy_ms = 0.0
+        fetch_start = get_trace_time()
+        if ucxx_tasks and self._ucxx_trainer_request_queue is not None:
+            batch_id = self._ucxx_trainer_batch_id
+            self._ucxx_trainer_batch_id += 1
+
+            self._ucxx_trainer_request_queue.put((batch_id, ucxx_tasks))
+
+            try:
+                result_batch_id, results, transfer_ms, copy_ms = (
+                    self._ucxx_trainer_result_queue.get(
+                        timeout=self._ucxx_trainer_prefetch_timeout
+                    )
+                )
+                if result_batch_id != batch_id:
+                    logger.warning(
+                        f"[UCXXTrainerMixin] Batch ID mismatch: expected {batch_id}, got {result_batch_id}"
+                    )
+                if "_error" in results:
+                    logger.warning(
+                        f"[UCXXTrainerMixin] Batch {batch_id} prefetch error: "
+                        f"{results['_error']}, proceeding with available results"
+                    )
+                    ucxx_results = {}
+                else:
+                    ucxx_results = results
+            except queue.Empty:
+                logger.error(
+                    f"[UCXXTrainerMixin] Prefetch timeout after "
+                    f"{self._ucxx_trainer_prefetch_timeout}s, proceeding "
+                    f"without UCXX data"
+                )
+                ucxx_results = {}
+        fetch_end = get_trace_time()
+
+        # Phase 3: Build results
+        ucxx_indices = {i for i, _ in ucxx_tasks}
+        result = []
+        ucxx_count = 0
+        ucxx_skipped = 0
+        total_bytes = 0
+
+        for i, item in enumerate(items):
+            if item is None:
+                continue
+
+            if i in ucxx_results:
+                result.append(ucxx_results[i])
+                ucxx_count += 1
+                for val in ucxx_results[i].values():
+                    if isinstance(val, torch.Tensor):
+                        total_bytes += val.nelement() * val.element_size()
+            elif i in ucxx_indices:
+                # UCXX-eligible but fetch failed after all retries — the
+                # metadata dict has no tensor data, so skip rather than
+                # appending an incomplete dict that would crash training.
+                ucxx_skipped += 1
+            else:
+                # Fallback: data came through cosmos-rl serialization
+                processed = {}
+                for key, value in item.items():
+                    if key.startswith("_"):
+                        continue
+                    if isinstance(value, torch.Tensor):
+                        processed[key] = value.to(self._ucxx_trainer_device)
+                    elif hasattr(value, "shape"):
+                        processed[key] = torch.from_numpy(value).to(
+                            self._ucxx_trainer_device
+                        )
+                    else:
+                        processed[key] = value
+                result.append(processed)
+
+        if ucxx_skipped:
+            logger.warning(
+                f"[UCXXTrainerMixin] {ucxx_skipped} UCXX episodes skipped "
+                f"(fetch failed after all retries), batch size reduced to "
+                f"{len(result)}"
+            )
+
+        if not result:
+            raise RuntimeError(
+                f"[UCXXTrainerMixin] All {len(rollouts)} episodes failed — "
+                f"no data available for training iteration"
+            )
+
+        fetch_latency = fetch_end - fetch_start
+        wait_ms = max(0.0, fetch_latency - transfer_ms - copy_ms)
+        source_replicas = [m.get("_replica_id", "?") for _, m in ucxx_tasks]
+        logger.debug(
+            f"[Trace] thread=trainer op=ucxx_fetch "
+            f"start={fetch_start:.1f} end={fetch_end:.1f} "
+            f"wait_ms={wait_ms:.1f} transfer_ms={transfer_ms:.1f} copy_ms={copy_ms:.1f} "
+            f"count={ucxx_count} bytes={total_bytes} "
+            f"sources={','.join(str(s) for s in source_replicas)}"
+        )
+        logger.debug(
+            f"[UCXXTrainerMixin] Fetched {ucxx_count}/{len(rollouts)} rollouts via UCXX: "
+            f"{total_bytes / 1e6:.2f} MB, {fetch_latency:.1f} ms "
+            f"(wait={wait_ms:.1f}, transfer={transfer_ms:.1f}, copy={copy_ms:.1f})"
+        )
+
+        # Periodic INFO summary to avoid per-iteration log noise
+        self._ucxx_trainer_step_count += 1
+        self._ucxx_trainer_total_ucxx += ucxx_count
+        self._ucxx_trainer_total_fallback += len(rollouts) - ucxx_count - n_skipped
+        self._ucxx_trainer_total_bytes += total_bytes
+        self._ucxx_trainer_total_latency_ms += fetch_latency
+        step = self._ucxx_trainer_step_count
+        if step == 1 or step % self._UCXX_LOG_INTERVAL == 0:
+            avg_ms = self._ucxx_trainer_total_latency_ms / step
+            logger.info(
+                f"[UCXXTrainerMixin] Iteration {step}: "
+                f"{self._ucxx_trainer_total_ucxx} UCXX / "
+                f"{self._ucxx_trainer_total_fallback} fallback, "
+                f"{self._ucxx_trainer_total_bytes / 1e6:.1f} MB total, "
+                f"avg {avg_ms:.0f} ms/iter"
+            )
+
+        return result
+
+    def cleanup_ucxx_trainer(self) -> None:
+        """Clean up UCXX trainer resources."""
+        # Stop prefetch worker
+        if self._ucxx_trainer_shutdown is not None:
+            self._ucxx_trainer_shutdown.set()
+
+        if self._ucxx_trainer_prefetch_thread is not None:
+            self._ucxx_trainer_prefetch_thread.join(timeout=5.0)
+            if self._ucxx_trainer_prefetch_thread.is_alive():
+                logger.warning(
+                    "[UCXXTrainerMixin] Prefetch worker did not stop cleanly"
+                )
+            self._ucxx_trainer_prefetch_thread = None
+
+        # Close UCXX client
+        if self._ucxx_trainer_client is not None:
+            try:
+                loop = asyncio.new_event_loop()
+                loop.run_until_complete(self._ucxx_trainer_client.close())
+                loop.close()
+            except Exception as e:
+                logger.warning(f"[UCXXTrainerMixin] Failed to close UCXX client: {e}")
+            self._ucxx_trainer_client = None
+
+        self._ucxx_trainer_enabled = False
+        # Final summary
+        if self._ucxx_trainer_step_count > 0:
+            avg_ms = self._ucxx_trainer_total_latency_ms / self._ucxx_trainer_step_count
+            logger.info(
+                f"[UCXXTrainerMixin] Final: {self._ucxx_trainer_step_count} iterations, "
+                f"{self._ucxx_trainer_total_ucxx} UCXX / "
+                f"{self._ucxx_trainer_total_fallback} fallback, "
+                f"{self._ucxx_trainer_total_bytes / 1e6:.1f} MB, "
+                f"avg {avg_ms:.0f} ms/iter"
+            )
+        logger.info("[UCXXTrainerMixin] Cleaned up")

--- a/cosmos_rl/utils/payload_transport/ucxx/shared_buffer.py
+++ b/cosmos_rl/utils/payload_transport/ucxx/shared_buffer.py
@@ -1,0 +1,773 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Shared-memory ring buffer used by the UCXX payload transport.
+
+Tensors are copied directly to shared memory (``memcpy`` via numpy) with
+no pickle in the fast path: each schema-described entry has a fixed
+layout so the writer and reader simply ``memmove`` bytes.
+
+The buffer uses a four-state slot machine
+(``FREE → WRITING → READY → READING → FREE``) implemented in the entry
+metadata header, so producers and consumers can coordinate without
+shared-memory locks beyond a single per-process :class:`threading.Lock`
+guarding the header.
+"""
+
+import os
+import struct
+import socket
+from dataclasses import dataclass, field
+from enum import IntEnum
+from multiprocessing import shared_memory
+from threading import Lock
+from typing import Any, Dict, List, Optional, Tuple
+
+import numpy as np
+import torch
+
+from cosmos_rl.utils.logging import logger
+from cosmos_rl.utils.payload_transport.ucxx.tensor_spec import TensorSpec
+
+
+class SlotError(Exception):
+    """Exception for buffer slot operations."""
+
+    pass
+
+
+class SlotState(IntEnum):
+    """
+    State machine for buffer slots.
+
+    Transitions:
+        FREE -> WRITING: Writer acquires slot
+        WRITING -> READY: Writer completes write
+        READY -> READING: Reader starts reading
+        READING -> FREE: Reader completes and marks consumed
+
+        Overwrite path (when buffer full):
+        READY -> WRITING: Writer overwrites unconsumed slot (logs warning)
+    """
+
+    FREE = 0  # Slot is available for writing
+    WRITING = 1  # Writer is actively writing to slot
+    READY = 2  # Data is ready to be read
+    READING = 3  # Reader is actively reading from slot
+
+
+@dataclass
+class BufferMetrics:
+    """Metrics for buffer operations."""
+
+    writes_total: int = 0
+    reads_total: int = 0
+    drops_total: int = 0  # Overwrites of unconsumed data
+
+    @property
+    def current_fill(self) -> int:
+        """Approximate fill level (writes - reads - drops)."""
+        return max(0, self.writes_total - self.reads_total - self.drops_total)
+
+
+@dataclass
+class BufferConfig:
+    """Configuration for shared buffer."""
+
+    max_entries: int = 64
+    entry_size_bytes: int = 65536  # Fallback if no schema provided
+    buffer_name: str = ""
+
+    # Schema: list of TensorSpecs defining what tensors are stored
+    # If empty, falls back to pickle-based serialization
+    schema: List[TensorSpec] = field(default_factory=list)
+
+    def __post_init__(self):
+        if not self.buffer_name:
+            self.buffer_name = f"cosmos_rl_shm_{os.getpid()}_{id(self)}"
+
+
+class SharedRingBuffer:
+    """
+    Fast shared memory ring buffer for inter-process RL data transfer.
+
+    Each entry represents ONE COMPLETE ROLLOUT (trajectory) with a fixed schema.
+    All entries have identical size, enabling direct memcpy without serialization.
+
+    Typical schema for RL:
+        observations:   (max_steps, obs_dim)    float32
+        actions:        (max_steps, action_dim) float32
+        rewards:        (max_steps,)            float32
+        terminated:     (max_steps,)            bool
+        truncated:      (max_steps,)            bool
+        episode_length: (1,)                    int64  <- actual valid steps
+
+    Variable-length episodes are padded to max_steps; episode_length indicates
+    how many steps are valid (the rest is zero-padding).
+
+    Operations:
+        Write: memcpy from source tensor to shared array (no serialization)
+        Read:  return view into shared memory (true fast read)
+
+    Memory layout:
+        [Header: 24 bytes (write_idx, read_idx, entry_count)]
+        [Entry 0 metadata: 16 bytes][Entry 0 tensors...]
+        [Entry 1 metadata: 16 bytes][Entry 1 tensors...]
+        ...
+
+    Entry metadata: (size: u64, state: u8 (SlotState), padding)
+
+    Slot State Machine:
+        FREE -> WRITING -> READY -> READING -> FREE
+        (Overwrite path: READY -> WRITING when buffer full)
+    """
+
+    HEADER_SIZE = 24  # write_idx, read_idx, entry_count (3 x u64)
+    ENTRY_META_SIZE = 16  # size (u64) + state (u8) + padding (7 bytes)
+
+    def __init__(self, config: BufferConfig, create: bool = False):
+        self.config = config
+        self.buffer_name = config.buffer_name
+        self.max_entries = config.max_entries
+        self.schema = config.schema
+
+        # Calculate sizes
+        if self.schema:
+            # Schema-based: fixed layout for each entry
+            self.entry_data_size = sum(spec.nbytes for spec in self.schema)
+        else:
+            # Fallback: variable size entries (still uses pickle)
+            self.entry_data_size = config.entry_size_bytes
+
+        self.entry_size = self.ENTRY_META_SIZE + self.entry_data_size
+        self.total_size = self.HEADER_SIZE + (self.max_entries * self.entry_size)
+
+        # Create/attach shared memory
+        self._shm: Optional[shared_memory.SharedMemory] = None
+        self._lock = Lock()
+        self._is_creator = create
+
+        # Metrics (local to this process, not shared)
+        self._metrics = BufferMetrics()
+
+        self._init_shm(create)
+
+        # Pre-compute tensor offsets within each entry
+        self._tensor_offsets: Dict[str, int] = {}
+        if self.schema:
+            offset = 0
+            for spec in self.schema:
+                self._tensor_offsets[spec.name] = offset
+                offset += spec.nbytes
+
+    def _init_shm(self, create: bool) -> None:
+        """Initialize shared memory segment."""
+        try:
+            if create:
+                # Clean up any existing segment with same name
+                try:
+                    old_shm = shared_memory.SharedMemory(name=self.buffer_name)
+                    old_shm.close()
+                    old_shm.unlink()
+                except FileNotFoundError:
+                    pass
+
+                self._shm = shared_memory.SharedMemory(
+                    name=self.buffer_name, create=True, size=self.total_size
+                )
+                # Initialize header
+                self._write_header(0, 0, 0)
+
+                # Initialize all slots to FREE state
+                for i in range(self.max_entries):
+                    self._write_entry_meta(i, 0, SlotState.FREE)
+
+                logger.info(
+                    f"[SharedRingBuffer] Created '{self.buffer_name}' "
+                    f"({self.total_size / 1024:.1f} KB, {self.max_entries} entries)"
+                )
+            else:
+                self._shm = shared_memory.SharedMemory(name=self.buffer_name)
+                logger.info(f"[SharedRingBuffer] Attached to '{self.buffer_name}'")
+        except Exception as e:
+            logger.error(f"[SharedRingBuffer] Failed to create/attach: {e}")
+            raise
+
+    def _write_header(self, write_idx: int, read_idx: int, entry_count: int) -> None:
+        """Write header to shared memory."""
+        struct.pack_into("QQQ", self._shm.buf, 0, write_idx, read_idx, entry_count)
+
+    def _read_header(self) -> Tuple[int, int, int]:
+        """Read header from shared memory."""
+        return struct.unpack_from("QQQ", self._shm.buf, 0)
+
+    def _entry_offset(self, index: int) -> int:
+        """Get byte offset for entry metadata."""
+        return self.HEADER_SIZE + (index * self.entry_size)
+
+    def _entry_data_offset(self, index: int) -> int:
+        """Get byte offset for entry data."""
+        return self._entry_offset(index) + self.ENTRY_META_SIZE
+
+    def _write_entry_meta(self, index: int, size: int, state: SlotState) -> None:
+        """Write entry metadata with state."""
+        offset = self._entry_offset(index)
+        # Format: Q (u64 size) + B (u8 state) + 7 bytes padding = 16 bytes
+        struct.pack_into("QB", self._shm.buf, offset, size, state)
+
+    def _read_entry_meta(self, index: int) -> Tuple[int, SlotState]:
+        """Read entry metadata."""
+        offset = self._entry_offset(index)
+        size, state_val = struct.unpack_from("QB", self._shm.buf, offset)
+        return size, SlotState(state_val)
+
+    def _try_transition(
+        self, index: int, from_state: SlotState, to_state: SlotState
+    ) -> bool:
+        """
+        Attempt atomic state transition for a slot.
+
+        Args:
+            index: Slot index
+            from_state: Expected current state
+            to_state: Desired new state
+
+        Returns:
+            True if transition succeeded, False if current state didn't match.
+        """
+        with self._lock:
+            size, current_state = self._read_entry_meta(index)
+            if current_state != from_state:
+                return False
+            self._write_entry_meta(index, size, to_state)
+            return True
+
+    def get_slot_state(self, index: int) -> SlotState:
+        """Get the current state of a slot."""
+        _, state = self._read_entry_meta(index)
+        return state
+
+    def write(self, data: Dict[str, Any], overwrite_if_full: bool = True) -> int:
+        """
+        Write data to buffer (fast for tensors).
+
+        Args:
+            data: Dict of tensors/arrays. Keys must match schema if schema is defined.
+            overwrite_if_full: If True, overwrite oldest unconsumed entry when full.
+                               If False, raise SlotError when full.
+
+        Returns:
+            Slot index where data was written.
+
+        Raises:
+            SlotError: If buffer is full and overwrite_if_full=False.
+        """
+        with self._lock:
+            write_idx, read_idx, entry_count = self._read_header()
+
+            # Get slot (ring buffer)
+            slot = write_idx % self.max_entries
+
+            # Check slot state and handle appropriately
+            _, current_state = self._read_entry_meta(slot)
+
+            if current_state == SlotState.READY:
+                # Slot has unconsumed data
+                if entry_count >= self.max_entries:
+                    if not overwrite_if_full:
+                        raise SlotError(f"Buffer full, slot {slot} not consumed")
+                    # Overwrite mode: log warning and continue (data loss is acceptable
+                    # for RL - old trajectories become stale anyway)
+                    logger.warning(
+                        f"[SharedRingBuffer] Overwriting unconsumed slot {slot} "
+                        f"write_idx={write_idx} entry_count={entry_count}"
+                    )
+                    self._metrics.drops_total += 1
+            elif current_state == SlotState.WRITING:
+                raise SlotError(f"Slot {slot} is being written by another process")
+            elif current_state == SlotState.READING:
+                raise SlotError(f"Slot {slot} is being read, cannot overwrite")
+
+            # Transition to WRITING state
+            self._write_entry_meta(slot, 0, SlotState.WRITING)
+
+            data_offset = self._entry_data_offset(slot)
+
+            if self.schema:
+                # Fast path: write tensors directly
+                self._write_tensors(data, data_offset)
+                size = self.entry_data_size
+            else:
+                # Fallback: pickle (for backward compatibility)
+                import pickle
+
+                serialized = pickle.dumps(data)
+                size = len(serialized)
+                if size > self.entry_data_size:
+                    # Reset state on error
+                    self._write_entry_meta(slot, 0, SlotState.FREE)
+                    raise SlotError(
+                        f"Data size {size} exceeds entry size {self.entry_data_size}"
+                    )
+                self._shm.buf[data_offset : data_offset + size] = serialized
+
+            # Transition to READY state
+            self._write_entry_meta(slot, size, SlotState.READY)
+
+            # Update header
+            new_count = min(entry_count + 1, self.max_entries)
+            self._write_header(write_idx + 1, read_idx, new_count)
+
+            # Update metrics
+            self._metrics.writes_total += 1
+
+            return slot
+
+    def write_raw(self, buf: bytes, overwrite_if_full: bool = True) -> int:
+        """Write a pre-packed contiguous buffer to the next slot.
+
+        This is the fast path used by ``UCXXRolloutMixin.write_to_buffer``:
+        the caller has already coalesced all tensors into a single
+        byte-buffer matching the schema layout, so we skip per-tensor
+        iteration and do a single ``memoryview`` copy (one ``memmove``).
+
+        Args:
+            buf: Contiguous bytes/memoryview whose length equals
+                ``self.entry_data_size``.
+            overwrite_if_full: Same semantics as ``write()``.
+
+        Returns:
+            Slot index where data was written.
+        """
+        if len(buf) != self.entry_data_size:
+            raise SlotError(
+                f"Raw buffer size {len(buf)} != expected {self.entry_data_size}"
+            )
+
+        with self._lock:
+            write_idx, read_idx, entry_count = self._read_header()
+            slot = write_idx % self.max_entries
+
+            _, current_state = self._read_entry_meta(slot)
+            if current_state == SlotState.READY:
+                if entry_count >= self.max_entries:
+                    if not overwrite_if_full:
+                        raise SlotError(f"Buffer full, slot {slot} not consumed")
+                    logger.warning(
+                        f"[SharedRingBuffer] Overwriting unconsumed slot {slot} "
+                        f"write_idx={write_idx} entry_count={entry_count}"
+                    )
+                    self._metrics.drops_total += 1
+            elif current_state == SlotState.WRITING:
+                raise SlotError(f"Slot {slot} is being written by another process")
+            elif current_state == SlotState.READING:
+                raise SlotError(f"Slot {slot} is being read, cannot overwrite")
+
+            self._write_entry_meta(slot, 0, SlotState.WRITING)
+
+            data_offset = self._entry_data_offset(slot)
+            self._shm.buf[data_offset : data_offset + self.entry_data_size] = buf
+
+            self._write_entry_meta(slot, self.entry_data_size, SlotState.READY)
+            new_count = min(entry_count + 1, self.max_entries)
+            self._write_header(write_idx + 1, read_idx, new_count)
+            self._metrics.writes_total += 1
+            return slot
+
+    def _write_tensors(self, data: Dict[str, Any], base_offset: int) -> None:
+        """Write tensors directly to shared memory (no serialization)."""
+        for spec in self.schema:
+            if spec.name not in data:
+                raise SlotError(f"Missing tensor '{spec.name}' in data")
+
+            tensor = data[spec.name]
+
+            # Convert to numpy if needed
+            if isinstance(tensor, torch.Tensor):
+                arr = tensor.detach().cpu().numpy()
+            elif isinstance(tensor, np.ndarray):
+                arr = tensor
+            else:
+                # Scalar or other - convert to numpy
+                arr = np.array(tensor, dtype=spec.dtype)
+
+            # Ensure correct dtype and contiguous
+            if arr.dtype != spec.dtype:
+                arr = arr.astype(spec.dtype)
+            if not arr.flags["C_CONTIGUOUS"]:
+                arr = np.ascontiguousarray(arr)
+
+            # Create view into shared memory and copy directly (memcpy, no tobytes())
+            offset = base_offset + self._tensor_offsets[spec.name]
+
+            # Get destination as numpy array view
+            dst = np.ndarray(
+                shape=spec.shape, dtype=spec.dtype, buffer=self._shm.buf, offset=offset
+            )
+
+            # Reshape source to match destination
+            src = arr.reshape(spec.shape) if arr.shape != spec.shape else arr
+
+            # Direct memcpy via numpy (TRUE fast write)
+            np.copyto(dst, src)
+
+    def is_ready(self, index: int) -> bool:
+        """Check if an entry is ready to read."""
+        _, state = self._read_entry_meta(index)
+        return state == SlotState.READY
+
+    def get_ready_count(self) -> int:
+        """Get number of entries ready to be consumed."""
+        _, _, entry_count = self._read_header()
+        return entry_count
+
+    def is_full(self) -> bool:
+        """Check if buffer is full."""
+        _, _, entry_count = self._read_header()
+        return entry_count >= self.max_entries
+
+    def read(self, index: int) -> Dict[str, Any]:
+        """
+        Read data from buffer (fast for tensors).
+
+        Transitions slot state: READY -> READING (during read) -> stays READING
+        Call mark_consumed() after processing to transition to FREE.
+
+        Args:
+            index: Slot index to read from.
+
+        Returns:
+            Dict of numpy arrays (copies from shared memory).
+
+        Raises:
+            SlotError: If entry is not ready.
+        """
+        with self._lock:
+            size, state = self._read_entry_meta(index)
+
+            if state != SlotState.READY:
+                raise SlotError(f"Entry {index} not ready (state={state.name})")
+
+            # Transition to READING state
+            self._write_entry_meta(index, size, SlotState.READING)
+
+        data_offset = self._entry_data_offset(index)
+
+        if self.schema:
+            # Fast path: read tensors directly
+            result = self._read_tensors(data_offset)
+        else:
+            # Fallback: pickle
+            import pickle
+
+            serialized = bytes(self._shm.buf[data_offset : data_offset + size])
+            result = pickle.loads(serialized)
+
+        # Update metrics
+        self._metrics.reads_total += 1
+
+        return result
+
+    def _read_tensors(self, base_offset: int) -> Dict[str, np.ndarray]:
+        """Read tensors directly from shared memory (fast when possible)."""
+        result = {}
+
+        for spec in self.schema:
+            offset = base_offset + self._tensor_offsets[spec.name]
+
+            # Create numpy array view into shared memory (TRUE fast read)
+            # Note: This is a view, not a copy. Modifications affect shared memory.
+            arr = np.ndarray(
+                shape=spec.shape, dtype=spec.dtype, buffer=self._shm.buf, offset=offset
+            )
+
+            # Return a copy to be safe (caller may hold reference after we move on)
+            # For true fast, caller should process immediately
+            result[spec.name] = arr.copy()
+
+        return result
+
+    def try_read(self, index: int) -> Optional[Dict[str, Any]]:
+        """
+        Try to read data from buffer, return None if not ready.
+
+        Non-blocking version of read() for consumer-faster-than-producer scenarios.
+        Transitions slot state: READY -> READING if successful.
+        Call mark_consumed() after processing to transition to FREE.
+
+        Args:
+            index: Slot index to read from.
+
+        Returns:
+            Dict of numpy arrays, or None if entry not ready.
+        """
+        with self._lock:
+            size, state = self._read_entry_meta(index)
+
+            if state != SlotState.READY:
+                return None
+
+            # Transition to READING state
+            self._write_entry_meta(index, size, SlotState.READING)
+
+        data_offset = self._entry_data_offset(index)
+
+        if self.schema:
+            result = self._read_tensors(data_offset)
+        else:
+            import pickle
+
+            serialized = bytes(self._shm.buf[data_offset : data_offset + size])
+            result = pickle.loads(serialized)
+
+        # Update metrics
+        self._metrics.reads_total += 1
+
+        return result
+
+    def get_ready_indices(self) -> List[int]:
+        """
+        Get list of slot indices that are ready to be consumed.
+
+        Returns:
+            List of slot indices with ready data (state == READY).
+        """
+        ready_indices = []
+        for i in range(self.max_entries):
+            _, state = self._read_entry_meta(i)
+            if state == SlotState.READY:
+                ready_indices.append(i)
+        return ready_indices
+
+    def read_view(self, index: int) -> Dict[str, np.ndarray]:
+        """
+        Read data as views into shared memory (TRUE fast).
+
+        WARNING: Returned arrays are views. They become invalid after mark_consumed()
+        or if the slot is overwritten. Process immediately!
+
+        Transitions slot state: READY -> READING.
+        Call mark_consumed() after processing to transition to FREE.
+
+        Args:
+            index: Slot index to read from.
+
+        Returns:
+            Dict of numpy array views into shared memory.
+
+        Raises:
+            SlotError: If entry is not ready.
+        """
+        with self._lock:
+            size, state = self._read_entry_meta(index)
+
+            if state != SlotState.READY:
+                raise SlotError(f"Entry {index} not ready (state={state.name})")
+
+            if not self.schema:
+                raise SlotError("read_view() requires schema-based buffer")
+
+            # Transition to READING state
+            self._write_entry_meta(index, size, SlotState.READING)
+
+        data_offset = self._entry_data_offset(index)
+        result = {}
+
+        for spec in self.schema:
+            offset = data_offset + self._tensor_offsets[spec.name]
+
+            # True fast: numpy view into shared memory
+            result[spec.name] = np.ndarray(
+                shape=spec.shape, dtype=spec.dtype, buffer=self._shm.buf, offset=offset
+            )
+
+        # Update metrics
+        self._metrics.reads_total += 1
+
+        return result
+
+    def read_raw(self, index: int) -> np.ndarray:
+        """Return the raw bytes of a slot as a contiguous uint8 array view.
+
+        Transitions slot state: READY -> READING on first call.
+        Allows concurrent reads from READING state for chunked transfers.
+        Caller must call :meth:`mark_consumed` after all readers are done.
+
+        This is the read-side counterpart of :meth:`write_raw` and is used
+        by the UCXX server for coalesced (single-send) transfers.
+        """
+        with self._lock:
+            size, state = self._read_entry_meta(index)
+
+            if state == SlotState.READY:
+                if not self.schema:
+                    raise SlotError("read_raw() requires schema-based buffer")
+                self._write_entry_meta(index, size, SlotState.READING)
+            elif state != SlotState.READING:
+                raise SlotError(f"Entry {index} not ready (state={state.name})")
+
+        data_offset = self._entry_data_offset(index)
+        self._metrics.reads_total += 1
+        return np.ndarray(
+            shape=(self.entry_data_size,),
+            dtype=np.uint8,
+            buffer=self._shm.buf,
+            offset=data_offset,
+        )
+
+    def mark_consumed(self, index: int) -> None:
+        """
+        Mark entry as consumed (slot can be reused).
+
+        Transitions slot state: READING -> FREE.
+        """
+        with self._lock:
+            size, state = self._read_entry_meta(index)
+
+            if state != SlotState.READING:
+                logger.warning(
+                    f"[SharedRingBuffer] mark_consumed on slot {index} with unexpected "
+                    f"state {state.name} (expected READING)"
+                )
+
+            # Transition to FREE state
+            self._write_entry_meta(index, 0, SlotState.FREE)
+            logger.debug(
+                f"[SharedRingBuffer] mark_consumed slot={index} (READING->FREE)"
+            )
+
+    def release_reading(self, index: int) -> None:
+        """
+        Release slot from READING back to READY (data preserved for retry).
+
+        Called when a send fails mid-transfer. The data is still valid in
+        shared memory, so transitioning back to READY allows a new handler
+        to read_view() the same slot on the client's retry.
+
+        Transitions slot state: READING -> READY.
+        """
+        with self._lock:
+            size, state = self._read_entry_meta(index)
+
+            if state != SlotState.READING:
+                logger.warning(
+                    f"[SharedRingBuffer] release_reading on slot {index} with "
+                    f"unexpected state {state.name} (expected READING)"
+                )
+                return
+
+            self._write_entry_meta(index, size, SlotState.READY)
+
+    def get_metrics(self) -> BufferMetrics:
+        """
+        Get buffer metrics.
+
+        Note: Metrics are local to this process and not shared across processes.
+        Each process maintains its own metrics for operations it performs.
+
+        Returns:
+            BufferMetrics with writes_total, reads_total, drops_total, current_fill.
+        """
+        return self._metrics
+
+    def get_slot_states(self) -> Dict[int, SlotState]:
+        """
+        Get states of all slots (for debugging/monitoring).
+
+        Returns:
+            Dict mapping slot index to SlotState.
+        """
+        states = {}
+        for i in range(self.max_entries):
+            _, state = self._read_entry_meta(i)
+            states[i] = state
+        return states
+
+    def get_handle(self) -> Dict[str, Any]:
+        """Get serializable handle for buffer discovery."""
+        return {
+            "type": "cpu_shm",
+            "buffer_name": self.buffer_name,
+            "max_entries": self.max_entries,
+            "entry_size": self.entry_data_size,
+            "node_id": socket.gethostname(),
+            "schema": [
+                {"name": s.name, "shape": s.shape, "dtype": str(s.dtype)}
+                for s in self.schema
+            ]
+            if self.schema
+            else None,
+        }
+
+    @classmethod
+    def from_handle(cls, handle: Dict[str, Any]) -> "SharedRingBuffer":
+        """Create buffer from handle (attach to existing)."""
+        schema = []
+        if handle.get("schema"):
+            for s in handle["schema"]:
+                schema.append(
+                    TensorSpec(
+                        name=s["name"],
+                        shape=tuple(s["shape"]),
+                        dtype=np.dtype(s["dtype"]),
+                    )
+                )
+
+        config = BufferConfig(
+            buffer_name=handle["buffer_name"],
+            max_entries=handle["max_entries"],
+            entry_size_bytes=handle["entry_size"],
+            schema=schema,
+        )
+        return cls(config, create=False)
+
+    def close(self) -> None:
+        """Close shared memory (doesn't unlink)."""
+        if self._shm:
+            self._shm.close()
+            self._shm = None
+
+    def unlink(self) -> None:
+        """Unlink (delete) shared memory. Only creator should call this.
+
+        Can be called before or after close(). Safe to call multiple times.
+        """
+        if not self._is_creator:
+            return
+
+        # Try to unlink via _shm if still open
+        if self._shm:
+            try:
+                self._shm.unlink()
+            except FileNotFoundError:
+                pass
+            self._shm = None
+        else:
+            # Already closed, unlink by name
+            try:
+                from multiprocessing.shared_memory import SharedMemory
+
+                shm = SharedMemory(name=self.buffer_name, create=False)
+                shm.close()
+                shm.unlink()
+            except FileNotFoundError:
+                pass
+
+    def __del__(self):
+        if self._is_creator:
+            # Creator should unlink to clean up /dev/shm segment
+            self.unlink()
+        else:
+            self.close()

--- a/cosmos_rl/utils/payload_transport/ucxx/tensor_spec.py
+++ b/cosmos_rl/utils/payload_transport/ucxx/tensor_spec.py
@@ -1,0 +1,71 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""``TensorSpec`` — fixed-shape tensor descriptor for flat byte schemas.
+
+Used by :mod:`cosmos_rl.utils.payload_transport.ucxx` to describe the
+on-the-wire layout of a single trajectory entry in a
+:class:`~cosmos_rl.utils.payload_transport.ucxx.shared_buffer.SharedRingBuffer`.
+Lives in its own module so it can be re-used by additional transports
+or by callers wanting to declare a flat schema without depending on the
+full UCXX stack.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Tuple, Union
+
+import numpy as np
+
+
+@dataclass
+class TensorSpec:
+    """Fixed-shape tensor descriptor.
+
+    Attributes:
+        shape: Tuple of dimensions (e.g. ``(max_steps, obs_dim)``).
+        dtype: Element type, accepted as a Python type
+            (``np.float32``) or :class:`numpy.dtype` instance.  Always
+            normalized to :class:`numpy.dtype` after construction.
+        name: Identifier used in flat schemas (e.g.
+            ``"observations"``).  Required when the spec participates
+            in a UCXX schema.
+    """
+
+    shape: Tuple[int, ...]
+    dtype: Union[type, np.dtype]
+    name: str = ""
+
+    def __post_init__(self) -> None:
+        # ``dataclass`` is permissive about dtype; normalize once so
+        # downstream code can rely on ``self.dtype.itemsize`` etc.
+        self.dtype = np.dtype(self.dtype)
+
+    @property
+    def nbytes(self) -> int:
+        """Byte size of one tensor matching this spec."""
+        return int(np.prod(self.shape)) * self.dtype.itemsize
+
+    def contains(self, tensor: np.ndarray) -> bool:
+        """Return True if ``tensor`` has matching shape and dtype."""
+        if tensor.shape != self.shape:
+            return False
+        if tensor.dtype != self.dtype:
+            return False
+        return True
+
+
+__all__ = ["TensorSpec"]

--- a/cosmos_rl/utils/payload_transport/ucxx/transport.py
+++ b/cosmos_rl/utils/payload_transport/ucxx/transport.py
@@ -1,0 +1,141 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""``PayloadTransport`` registration for UCXX.
+
+UCXX intentionally diverges from NCCL on two integration points:
+
+1. ``completion_prefix`` is ``None``.  UCXX rollouts return dict-shaped
+   metadata (``{"_ucxx": True, "_worker_ip": ..., "_slot": ...}``) rather
+   than a string-prefixed completion.  Setting the prefix to ``None``
+   tells :meth:`PayloadTransportRegistry.handle_discarded` to skip UCXX
+   cleanly when partitioning discards by prefix.
+
+2. ``publish_cleanup_for_discarded`` inherits the base no-op (returns 0).
+   Worker-side ring-buffer slots are producer-driven and auto-recycle
+   when the writer overwrites an unconsumed READY slot, so the
+   controller has nothing to publish.
+
+The ``attach_data_packer`` hook drives the per-packer setup that used
+to live in a manual trainer-side call, so the trainer no longer has to
+remember to invoke ``_setup_ucxx_data_packer`` after constructing its
+data packer.  The ``UCXXDataPackerMixin`` (MR5) provides the actual
+``_setup_ucxx_data_packer`` method; on MR3b the hook is a no-op for
+any packer that does not subclass that mixin.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+from cosmos_rl.utils.logging import logger
+from cosmos_rl.utils.payload_transport.registry import (
+    PayloadTransport,
+    PayloadTransportRegistry,
+    RedisEndpoint,
+)
+
+
+class UCXXPayloadTransport(PayloadTransport):
+    """UCXX backend (zero-copy RDMA / shared-memory transfer)."""
+
+    name = "ucxx"
+    # Intentionally None: UCXX uses dict-shaped completion metadata and
+    # SHM ring buffers auto-recycle slots, so it does NOT participate in
+    # the controller's discard-cleanup dispatch.  ``handle_discarded``
+    # skips transports with completion_prefix=None, which is what we
+    # want for UCXX.  See module docstring for the longer rationale.
+    completion_prefix = None
+
+    def attach_data_packer(
+        self,
+        packer: Any,
+        *,
+        config: Any,
+        device: Any = None,
+        redis_endpoint: Optional[RedisEndpoint] = None,
+    ) -> None:
+        """Wire UCXX-specific state into a UCXX-aware data packer.
+
+        Looks for the ``_setup_ucxx_data_packer`` method on the packer
+        (provided by :class:`UCXXDataPackerMixin` in MR5).  When present,
+        invokes it with ``device`` plus tunables resolved from
+        ``config.custom``:
+
+        * ``ucxx_prefetch_timeout`` (float, default 30.0): per-batch wait
+          ceiling for the prefetch worker thread's result queue.  Bounds
+          how long the trainer is willing to block on a single prefetch
+          batch before giving up.
+        * ``ucxx_n_chunks`` (int, default 2): number of in-flight prefetch
+          slots reserved on the trainer side.
+        * ``ucxx_read_max_attempts`` (int, default 2): total attempts per
+          remote slot read (initial + retries).  Retries fire only on
+          transient UCX errors classified in ``_TRANSIENT_UCXX_ERRORS``;
+          non-transient errors short-circuit immediately.
+        * ``ucxx_read_timeout`` (float, default 60.0): per-await wall
+          clock budget for each ``endpoint.send`` / ``endpoint.recv``
+          inside one ``UCXXClient.read`` call (distinct from
+          ``ucxx_prefetch_timeout`` above -- this bounds a single
+          network operation, not a whole batch).
+
+        No-op for packers that do not subclass the mixin -- matches the
+        defensive default of the base class.
+        """
+        setup = getattr(packer, "_setup_ucxx_data_packer", None)
+        if setup is None:
+            return
+        custom = getattr(config, "custom", None) or {}
+        try:
+            prefetch_timeout = float(custom.get("ucxx_prefetch_timeout", 30.0))
+        except (TypeError, ValueError):
+            prefetch_timeout = 30.0
+        try:
+            n_chunks = int(custom.get("ucxx_n_chunks", 2))
+        except (TypeError, ValueError):
+            n_chunks = 2
+        try:
+            max_attempts = int(custom.get("ucxx_read_max_attempts", 2))
+        except (TypeError, ValueError):
+            max_attempts = 2
+        if max_attempts < 1:
+            max_attempts = 1
+        try:
+            read_timeout = float(custom.get("ucxx_read_timeout", 60.0))
+        except (TypeError, ValueError):
+            read_timeout = 60.0
+        logger.debug(
+            f"[UCXXPayloadTransport] Attaching UCXX data packer "
+            f"(device={device}, prefetch_timeout={prefetch_timeout}, "
+            f"n_chunks={n_chunks}, max_attempts={max_attempts}, "
+            f"read_timeout={read_timeout})"
+        )
+        setup(
+            device=device,
+            prefetch_timeout=prefetch_timeout,
+            n_chunks=n_chunks,
+            max_attempts=max_attempts,
+            read_timeout=read_timeout,
+        )
+
+    # publish_cleanup_for_discarded is intentionally NOT overridden:
+    # the inherited default returns 0, which is correct for UCXX (SHM
+    # ring slots auto-recycle on producer overwrite; the controller has
+    # nothing to publish).
+
+
+PayloadTransportRegistry.register_class(UCXXPayloadTransport)
+
+
+__all__ = ["UCXXPayloadTransport"]

--- a/cosmos_rl/utils/payload_transport/ucxx/ucxx_buffer.py
+++ b/cosmos_rl/utils/payload_transport/ucxx/ucxx_buffer.py
@@ -1,0 +1,862 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""UCXX-based payload-transfer server / client.
+
+UCX (and its Python binding UCXX) provides unified communication that
+auto-optimizes the underlying transport:
+
+* Same-node: shared-memory transport (~100 GB/s)
+* Cross-node: RDMA (~12.5 GB/s) or TCP fallback
+
+This module wraps :class:`SharedRingBuffer` with a UCXX server that
+lets remote trainers read slot data directly from a worker's CPU
+buffer without going through Redis.
+
+The ``ucxx-cu12`` (or platform-equivalent) extra is **optional**.  When
+it is not installed, importing this module still succeeds and
+:data:`UCXX_AVAILABLE` is set to ``False``; attempts to start a server
+or client will raise an explicit ``RuntimeError`` rather than failing
+with an import error in random places.
+"""
+
+import asyncio
+import collections
+import os
+import threading
+import time
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional
+
+import numpy as np
+import torch
+
+from cosmos_rl.utils.logging import logger
+from cosmos_rl.utils.payload_transport.ucxx.shared_buffer import (
+    BufferConfig,
+    BufferMetrics,
+    SharedRingBuffer,
+    SlotError,
+    SlotState,
+)
+
+# Optional UCXX import - graceful handling if not available
+# Package: pip install ucxx-cu12 (for CUDA 12)
+try:
+    import ucxx
+
+    UCXX_AVAILABLE = True
+except ImportError:
+    ucxx = None
+    UCXX_AVAILABLE = False
+    logger.warning(
+        "[UCXXBuffer] ucxx not available. Install with: pip install ucxx-cu12. "
+        "Cross-node UCXX will not work."
+    )
+
+
+class StaleSlotError(RuntimeError):
+    """Raised when a client reads a slot that has already been consumed."""
+
+    pass
+
+
+@dataclass
+class UCXXBufferConfig:
+    """Configuration for UCXXBuffer."""
+
+    # SharedRingBuffer config
+    buffer_name: str = ""
+    max_entries: int = 100
+    entry_size_bytes: int = 65536
+    schema: List[Any] = None  # List of TensorSpec
+
+    # UCXX server config
+    port: int = 13337
+    n_server_threads: int = 4
+
+    def __post_init__(self):
+        if self.schema is None:
+            self.schema = []
+
+    def to_buffer_config(self) -> BufferConfig:
+        """Convert to BufferConfig for SharedRingBuffer."""
+        return BufferConfig(
+            buffer_name=self.buffer_name,
+            max_entries=self.max_entries,
+            entry_size_bytes=self.entry_size_bytes,
+            schema=self.schema,
+        )
+
+
+class UCXXBuffer:
+    """
+    CPU ring buffer with UCXX server for remote reads.
+
+    Worker side: Creates a SharedRingBuffer and starts a UCXX listener
+    that allows trainers to read slot data remotely.
+
+    The UCXX server handles read requests:
+    1. Trainer connects to worker's UCXX server
+    2. Trainer sends slot index
+    3. Worker reads from local buffer and sends data back
+    4. UCX auto-selects transport (shm for same-node, RDMA for cross-node)
+
+    Usage:
+        # Worker side
+        buffer = UCXXBuffer(config)
+        await buffer.start_server()
+
+        slot = buffer.write(rollout_data)
+        metadata = buffer.get_metadata(slot)
+        # Send metadata via Redis stream...
+
+        # Cleanup
+        await buffer.stop_server()
+        buffer.close()
+    """
+
+    def __init__(self, config: UCXXBufferConfig, create: bool = True):
+        """
+        Initialize UCXXBuffer.
+
+        Args:
+            config: Buffer configuration
+            create: If True, create new shared memory; if False, attach to existing
+        """
+        self.config = config
+        self._base_port = config.port
+        self._n_threads = max(1, config.n_server_threads)
+        self._local_ip = self._get_local_ip()
+
+        # Create underlying SharedRingBuffer
+        buffer_config = config.to_buffer_config()
+        self._buffer = SharedRingBuffer(buffer_config, create=create)
+
+        # Multi-threaded UCXX server state (one per server thread)
+        self._ports: List[int] = []
+        self._listeners: List[Any] = []
+        self._server_threads: List[threading.Thread] = []
+        self._server_loops: List[Optional[asyncio.AbstractEventLoop]] = []
+        self._shutdown_flag = threading.Event()
+        self._active_endpoints: List[Any] = []
+        self._endpoints_lock = threading.Lock()
+        self._server_ready_count = 0
+        self._server_ready_lock = threading.Lock()
+        self._server_ready_event = threading.Event()
+        self._handler_tasks_per_thread: List[List[asyncio.Task]] = []
+        self._slot_refcount: Dict[int, int] = {}
+        self._slot_refcount_lock = threading.Lock()
+        self._thread_metrics: Dict[str, Dict[str, float]] = {}
+        self._thread_metrics_lock = threading.Lock()
+
+        logger.info(
+            f"[UCXXBuffer] Initialized '{config.buffer_name}' on {self._local_ip} "
+            f"(n_server_threads={self._n_threads})"
+        )
+
+    @staticmethod
+    def _get_local_ip() -> str:
+        """Get local IP for UCXX listener, preferring RDMA interfaces.
+
+        Delegates to mixins._get_local_ip() which checks rdma* interfaces
+        first to avoid binding to the management network on IB clusters.
+        """
+        from .mixins import _get_local_ip
+
+        return _get_local_ip()
+
+    # =========================================================================
+    # UCXX Server (Worker Side)
+    # =========================================================================
+
+    def start_server(self, timeout: float = 10.0) -> None:
+        """Start N UCXX listeners on consecutive ports in background threads.
+
+        This method is synchronous and blocks until all server threads are
+        ready.  Each thread gets its own asyncio event loop and UCX worker.
+
+        Args:
+            timeout: Timeout in seconds to wait for all threads to start.
+
+        Raises:
+            RuntimeError: If UCXX is not available or server fails to start.
+        """
+        if not UCXX_AVAILABLE:
+            raise RuntimeError(
+                "UCXX is required for UCXXBuffer server. "
+                "Install with: pip install ucxx-cu12"
+            )
+
+        if self._server_threads and any(t.is_alive() for t in self._server_threads):
+            logger.warning("[UCXXBuffer] Server already running")
+            return
+
+        self._shutdown_flag.clear()
+        self._server_ready_count = 0
+        self._server_ready_event.clear()
+        self._ports = []
+        self._listeners = [None] * self._n_threads
+        self._server_loops = [None] * self._n_threads
+        self._handler_tasks_per_thread = [[] for _ in range(self._n_threads)]
+        self._server_threads = []
+
+        for i in range(self._n_threads):
+            port = self._base_port + i
+            t = threading.Thread(
+                target=self._run_server_loop,
+                args=(i, port),
+                daemon=True,
+                name=f"UCXXServer-{port}",
+            )
+            self._server_threads.append(t)
+            t.start()
+
+        if not self._server_ready_event.wait(timeout=timeout):
+            raise RuntimeError(
+                f"UCXX server failed to start {self._n_threads} threads "
+                f"within {timeout}s (ports {self._base_port}–"
+                f"{self._base_port + self._n_threads - 1})"
+            )
+
+        ucx_tls = os.environ.get("UCX_TLS", "(not set)")
+        logger.info(
+            f"[UCXXBuffer] Server started: {self._n_threads} threads on "
+            f"{self._local_ip} ports {self._ports}"
+        )
+        logger.info(f"[UCXXBuffer] UCX_TLS={ucx_tls}")
+
+    def _run_server_loop(self, thread_idx: int, port: int) -> None:
+        """Run the UCXX server event loop in background thread."""
+        with self._thread_metrics_lock:
+            self._thread_metrics[threading.current_thread().name] = {
+                "requests": 0,
+                "total_read_ms": 0.0,
+                "total_send_ms": 0.0,
+            }
+        try:
+            loop = asyncio.new_event_loop()
+            asyncio.set_event_loop(loop)
+            self._server_loops[thread_idx] = loop
+
+            loop.run_until_complete(self._async_server_main(thread_idx, port))
+
+        except Exception as e:
+            logger.error(f"[UCXXBuffer] Server loop error (thread {thread_idx}): {e}")
+            import traceback
+
+            traceback.print_exc()
+        finally:
+            loop = self._server_loops[thread_idx]
+            if loop:
+                loop.close()
+                self._server_loops[thread_idx] = None
+
+    async def _async_server_main(self, thread_idx: int, port: int) -> None:
+        """Async main function for one server thread.
+
+        Each thread has its own event loop and UCX worker so that
+        concurrent sends don't block each other (eliminates head-of-line
+        blocking).
+        """
+        try:
+            ucxx.init()
+        except RuntimeError as e:
+            if "already initiated" not in str(e):
+                logger.error(f"[UCXXBuffer] Failed to init UCXX: {e}")
+                return
+
+        handler_tasks = self._handler_tasks_per_thread[thread_idx]
+
+        def _dispatch(endpoint):
+            task = asyncio.get_event_loop().create_task(
+                self._handle_connection(endpoint)
+            )
+            handler_tasks.append(task)
+
+        last_err: Optional[Exception] = None
+        bound_port = port
+        for attempt in range(self._PORT_RETRY_ATTEMPTS):
+            candidate = port + attempt * self._n_threads
+            try:
+                listener = ucxx.create_listener(_dispatch, port=candidate)
+                bound_port = candidate
+                self._listeners[thread_idx] = listener
+                if candidate != port:
+                    logger.warning(
+                        f"[UCXXBuffer] Thread {thread_idx}: port {port} busy, "
+                        f"bound to {candidate} instead"
+                    )
+                break
+            except Exception as e:
+                last_err = e
+                logger.debug(
+                    f"[UCXXBuffer] Thread {thread_idx}: port {candidate} unavailable: {e}"
+                )
+        else:
+            logger.error(
+                f"[UCXXBuffer] Thread {thread_idx}: failed to bind after "
+                f"{self._PORT_RETRY_ATTEMPTS} attempts: {last_err}"
+            )
+            return
+
+        logger.info(f"[UCXXBuffer] Thread {thread_idx} listener on port {bound_port}")
+
+        with self._server_ready_lock:
+            self._ports.append(bound_port)
+            self._server_ready_count += 1
+            if self._server_ready_count >= self._n_threads:
+                self._ports.sort()
+                self._server_ready_event.set()
+
+        logger.info(
+            f"[UCXXBuffer] Server ready in thread {threading.current_thread().name}"
+        )
+
+        last_handler_log = time.perf_counter()
+        while not self._shutdown_flag.is_set():
+            handler_tasks[:] = [t for t in handler_tasks if not t.done()]
+            now = time.perf_counter()
+            if now - last_handler_log >= 10.0:
+                logger.info(
+                    f"[UCXXBuffer] Thread {thread_idx}: "
+                    f"{len(handler_tasks)} active handlers"
+                )
+                last_handler_log = now
+            await asyncio.sleep(0)
+
+        with self._endpoints_lock:
+            endpoints_to_close = list(self._active_endpoints)
+            self._active_endpoints.clear()
+        for ep in endpoints_to_close:
+            try:
+                await ep.close()
+            except Exception:
+                pass
+
+        for task in handler_tasks:
+            if not task.done():
+                task.cancel()
+        if handler_tasks:
+            await asyncio.gather(*handler_tasks, return_exceptions=True)
+        handler_tasks.clear()
+
+    _HANDLER_RECV_TIMEOUT = 5.0  # seconds per recv wait cycle
+    _HANDLER_MAX_IDLE_CYCLES = 24  # exit after 24 × 5s = 120s idle
+    _PORT_RETRY_ATTEMPTS = 10
+
+    async def _handle_connection(self, endpoint) -> None:
+        """Handle incoming connection from trainer.
+
+        Chunked protocol:
+        1. Receive: int64[3] = [slot, chunk_idx, n_chunks]
+        2. Send: status byte (1 byte)
+        3. Send: chunk slice of the raw SHM slot
+        """
+        logger.debug("[UCXXBuffer] New connection from trainer")
+        with self._endpoints_lock:
+            self._active_endpoints.append(endpoint)
+
+        idle_cycles = 0
+        try:
+            while not self._shutdown_flag.is_set():
+                try:
+                    slot_buf = np.empty(3, dtype=np.int64)
+                    await asyncio.wait_for(
+                        endpoint.recv(slot_buf), timeout=self._HANDLER_RECV_TIMEOUT
+                    )
+                    idle_cycles = 0
+                    t_recv_done = time.perf_counter()
+                    slot = int(slot_buf[0])
+                    chunk_idx = int(slot_buf[1])
+                    n_chunks = int(slot_buf[2])
+
+                    acquired_ref = False
+                    try:
+                        if not self._buffer.schema:
+                            raise RuntimeError(
+                                "Zero-pack protocol requires schema-based buffer"
+                            )
+
+                        try:
+                            raw_buf = self._buffer.read_raw(slot)
+                        except SlotError as e:
+                            status = np.array([1], dtype=np.uint8)
+                            await endpoint.send(status)
+                            with self._slot_refcount_lock:
+                                rc_snap = dict(self._slot_refcount)
+                            write_idx, _, entry_count = self._buffer._read_header()
+                            logger.warning(
+                                f"[UCXXBuffer] StaleSlot slot={slot} chunk={chunk_idx}/{n_chunks} "
+                                f"err='{e}' write_idx={write_idx} entry_count={entry_count} "
+                                f"refcount_snapshot={rc_snap} thread={threading.current_thread().name}"
+                            )
+                            continue
+                        with self._slot_refcount_lock:
+                            if slot not in self._slot_refcount:
+                                self._slot_refcount[slot] = n_chunks
+                            elif self._slot_refcount[slot] <= 0:
+                                self._slot_refcount[slot] = n_chunks
+                        acquired_ref = True
+
+                        total = raw_buf.nbytes
+                        chunk_size = (total + n_chunks - 1) // n_chunks
+                        start = chunk_idx * chunk_size
+                        end = min(start + chunk_size, total)
+                        chunk_buf = raw_buf[start:end]
+                        t_read_done = time.perf_counter()
+
+                        status = np.array([0], dtype=np.uint8)
+                        await endpoint.send(status)
+
+                        await endpoint.send(chunk_buf)
+
+                        with self._slot_refcount_lock:
+                            self._slot_refcount[slot] -= 1
+                            remaining = self._slot_refcount[slot]
+                            if remaining <= 0:
+                                self._slot_refcount.pop(slot, None)
+                        acquired_ref = False
+                        if remaining <= 0:
+                            self._buffer.mark_consumed(slot)
+
+                        t_send_done = time.perf_counter()
+                        read_ms = (t_read_done - t_recv_done) * 1000
+                        send_ms = (t_send_done - t_read_done) * 1000
+                        total_ms = (t_send_done - t_recv_done) * 1000
+                        logger.info(
+                            f"[UCXXBuffer] req slot={slot} chunk={chunk_idx}/{n_chunks} "
+                            f"bytes={chunk_buf.nbytes} read_ms={read_ms:.1f} "
+                            f"send_ms={send_ms:.1f} total_ms={total_ms:.1f}"
+                        )
+
+                        tname = threading.current_thread().name
+                        with self._thread_metrics_lock:
+                            m = self._thread_metrics.setdefault(
+                                tname,
+                                {
+                                    "requests": 0,
+                                    "total_read_ms": 0.0,
+                                    "total_send_ms": 0.0,
+                                },
+                            )
+                            m["requests"] += 1
+                            m["total_read_ms"] += read_ms
+                            m["total_send_ms"] += send_ms
+
+                    except Exception as e:
+                        if acquired_ref:
+                            with self._slot_refcount_lock:
+                                self._slot_refcount[slot] = (
+                                    self._slot_refcount.get(slot, 0) - 1
+                                )
+                                remaining = self._slot_refcount[slot]
+                                if remaining <= 0:
+                                    self._slot_refcount.pop(slot, None)
+                            if remaining <= 0:
+                                self._buffer.release_reading(slot)
+                                logger.warning(
+                                    f"[UCXXBuffer] Released slot {slot} back "
+                                    f"to READY after chunk {chunk_idx} failure"
+                                )
+                        try:
+                            status = np.array([2], dtype=np.uint8)
+                            await endpoint.send(status)
+                            error_msg = str(e).encode("utf-8")
+                            msg_len = np.array([len(error_msg)], dtype=np.int32)
+                            await endpoint.send(msg_len)
+                            await endpoint.send(
+                                np.frombuffer(error_msg, dtype=np.uint8)
+                            )
+                        except Exception:
+                            pass
+                        logger.warning(f"[UCXXBuffer] Send error for slot {slot}: {e}")
+
+                except asyncio.TimeoutError:
+                    idle_cycles += 1
+                    if idle_cycles >= self._HANDLER_MAX_IDLE_CYCLES:
+                        logger.debug(
+                            f"[UCXXBuffer] Handler idle for "
+                            f"{idle_cycles * self._HANDLER_RECV_TIMEOUT:.0f}s, closing"
+                        )
+                        break
+                    continue
+                except Exception as e:
+                    # Connection closed by client is expected
+                    if "canceled" in str(e).lower() or "reset" in str(e).lower():
+                        logger.debug(f"[UCXXBuffer] Client disconnected: {e}")
+                    else:
+                        logger.warning(f"[UCXXBuffer] Connection error: {e}")
+                    break
+        finally:
+            with self._endpoints_lock:
+                if endpoint in self._active_endpoints:
+                    self._active_endpoints.remove(endpoint)
+
+    def stop_server(self, timeout: float = 5.0) -> None:
+        """Stop all UCXX server threads and wait for them to finish.
+
+        Args:
+            timeout: Timeout in seconds to wait for each server thread to stop.
+        """
+        self._shutdown_flag.set()
+
+        for t in self._server_threads:
+            if t is not None and t.is_alive():
+                t.join(timeout=timeout)
+                if t.is_alive():
+                    logger.warning(
+                        f"[UCXXBuffer] Server thread {t.name} did not stop cleanly"
+                    )
+
+        for listener in self._listeners:
+            if listener is not None:
+                try:
+                    listener.close()
+                except Exception:
+                    pass
+
+        self._listeners.clear()
+        self._server_threads.clear()
+        self._ports.clear()
+        logger.info("[UCXXBuffer] Server stopped")
+
+    def get_server_metrics(self) -> Dict[str, Dict[str, float]]:
+        """Return per-thread server metrics (request count, cumulative timings)."""
+        with self._thread_metrics_lock:
+            return {k: dict(v) for k, v in self._thread_metrics.items()}
+
+    # =========================================================================
+    # Buffer Write Operations (Worker Side)
+    # =========================================================================
+
+    def write(self, data: Dict[str, Any], overwrite_if_full: bool = True) -> int:
+        """
+        Write data to buffer.
+
+        Args:
+            data: Dict of tensors/arrays matching schema.
+            overwrite_if_full: If True, overwrite oldest unconsumed entry.
+
+        Returns:
+            Slot index where data was written.
+        """
+        return self._buffer.write(data, overwrite_if_full)
+
+    def write_raw(self, buf: bytes, overwrite_if_full: bool = True) -> int:
+        """Write a pre-packed contiguous buffer to the next slot.
+
+        See :meth:`SharedRingBuffer.write_raw` for details.
+        """
+        return self._buffer.write_raw(buf, overwrite_if_full)
+
+    def get_metadata(self, slot: int) -> Dict[str, Any]:
+        """
+        Get metadata for a slot (to be sent via Redis stream).
+
+        Args:
+            slot: Slot index.
+
+        Returns:
+            Metadata dict with worker_ip, ports, slot for trainer to connect.
+        """
+        return {
+            "worker_ip": self._local_ip,
+            "ports": list(self._ports) if self._ports else [self._base_port],
+            "slot": slot,
+            "buffer_name": self._buffer.buffer_name,
+        }
+
+    # =========================================================================
+    # Buffer Read Operations (for local reads)
+    # =========================================================================
+
+    def read(self, index: int) -> Dict[str, Any]:
+        """Read data from buffer (local access)."""
+        return self._buffer.read(index)
+
+    def try_read(self, index: int) -> Optional[Dict[str, Any]]:
+        """Try to read data, return None if not ready."""
+        return self._buffer.try_read(index)
+
+    def mark_consumed(self, index: int) -> None:
+        """Mark slot as consumed (for local reads)."""
+        self._buffer.mark_consumed(index)
+
+    def is_ready(self, index: int) -> bool:
+        """Check if slot is ready to read."""
+        return self._buffer.is_ready(index)
+
+    def get_slot_state(self, index: int) -> SlotState:
+        """Get current state of a slot."""
+        return self._buffer.get_slot_state(index)
+
+    # =========================================================================
+    # Metrics and Info
+    # =========================================================================
+
+    def get_metrics(self) -> BufferMetrics:
+        """Get buffer metrics."""
+        return self._buffer.get_metrics()
+
+    def get_handle(self) -> Dict[str, Any]:
+        """Get serializable handle for buffer discovery."""
+        handle = self._buffer.get_handle()
+        handle["ucxx_ports"] = list(self._ports) if self._ports else [self._base_port]
+        handle["worker_ip"] = self._local_ip
+        return handle
+
+    @property
+    def buffer_name(self) -> str:
+        """Get buffer name."""
+        return self._buffer.buffer_name
+
+    @property
+    def local_ip(self) -> str:
+        """Get local IP address."""
+        return self._local_ip
+
+    @property
+    def port(self) -> int:
+        """Get primary UCXX server port."""
+        return self._ports[0] if self._ports else self._base_port
+
+    @property
+    def ports(self) -> List[int]:
+        """Get all UCXX server ports."""
+        return list(self._ports) if self._ports else [self._base_port]
+
+    # =========================================================================
+    # Cleanup
+    # =========================================================================
+
+    def close(self) -> None:
+        """Close buffer (doesn't unlink shared memory)."""
+        self._buffer.close()
+
+    def unlink(self) -> None:
+        """Unlink (delete) shared memory."""
+        self._buffer.unlink()
+
+    def __del__(self):
+        self.close()
+
+
+class UCXXClient:
+    """UCXX client for reading from remote UCXXBuffer servers.
+
+    Trainer side: connects to worker UCXX servers and reads slot data.
+    Endpoints are cached per (worker_ip, port) using exclusive checkout
+    (``dict.pop``) so concurrent reads to the same target never share an
+    endpoint.  A successful read returns the endpoint to the cache for
+    reuse; a failed read discards it.
+
+    Usage::
+
+        client = UCXXClient()
+        data = await client.read(worker_ip="10.0.0.5", port=13337,
+                                 slot=42, schema=schema)
+        await client.close()
+    """
+
+    _PINNED_POOL_MAX = 8
+
+    def __init__(self) -> None:
+        if not UCXX_AVAILABLE:
+            raise RuntimeError(
+                "UCXX is required for UCXXClient. Install with: pip install ucxx-cu12"
+            )
+
+        self._pool: Dict[tuple, collections.deque] = {}
+        self._pool_size = 2
+        self._rr_counter = 0
+        self._rr_lock = threading.Lock()
+
+        self._pinned_pool: collections.deque = collections.deque()
+        self._pinned_buf_size: int = 0
+
+        try:
+            ucxx.init()
+        except RuntimeError as e:
+            if "already initiated" not in str(e):
+                raise
+
+    def _acquire_pinned(self, nbytes: int) -> torch.Tensor:
+        """Get a pinned CPU buffer from the pool, or allocate a new one."""
+        if self._pinned_buf_size == nbytes and self._pinned_pool:
+            return self._pinned_pool.popleft()
+        if self._pinned_buf_size != nbytes:
+            self._pinned_pool.clear()
+            self._pinned_buf_size = nbytes
+        try:
+            buf = torch.empty(nbytes, dtype=torch.uint8, pin_memory=True)
+        except RuntimeError:
+            buf = torch.empty(nbytes, dtype=torch.uint8)
+            logger.warning("[UCXXClient] cudaHostAlloc failed, using pageable memory")
+        return buf
+
+    def return_pinned(self, buf: torch.Tensor) -> None:
+        """Return a pinned buffer to the pool for reuse."""
+        if len(self._pinned_pool) < self._PINNED_POOL_MAX:
+            self._pinned_pool.append(buf)
+
+    async def _read_chunk(
+        self,
+        worker_ip: str,
+        port: int,
+        slot: int,
+        chunk_idx: int,
+        n_chunks: int,
+        recv_buf: np.ndarray,
+        timeout: float,
+    ) -> None:
+        """Read a single chunk from the server into a slice of recv_buf."""
+        key = (worker_ip, port)
+        pool = self._pool.get(key)
+        endpoint = None
+        if pool:
+            try:
+                endpoint = pool.popleft()
+            except IndexError:
+                pass
+        if endpoint is None:
+            endpoint = await asyncio.wait_for(
+                ucxx.create_endpoint(worker_ip, port), timeout=timeout
+            )
+
+        ok = False
+        try:
+            slot_arr = np.array([slot, chunk_idx, n_chunks], dtype=np.int64)
+            await asyncio.wait_for(endpoint.send(slot_arr), timeout=timeout)
+
+            status = np.empty(1, dtype=np.uint8)
+            await asyncio.wait_for(endpoint.recv(status), timeout=timeout)
+
+            if status[0] == 0:
+                total = len(recv_buf)
+                chunk_size = (total + n_chunks - 1) // n_chunks
+                start = chunk_idx * chunk_size
+                end = min(start + chunk_size, total)
+                chunk_view = recv_buf[start:end]
+                await asyncio.wait_for(endpoint.recv(chunk_view), timeout=timeout)
+                ok = True
+            elif status[0] == 1:
+                ok = True
+                raise StaleSlotError(f"Slot {slot} unavailable (stale reference)")
+            elif status[0] == 2:
+                msg_len = np.empty(1, dtype=np.int32)
+                await asyncio.wait_for(endpoint.recv(msg_len), timeout=timeout)
+                msg_buf = np.empty(int(msg_len[0]), dtype=np.uint8)
+                await asyncio.wait_for(endpoint.recv(msg_buf), timeout=timeout)
+                raise RuntimeError(
+                    f"Remote read failed: {msg_buf.tobytes().decode('utf-8')}"
+                )
+            else:
+                raise RuntimeError(f"Unknown response status: {status[0]}")
+        finally:
+            if ok:
+                ep_pool = self._pool.setdefault(key, collections.deque())
+                if len(ep_pool) < self._pool_size:
+                    ep_pool.append(endpoint)
+                else:
+                    try:
+                        await endpoint.close()
+                    except Exception:
+                        pass
+            else:
+                try:
+                    await endpoint.close()
+                except Exception:
+                    pass
+
+    async def read(
+        self,
+        worker_ip: str,
+        port: int,
+        slot: int,
+        schema: List[Any],
+        timeout: float = 60.0,
+        ports: Optional[List[int]] = None,
+        n_chunks: int = 1,
+    ) -> Dict[str, np.ndarray]:
+        """Read slot data from a remote worker buffer.
+
+        When ``n_chunks > 1`` and multiple ``ports`` are available, the
+        transfer is split into parallel chunk reads across different server
+        threads for higher aggregate RDMA throughput.
+
+        Returns a dict of tensor name -> numpy view into a pinned CPU buffer.
+        The pinned backing tensor is stored under the ``_pinned_buf`` key and
+        must be returned to the pool via :meth:`return_pinned` after the
+        caller has finished copying data to GPU.
+        """
+        if not schema:
+            raise ValueError("Schema required for zero-pack protocol")
+
+        available_ports = ports if ports and len(ports) > 1 else [port]
+        n_chunks = min(n_chunks, len(available_ports))
+        total_bytes = sum(spec.nbytes for spec in schema)
+        pinned_buf = self._acquire_pinned(total_bytes)
+        raw = pinned_buf.numpy()
+
+        t_start = time.perf_counter()
+
+        if n_chunks > 1:
+            coros = []
+            for ci in range(n_chunks):
+                target_port = available_ports[ci % len(available_ports)]
+                coros.append(
+                    self._read_chunk(
+                        worker_ip, target_port, slot, ci, n_chunks, raw, timeout
+                    )
+                )
+            results = await asyncio.gather(*coros, return_exceptions=True)
+            for r in results:
+                if isinstance(r, Exception):
+                    raise r
+        else:
+            target_port = available_ports[0]
+            await self._read_chunk(worker_ip, target_port, slot, 0, 1, raw, timeout)
+
+        t_done = time.perf_counter()
+        total_ms = (t_done - t_start) * 1000
+        mb = total_bytes / (1024 * 1024)
+        bw_str = f", bw={mb / (total_ms / 1000):.0f} MB/s" if total_ms > 0 else ""
+        logger.debug(
+            f"[UCXXClient] read {worker_ip} slot={slot}: "
+            f"{mb:.1f} MB in {total_ms:.1f} ms "
+            f"(n_chunks={n_chunks}{bw_str})"
+        )
+
+        result: Dict[str, Any] = {}
+        offset = 0
+        for spec in schema:
+            result[spec.name] = np.frombuffer(
+                raw[offset : offset + spec.nbytes], dtype=spec.dtype
+            ).reshape(spec.shape)
+            offset += spec.nbytes
+        result["_pinned_buf"] = pinned_buf
+        return result
+
+    async def close(self) -> None:
+        """Drain and close all pooled endpoints."""
+        for key in list(self._pool):
+            pool = self._pool.pop(key, None)
+            if pool:
+                for ep in pool:
+                    try:
+                        await ep.close()
+                    except Exception:
+                        pass

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -122,8 +122,14 @@ gym = [
     "gymnasium>=0.29",
 ]
 
+# UCXX-based zero-copy payload transport (RDMA / SHM auto-routing).
+# CUDA 12 wheels; users on CUDA 11 should install ucxx-cu11 manually.
+ucxx = [
+    "ucxx-cu12>=0.40.0",
+]
+
 all = [
-    "cosmos_rl[wfm,vla,rl,gym]",
+    "cosmos_rl[wfm,vla,rl,gym,ucxx]",
 ]
 
 [tool.uv.sources]

--- a/tests/test_ucxx_transport.py
+++ b/tests/test_ucxx_transport.py
@@ -1,0 +1,554 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the UCXX payload transport (MR3b).
+
+The UCXX network path requires the optional ``ucxx-cu12`` extra and a
+machine with UCX + (ideally) RDMA hardware, so the test suite focuses
+on what we can validate hermetically:
+
+* ``TensorSpec`` semantics (shape / dtype / nbytes / contains).
+* ``SharedRingBuffer`` round-trip and slot state machine -- this is the
+  core data structure underlying both same-node and cross-node UCXX
+  transfers and is pure POSIX shared memory + numpy.
+* ``UCXXPayloadTransport`` registration with the
+  :class:`PayloadTransportRegistry` (string mode resolution +
+  ``attach_data_packer`` invocation + ``completion_prefix=None`` skips
+  controller cleanup).
+* ``ucxx_buffer`` import gracefully degrades when ``ucxx-cu12`` is not
+  installed (i.e. ``UCXX_AVAILABLE`` is False rather than ImportError).
+"""
+
+import os
+import unittest
+from types import SimpleNamespace
+from unittest import mock
+
+import numpy as np
+
+from cosmos_rl.utils.payload_transport import (
+    PAYLOAD_TRANSFER_KEY,
+    PayloadTransportRegistry,
+    get_payload_transfer_mode,
+)
+
+# Import side-effect: registers the UCXX backend.
+import cosmos_rl.utils.payload_transport.ucxx as ucxx_pkg
+from cosmos_rl.utils.payload_transport.ucxx import (
+    UCXX_AVAILABLE,
+    BufferConfig,
+    SharedRingBuffer,
+    SlotError,
+    SlotState,
+    TensorSpec,
+    UCXXPayloadTransport,
+)
+
+
+# ---------------------------------------------------------------------------
+# TensorSpec
+# ---------------------------------------------------------------------------
+
+
+class TestTensorSpec(unittest.TestCase):
+    def test_dtype_normalized(self):
+        spec = TensorSpec(shape=(4,), dtype=np.float32)
+        self.assertIsInstance(spec.dtype, np.dtype)
+        self.assertEqual(spec.dtype, np.dtype(np.float32))
+
+    def test_nbytes(self):
+        # 4 floats * 4 bytes each = 16 bytes.
+        spec = TensorSpec(shape=(4,), dtype=np.float32)
+        self.assertEqual(spec.nbytes, 16)
+        # Multi-dim: (2, 3) of int64 = 6 * 8 = 48 bytes.
+        spec2 = TensorSpec(shape=(2, 3), dtype=np.int64)
+        self.assertEqual(spec2.nbytes, 48)
+
+    def test_contains_matches(self):
+        spec = TensorSpec(shape=(4,), dtype=np.float32, name="obs")
+        ok = np.zeros(4, dtype=np.float32)
+        bad_shape = np.zeros(5, dtype=np.float32)
+        bad_dtype = np.zeros(4, dtype=np.float64)
+        self.assertTrue(spec.contains(ok))
+        self.assertFalse(spec.contains(bad_shape))
+        self.assertFalse(spec.contains(bad_dtype))
+
+
+# ---------------------------------------------------------------------------
+# SharedRingBuffer
+# ---------------------------------------------------------------------------
+
+
+def _make_schema(max_steps: int = 4, obs_dim: int = 3) -> list:
+    return [
+        TensorSpec(name="observations", shape=(max_steps, obs_dim), dtype=np.float32),
+        TensorSpec(name="actions", shape=(max_steps,), dtype=np.int64),
+        TensorSpec(name="rewards", shape=(max_steps,), dtype=np.float32),
+        TensorSpec(name="episode_length", shape=(1,), dtype=np.int64),
+    ]
+
+
+class _BufferTestBase(unittest.TestCase):
+    """Shared setup/teardown that ensures the SHM segment is unlinked
+    even when a test fails -- /dev/shm leakage poisons subsequent runs."""
+
+    def setUp(self) -> None:
+        self.schema = _make_schema()
+        # Per-test buffer name avoids cross-test SHM collisions when
+        # pytest is invoked in parallel mode.
+        name = f"cosmos_rl_test_{os.getpid()}_{id(self)}"
+        config = BufferConfig(
+            buffer_name=name,
+            max_entries=4,
+            schema=self.schema,
+        )
+        self.buf = SharedRingBuffer(config, create=True)
+
+    def tearDown(self) -> None:
+        try:
+            self.buf.unlink()
+        except Exception:
+            pass
+        try:
+            self.buf.close()
+        except Exception:
+            pass
+
+
+class TestSharedRingBufferBasics(_BufferTestBase):
+    def test_initial_state_all_free(self):
+        states = self.buf.get_slot_states()
+        self.assertEqual(len(states), 4)
+        for s in states.values():
+            self.assertEqual(s, SlotState.FREE)
+
+    def test_write_then_read_roundtrip(self):
+        data = {
+            "observations": np.arange(12, dtype=np.float32).reshape(4, 3),
+            "actions": np.array([1, 2, 3, 4], dtype=np.int64),
+            "rewards": np.array([0.1, 0.2, 0.3, 0.4], dtype=np.float32),
+            "episode_length": np.array([3], dtype=np.int64),
+        }
+        slot = self.buf.write(data)
+        self.assertEqual(self.buf.get_slot_state(slot), SlotState.READY)
+        out = self.buf.read(slot)
+        np.testing.assert_array_equal(out["observations"], data["observations"])
+        np.testing.assert_array_equal(out["actions"], data["actions"])
+        np.testing.assert_array_equal(out["rewards"], data["rewards"])
+        np.testing.assert_array_equal(out["episode_length"], data["episode_length"])
+        # After read, slot should be in READING state until mark_consumed.
+        self.assertEqual(self.buf.get_slot_state(slot), SlotState.READING)
+
+    def test_write_raw_path(self):
+        # Pre-pack a contiguous byte buffer matching the schema layout.
+        data = {
+            "observations": np.zeros(12, dtype=np.float32).reshape(4, 3),
+            "actions": np.zeros(4, dtype=np.int64),
+            "rewards": np.zeros(4, dtype=np.float32),
+            "episode_length": np.array([2], dtype=np.int64),
+        }
+        # Use the regular write to populate, then exercise read_raw to
+        # confirm raw bytes round-trip.
+        slot = self.buf.write(data)
+        raw = self.buf.read_raw(slot)
+        # raw should have entry_data_size bytes total.
+        expected_size = sum(s.nbytes for s in self.schema)
+        self.assertEqual(raw.nbytes, expected_size)
+        self.buf.mark_consumed(slot)
+
+    def test_write_raw_size_mismatch_raises(self):
+        with self.assertRaises(SlotError):
+            self.buf.write_raw(b"too short")
+
+    def test_mark_consumed_returns_slot_to_free(self):
+        data = {
+            "observations": np.zeros((4, 3), dtype=np.float32),
+            "actions": np.zeros(4, dtype=np.int64),
+            "rewards": np.zeros(4, dtype=np.float32),
+            "episode_length": np.array([1], dtype=np.int64),
+        }
+        slot = self.buf.write(data)
+        self.buf.read(slot)
+        self.assertEqual(self.buf.get_slot_state(slot), SlotState.READING)
+        self.buf.mark_consumed(slot)
+        self.assertEqual(self.buf.get_slot_state(slot), SlotState.FREE)
+
+    def test_read_view_is_a_view(self):
+        # ``read_view`` returns numpy arrays that point into shared
+        # memory.  Modifying them should be visible to read_raw.
+        data = {
+            "observations": np.ones((4, 3), dtype=np.float32),
+            "actions": np.zeros(4, dtype=np.int64),
+            "rewards": np.zeros(4, dtype=np.float32),
+            "episode_length": np.array([4], dtype=np.int64),
+        }
+        slot = self.buf.write(data)
+        view = self.buf.read_view(slot)
+        view["observations"][0, 0] = 42.0
+        # Re-read fresh to confirm shared memory was updated.
+        # (NB: read() requires READY state, so first put back via release_reading.)
+        self.buf.release_reading(slot)
+        out = self.buf.read(slot)
+        self.assertEqual(out["observations"][0, 0], 42.0)
+        self.buf.mark_consumed(slot)
+
+    def test_release_reading_back_to_ready(self):
+        data = {
+            "observations": np.zeros((4, 3), dtype=np.float32),
+            "actions": np.zeros(4, dtype=np.int64),
+            "rewards": np.zeros(4, dtype=np.float32),
+            "episode_length": np.array([1], dtype=np.int64),
+        }
+        slot = self.buf.write(data)
+        self.buf.read(slot)
+        self.assertEqual(self.buf.get_slot_state(slot), SlotState.READING)
+        self.buf.release_reading(slot)
+        self.assertEqual(self.buf.get_slot_state(slot), SlotState.READY)
+        self.buf.read(slot)
+        self.buf.mark_consumed(slot)
+
+    def test_get_ready_indices_and_count(self):
+        for _ in range(2):
+            self.buf.write(
+                {
+                    "observations": np.zeros((4, 3), dtype=np.float32),
+                    "actions": np.zeros(4, dtype=np.int64),
+                    "rewards": np.zeros(4, dtype=np.float32),
+                    "episode_length": np.array([1], dtype=np.int64),
+                }
+            )
+        ready = self.buf.get_ready_indices()
+        self.assertEqual(sorted(ready), [0, 1])
+        self.assertEqual(self.buf.get_ready_count(), 2)
+
+    def test_overwrite_when_full(self):
+        # Fill the 4-slot buffer, then write a 5th entry: oldest should
+        # be overwritten and drops_total bumped.
+        for _ in range(5):
+            self.buf.write(
+                {
+                    "observations": np.zeros((4, 3), dtype=np.float32),
+                    "actions": np.zeros(4, dtype=np.int64),
+                    "rewards": np.zeros(4, dtype=np.float32),
+                    "episode_length": np.array([1], dtype=np.int64),
+                }
+            )
+        metrics = self.buf.get_metrics()
+        self.assertEqual(metrics.writes_total, 5)
+        self.assertEqual(metrics.drops_total, 1)
+
+    def test_write_raises_when_full_and_overwrite_disabled(self):
+        for _ in range(4):
+            self.buf.write(
+                {
+                    "observations": np.zeros((4, 3), dtype=np.float32),
+                    "actions": np.zeros(4, dtype=np.int64),
+                    "rewards": np.zeros(4, dtype=np.float32),
+                    "episode_length": np.array([1], dtype=np.int64),
+                }
+            )
+        with self.assertRaises(SlotError):
+            self.buf.write(
+                {
+                    "observations": np.zeros((4, 3), dtype=np.float32),
+                    "actions": np.zeros(4, dtype=np.int64),
+                    "rewards": np.zeros(4, dtype=np.float32),
+                    "episode_length": np.array([1], dtype=np.int64),
+                },
+                overwrite_if_full=False,
+            )
+
+    def test_handle_roundtrip_attaches(self):
+        data = {
+            "observations": np.full((4, 3), 7.0, dtype=np.float32),
+            "actions": np.array([1, 2, 3, 4], dtype=np.int64),
+            "rewards": np.zeros(4, dtype=np.float32),
+            "episode_length": np.array([4], dtype=np.int64),
+        }
+        slot = self.buf.write(data)
+
+        handle = self.buf.get_handle()
+        attached = SharedRingBuffer.from_handle(handle)
+        try:
+            out = attached.read(slot)
+            np.testing.assert_array_equal(out["observations"], data["observations"])
+        finally:
+            attached.close()
+
+    def test_metrics_track_writes_and_reads(self):
+        data = {
+            "observations": np.zeros((4, 3), dtype=np.float32),
+            "actions": np.zeros(4, dtype=np.int64),
+            "rewards": np.zeros(4, dtype=np.float32),
+            "episode_length": np.array([1], dtype=np.int64),
+        }
+        for _ in range(3):
+            slot = self.buf.write(data)
+            self.buf.read(slot)
+            self.buf.mark_consumed(slot)
+        m = self.buf.get_metrics()
+        self.assertEqual(m.writes_total, 3)
+        self.assertEqual(m.reads_total, 3)
+        self.assertEqual(m.drops_total, 0)
+
+
+# ---------------------------------------------------------------------------
+# UCXX transport registration
+# ---------------------------------------------------------------------------
+
+
+class TestUCXXTransportRegistration(unittest.TestCase):
+    def test_registered_with_ucxx_name(self):
+        transport = PayloadTransportRegistry.get("ucxx")
+        self.assertIsInstance(transport, UCXXPayloadTransport)
+
+    def test_completion_prefix_is_none(self):
+        # UCXX intentionally uses dict-shaped completion metadata, not
+        # a string prefix.  ``completion_prefix=None`` makes
+        # ``handle_discarded`` skip UCXX cleanly when partitioning
+        # discards by prefix.  See transport.py module docstring for
+        # the longer rationale.
+        transport = PayloadTransportRegistry.get("ucxx")
+        self.assertIsNone(transport.completion_prefix)
+
+    def test_active_for_completion_does_not_match_ucxx(self):
+        # No completion string should ever resolve to UCXX (since UCXX
+        # does not stamp a prefix).  Even an obviously "ucxx-style"
+        # string must not match.
+        result = PayloadTransportRegistry.active_for_completion("ucxx:host:7000:42")
+        self.assertNotIsInstance(result, UCXXPayloadTransport)
+
+    def test_publish_cleanup_inherited_returns_zero(self):
+        # UCXX inherits the base no-op (returns 0): the producer-side
+        # ring buffer auto-recycles slots so the controller has nothing
+        # to publish.
+        transport = UCXXPayloadTransport()
+        n = transport.publish_cleanup_for_discarded(
+            transfer_ids=["host:7000:1", "host:7000:2"],
+            config=None,
+            redis_client=None,
+        )
+        self.assertEqual(n, 0)
+
+    def test_handle_discarded_skips_ucxx(self):
+        # End-to-end: a discard whose completion looks UCXX-ish should
+        # NOT route to UCXXPayloadTransport.publish_cleanup_for_discarded,
+        # because completion_prefix=None excludes UCXX from the dispatch.
+        rollouts = [
+            SimpleNamespace(completion={"_ucxx": True, "_slot": 1}),
+            SimpleNamespace(completion="ucxx:host:7000:1"),
+        ]
+        with mock.patch.object(
+            UCXXPayloadTransport,
+            "publish_cleanup_for_discarded",
+            return_value=99,
+        ) as patched:
+            published = PayloadTransportRegistry.handle_discarded(
+                rollouts, [], config=SimpleNamespace(), redis_client=None
+            )
+        self.assertEqual(published, 0)
+        patched.assert_not_called()
+
+    def test_get_payload_transfer_mode_with_ucxx(self):
+        config = SimpleNamespace(custom={PAYLOAD_TRANSFER_KEY: "ucxx"})
+        self.assertEqual(get_payload_transfer_mode(config), "ucxx")
+
+    def test_ucxx_completion_prefix_constant_removed(self):
+        # Regression guard: the dead ``UCXX_COMPLETION_PREFIX`` constant
+        # was removed when ``completion_prefix`` flipped to None.  Make
+        # sure it is not silently re-introduced from either the
+        # transport submodule or the package surface.
+        from cosmos_rl.utils.payload_transport.ucxx import transport as transport_mod
+
+        self.assertFalse(
+            hasattr(transport_mod, "UCXX_COMPLETION_PREFIX"),
+            "UCXX_COMPLETION_PREFIX must not be re-introduced; UCXX "
+            "uses completion_prefix=None and dict metadata",
+        )
+        self.assertFalse(
+            hasattr(ucxx_pkg, "UCXX_COMPLETION_PREFIX"),
+            "UCXX_COMPLETION_PREFIX must not be re-exported from the ucxx package",
+        )
+
+    def test_module_exports(self):
+        # The package __init__ should re-export everything callers need
+        # (minus the deliberately-removed UCXX_COMPLETION_PREFIX).
+        for symbol in [
+            "TensorSpec",
+            "SharedRingBuffer",
+            "UCXXBuffer",
+            "UCXXClient",
+            "UCXX_AVAILABLE",
+            "UCXXPayloadTransport",
+            "UCXXRolloutMixin",
+            "UCXXTrainerMixin",
+        ]:
+            self.assertTrue(
+                hasattr(ucxx_pkg, symbol),
+                f"public re-export missing: {symbol}",
+            )
+
+
+class TestUCXXAttachDataPacker(unittest.TestCase):
+    """The unified ``attach_data_packer`` hook drives per-packer setup."""
+
+    def test_attach_invokes_setup_with_resolved_args(self):
+        # When the packer exposes ``_setup_ucxx_data_packer`` (added by
+        # MR5's UCXXDataPackerMixin), attach_data_packer must invoke it
+        # with the device + tunables resolved from config.custom.
+        captured = {}
+
+        class _Packer:
+            def _setup_ucxx_data_packer(self, **kwargs):
+                captured.update(kwargs)
+
+        config = SimpleNamespace(
+            custom={
+                "ucxx_prefetch_timeout": 12.5,
+                "ucxx_n_chunks": 4,
+                "ucxx_read_max_attempts": 5,
+                "ucxx_read_timeout": 30.0,
+            }
+        )
+        UCXXPayloadTransport().attach_data_packer(
+            _Packer(),
+            config=config,
+            device="cuda:0",
+        )
+        self.assertEqual(captured["device"], "cuda:0")
+        self.assertEqual(captured["prefetch_timeout"], 12.5)
+        self.assertEqual(captured["n_chunks"], 4)
+        self.assertEqual(captured["max_attempts"], 5)
+        self.assertEqual(captured["read_timeout"], 30.0)
+
+    def test_attach_uses_defaults_when_config_missing(self):
+        captured = {}
+
+        class _Packer:
+            def _setup_ucxx_data_packer(self, **kwargs):
+                captured.update(kwargs)
+
+        UCXXPayloadTransport().attach_data_packer(_Packer(), config=SimpleNamespace())
+        self.assertEqual(captured["prefetch_timeout"], 30.0)
+        self.assertEqual(captured["n_chunks"], 2)
+        self.assertEqual(captured["max_attempts"], 2)
+        self.assertEqual(captured["read_timeout"], 60.0)
+
+    def test_attach_noop_when_setup_method_missing(self):
+        # Packers that do NOT subclass UCXXDataPackerMixin should be
+        # left untouched -- attach must not raise.
+        class _PlainPacker:
+            pass
+
+        # Should silently no-op.  Just assert it returns without raising.
+        UCXXPayloadTransport().attach_data_packer(
+            _PlainPacker(), config=SimpleNamespace()
+        )
+
+    def test_attach_passes_device_through(self):
+        captured = {}
+
+        class _Packer:
+            def _setup_ucxx_data_packer(self, **kwargs):
+                captured.update(kwargs)
+
+        for device in ("cuda:1", None, "cpu"):
+            UCXXPayloadTransport().attach_data_packer(
+                _Packer(), config=SimpleNamespace(), device=device
+            )
+            self.assertEqual(captured["device"], device)
+
+    def test_attach_falls_back_when_config_values_invalid(self):
+        # Garbled custom values should fall back to defaults rather
+        # than raising at attach time.
+        captured = {}
+
+        class _Packer:
+            def _setup_ucxx_data_packer(self, **kwargs):
+                captured.update(kwargs)
+
+        config = SimpleNamespace(
+            custom={
+                "ucxx_prefetch_timeout": "not-a-float",
+                "ucxx_n_chunks": object(),
+                "ucxx_read_max_attempts": "bad",
+                "ucxx_read_timeout": None,
+            }
+        )
+        UCXXPayloadTransport().attach_data_packer(_Packer(), config=config)
+        self.assertEqual(captured["prefetch_timeout"], 30.0)
+        self.assertEqual(captured["n_chunks"], 2)
+        self.assertEqual(captured["max_attempts"], 2)
+        self.assertEqual(captured["read_timeout"], 60.0)
+
+    def test_attach_clamps_max_attempts_to_at_least_one(self):
+        # max_attempts < 1 is nonsensical (no read would ever happen);
+        # the transport should clamp it to 1 rather than disabling reads.
+        captured = {}
+
+        class _Packer:
+            def _setup_ucxx_data_packer(self, **kwargs):
+                captured.update(kwargs)
+
+        for raw in (0, -1, -100):
+            config = SimpleNamespace(custom={"ucxx_read_max_attempts": raw})
+            UCXXPayloadTransport().attach_data_packer(_Packer(), config=config)
+            self.assertEqual(
+                captured["max_attempts"],
+                1,
+                f"max_attempts={raw} should clamp to 1",
+            )
+
+
+# ---------------------------------------------------------------------------
+# Optional-extra import contract
+# ---------------------------------------------------------------------------
+
+
+class TestOptionalUcxxExtra(unittest.TestCase):
+    """When ``ucxx-cu12`` is not installed, importing the buffer module
+    must still succeed and surface ``UCXX_AVAILABLE = False``.  Attempts
+    to actually start a server should raise ``RuntimeError`` rather than
+    failing at module import."""
+
+    def test_ucxx_available_is_bool(self):
+        self.assertIn(UCXX_AVAILABLE, (True, False))
+
+    def test_starting_server_without_ucxx_raises(self):
+        if UCXX_AVAILABLE:
+            self.skipTest("ucxx-cu12 is installed; skip the negative path")
+        from cosmos_rl.utils.payload_transport.ucxx import (
+            UCXXBuffer,
+            UCXXBufferConfig,
+        )
+
+        cfg = UCXXBufferConfig(
+            buffer_name=f"cosmos_rl_unavail_{os.getpid()}",
+            max_entries=2,
+            schema=_make_schema(),
+        )
+        try:
+            buf = UCXXBuffer(cfg)
+            with self.assertRaises(RuntimeError):
+                buf.start_server()
+        finally:
+            try:
+                buf._buffer.unlink()
+            except Exception:
+                pass
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds the `ucxx` backend on top of the payload-transport registry introduced in #676. Cosmos-RL workloads can now select a zero-copy data plane via `[custom].payload_transfer = "ucxx"`; the control plane (rollout metadata, completion signaling) still rides on Redis as before.

## Layout (`cosmos_rl/utils/payload_transport/ucxx/`)

- `tensor_spec.py` — `TensorSpec` descriptor (shape / dtype / nbytes / contains)
- `shared_buffer.py` — `SharedRingBuffer` + four-state slot machine (`FREE → WRITING → READY → READING → FREE`) over POSIX shared memory
- `ucxx_buffer.py` — `UCXXBuffer` (server) + `UCXXClient` (pooled-endpoint client) + `UCXX_AVAILABLE` feature flag
- `mixins.py` — `UCXXRolloutMixin` / `UCXXTrainerMixin`: worker- and trainer-side wiring, including coalesced D2H + pinned-CPU staging on the writer
- `transport.py` — `UCXXPayloadTransport` registered as `"ucxx"`. Implements the unified `attach_data_packer` hook so the trainer no longer has to manually call `_setup_ucxx_data_packer` after constructing its data packer. The hook resolves `ucxx_prefetch_timeout` / `ucxx_n_chunks` from `[custom]` and is a no-op for non-UCXX-aware packers.

## Integration notes

UCXX intentionally diverges from NCCL on two registry integration points:

1. **`completion_prefix = None`.** UCXX rollouts return dict-shaped metadata (`{"_ucxx": True, "_worker_ip": ..., "_slot": ...}`) rather than a string-prefixed completion, so `handle_discarded` skips UCXX cleanly when partitioning discards by prefix. The dead `UCXX_COMPLETION_PREFIX = "ucxx:"` constant from the original draft is removed; a regression test guards against re-introduction.
2. **`publish_cleanup_for_discarded` inherits the base no-op** (returns 0). Worker-side ring-buffer slots are producer-driven and auto-recycle when the writer overwrites an unconsumed READY slot, so the controller has nothing to publish.

## Optional dependency

`ucxx-cu12` is an **optional** extra; importing the subpackage when it is missing succeeds with `UCXX_AVAILABLE=False` and only raises when a server / client is actually started. The new `cosmos_rl[ucxx]` extra in `pyproject.toml` installs it on demand. The registry's `get_payload_transfer_mode` lazy-imports the UCXX subpackage when `payload_transfer = "ucxx"` is selected, so callers only pay the import cost when they opt in.

## Test plan

86 passed + 1 skipped (`tests/test_payload_transport.py`, `tests/test_ucxx_transport.py`, `tests/test_comm_base_attach.py`). Coverage: `tensor_spec.py` / `transport.py` / `__init__.py` 100%; `shared_buffer.py` 73%; `mixins.py` and `ucxx_buffer.py` low (15-16%) by design — the uncovered branches are the live UCXX wire-format paths that require RDMA / SHM connectivity and can only run on a UCXX-enabled host. Logical paths covered:

- `TensorSpec` semantics
- `SharedRingBuffer` round-trip + state-machine transitions + overwrite-when-full + handle re-attach
- `UCXXPayloadTransport` registration with `completion_prefix=None`
- `handle_discarded` correctly skipping UCXX
- `attach_data_packer` invocation with resolved tunables / no-op fallback / device pass-through / invalid-config recovery
- The inherited `publish_cleanup` no-op contract
- Regression guard for `UCXX_COMPLETION_PREFIX` removal
- The `ucxx-not-installed` graceful-degradation path