### PR TITLE
fix: invoke payload-transport cleanup unconditionally on discards

### DIFF
--- a/cosmos_rl/dispatcher/status.py
+++ b/cosmos_rl/dispatcher/status.py
@@ -848,7 +848,7 @@ class PolicyStatusManager:
         )
 
         discarded_count = len(rollouts) - len(filtered_rollouts)
-        if discarded_count > 0 and getattr(self, "_nccl_cleanup_enabled", False):
+        if discarded_count > 0:
             self._publish_payload_transport_cleanup(rollouts, filtered_rollouts)
 
         return filtered_rollouts
@@ -862,16 +862,14 @@ class PolicyStatusManager:
 
         The grouping/dispatch logic lives in
         :meth:`PayloadTransportRegistry.handle_discarded`.  This wrapper
-        only resolves the controller's Redis client and preserves the
-        ``_nccl_cleanup_enabled`` "first-detection" flag flip so the
-        existing log behavior is unchanged.
+        only resolves the controller's Redis client and flips the
+        ``_nccl_cleanup_enabled`` "first-detection" flag (used to
+        debounce the "now active" log line so it appears at most once).
 
-        NOTE: ``_nccl_cleanup_enabled`` carries a known cold-start
-        gating bug introduced in commit 55745c: ``filter_outdated_rollouts``
-        only invokes this method when the flag is already True, but the
-        flag is only flipped True from inside this method, so cleanup
-        is unreachable on cold start.  This refactor preserves the
-        existing behavior; the bug fix is tracked as a separate MR.
+        Called by :meth:`filter_outdated_rollouts` whenever any rollout
+        is discarded; ``handle_discarded`` itself is a cheap no-op when
+        no payload-transport-prefixed rollouts are present, so calling
+        it unconditionally is safe.
         """
         redis_client = self._resolve_cleanup_redis_client()
         published = PayloadTransportRegistry.handle_discarded(


### PR DESCRIPTION
## Summary

Fixes a cold-start dead-branch in payload-transport cleanup dispatch.

`PolicyStatusManager.filter_outdated_rollouts` previously gated the cleanup
dispatch on `self._nccl_cleanup_enabled`, but that flag is *only* flipped to
`True` from inside `_publish_payload_transport_cleanup` itself. On a fresh
controller the flag starts `False`, so the inner method is never reached —
transport cleanup is unreachable for the entire run.

The bug was introduced alongside the payload-transport-registry refactor
(commit `55745c`) and was explicitly documented in the inner method's
docstring as "tracked as a separate MR". This is that MR.

## Fix

Drop the `_nccl_cleanup_enabled` predicate from the call site so cleanup
runs on every batch with discards. Safe because
`PayloadTransportRegistry.handle_discarded` is already a cheap no-op when
no payload-transport-prefixed rollouts are present (early-returns `0` on
no discards / no matching prefix).

The flag stays in place for its other purpose: debouncing the
"transport cleanup publishing is now active" log line so it fires at most
once per run.

Docstring on `_publish_payload_transport_cleanup` is rewritten to match the
new behavior; the "known cold-start gating bug" note is removed.