### PR TITLE
fix(vllm_rollout): Filter prompts exceeding max_model_len instead of …

### DIFF
--- a/cosmos_rl/rollout/vllm_rollout/vllm_rollout.py
+++ b/cosmos_rl/rollout/vllm_rollout/vllm_rollout.py
@@ -641,15 +641,28 @@ class vLLMRollout(RolloutBase):
         skipped_count = 0
 
         # Determine how to get prompt token count based on prompt type
-        for idx, (prompt, payload) in enumerate(zip(new_prompts if isinstance(new_prompts, list) else [new_prompts], payloads)):
+        for idx, (prompt, payload) in enumerate(
+            zip(
+                new_prompts if isinstance(new_prompts, list) else [new_prompts],
+                payloads,
+            )
+        ):
             try:
                 # Handle both string prompts and dict/object prompts (VLM)
                 if isinstance(prompt, str):
-                    prompt_token_count = len(self.rollout_engine.llm_engine.tokenizer.encode(prompt))
+                    prompt_token_count = len(
+                        self.rollout_engine.llm_engine.tokenizer.encode(prompt)
+                    )
                 elif isinstance(prompt, dict) and "prompt" in prompt:
-                    prompt_token_count = len(self.rollout_engine.llm_engine.tokenizer.encode(prompt["prompt"]))
+                    prompt_token_count = len(
+                        self.rollout_engine.llm_engine.tokenizer.encode(
+                            prompt["prompt"]
+                        )
+                    )
                 elif hasattr(prompt, "prompt"):
-                    prompt_token_count = len(self.rollout_engine.llm_engine.tokenizer.encode(prompt.prompt))
+                    prompt_token_count = len(
+                        self.rollout_engine.llm_engine.tokenizer.encode(prompt.prompt)
+                    )
                 else:
                     # For VLM inputs (with images/videos), use prompt token ids if available
                     if hasattr(prompt, "prompt_token_ids"):
@@ -681,13 +694,17 @@ class vLLMRollout(RolloutBase):
                 filtered_payloads.append(payload)
 
         if skipped_count > 0:
-            logger.info(f"[Rollout] Skipped {skipped_count} prompts due to exceeding max_model_len")
+            logger.info(
+                f"[Rollout] Skipped {skipped_count} prompts due to exceeding max_model_len"
+            )
 
         stream = torch.cuda.current_stream() if stream is None else stream
         try:
             with torch.cuda.stream(stream):
                 if len(filtered_prompts) == 0:
-                    logger.warning("[Rollout] All prompts were filtered out, returning empty results")
+                    logger.warning(
+                        "[Rollout] All prompts were filtered out, returning empty results"
+                    )
                     results = []
                 else:
                     results = self.rollout_engine.generate(

--- a/cosmos_rl/rollout/vllm_rollout/vllm_rollout.py
+++ b/cosmos_rl/rollout/vllm_rollout/vllm_rollout.py
@@ -633,14 +633,70 @@ class vLLMRollout(RolloutBase):
 
         response: List[RolloutResult] = []
 
+        # Filter out prompts that exceed max_model_len to avoid vLLM errors
+        max_model_len = self.config.policy.model_max_length
+        valid_indices = []
+        filtered_prompts = []
+        filtered_payloads = []
+        skipped_count = 0
+
+        # Determine how to get prompt token count based on prompt type
+        for idx, (prompt, payload) in enumerate(zip(new_prompts if isinstance(new_prompts, list) else [new_prompts], payloads)):
+            try:
+                # Handle both string prompts and dict/object prompts (VLM)
+                if isinstance(prompt, str):
+                    prompt_token_count = len(self.rollout_engine.llm_engine.tokenizer.encode(prompt))
+                elif isinstance(prompt, dict) and "prompt" in prompt:
+                    prompt_token_count = len(self.rollout_engine.llm_engine.tokenizer.encode(prompt["prompt"]))
+                elif hasattr(prompt, "prompt"):
+                    prompt_token_count = len(self.rollout_engine.llm_engine.tokenizer.encode(prompt.prompt))
+                else:
+                    # For VLM inputs (with images/videos), use prompt token ids if available
+                    if hasattr(prompt, "prompt_token_ids"):
+                        prompt_token_count = len(prompt.prompt_token_ids)
+                    elif isinstance(prompt, dict) and "prompt_token_ids" in prompt:
+                        prompt_token_count = len(prompt["prompt_token_ids"])
+                    else:
+                        # Fallback: assume it's valid if we can't determine length
+                        prompt_token_count = 0
+
+                if prompt_token_count > 0 and prompt_token_count > max_model_len:
+                    logger.warning(
+                        f"[Rollout] Skipping prompt (token count: {prompt_token_count}) "
+                        f"exceeds max_model_len ({max_model_len}). This usually happens when "
+                        f"images/videos are large or the input text is too long."
+                    )
+                    skipped_count += 1
+                    continue
+
+                valid_indices.append(idx)
+                filtered_prompts.append(prompt)
+                filtered_payloads.append(payload)
+            except Exception as e:
+                logger.warning(
+                    f"[Rollout] Error checking prompt length: {str(e)}, assuming prompt is valid"
+                )
+                valid_indices.append(idx)
+                filtered_prompts.append(prompt)
+                filtered_payloads.append(payload)
+
+        if skipped_count > 0:
+            logger.info(f"[Rollout] Skipped {skipped_count} prompts due to exceeding max_model_len")
+
         stream = torch.cuda.current_stream() if stream is None else stream
         try:
             with torch.cuda.stream(stream):
-                results = self.rollout_engine.generate(
-                    new_prompts,
-                    sampling_params=local_sampling_params,
-                    use_tqdm=False,
-                )
+                if len(filtered_prompts) == 0:
+                    logger.warning("[Rollout] All prompts were filtered out, returning empty results")
+                    results = []
+                else:
+                    results = self.rollout_engine.generate(
+                        filtered_prompts,
+                        sampling_params=local_sampling_params,
+                        use_tqdm=False,
+                    )
+                    # Map results back to payloads
+                    payloads = filtered_payloads
                 if (
                     self.config.distillation.top_k > 0
                     and self.config.distillation.rollout_top_k_recompute

--- a/cosmos_rl/rollout/vllm_rollout/vllm_rollout_async.py
+++ b/cosmos_rl/rollout/vllm_rollout/vllm_rollout_async.py
@@ -286,6 +286,37 @@ class vLLMRolloutAsync(vLLMRollout):
             with torch.cuda.stream(stream):
                 cur_prompt = new_prompts[0]
                 cur_payload = payloads[0]
+
+                # Check if prompt exceeds max_model_len
+                max_model_len = self.config.policy.model_max_length
+                try:
+                    if isinstance(cur_prompt, str):
+                        prompt_token_count = len(self.rollout_engine.llm_engine.tokenizer.encode(cur_prompt))
+                    elif isinstance(cur_prompt, dict) and "prompt" in cur_prompt:
+                        prompt_token_count = len(self.rollout_engine.llm_engine.tokenizer.encode(cur_prompt["prompt"]))
+                    elif hasattr(cur_prompt, "prompt"):
+                        prompt_token_count = len(self.rollout_engine.llm_engine.tokenizer.encode(cur_prompt.prompt))
+                    else:
+                        # For VLM inputs, try to get prompt_token_ids
+                        if hasattr(cur_prompt, "prompt_token_ids"):
+                            prompt_token_count = len(cur_prompt.prompt_token_ids)
+                        elif isinstance(cur_prompt, dict) and "prompt_token_ids" in cur_prompt:
+                            prompt_token_count = len(cur_prompt["prompt_token_ids"])
+                        else:
+                            prompt_token_count = 0
+
+                    if prompt_token_count > 0 and prompt_token_count > max_model_len:
+                        logger.warning(
+                            f"[Rollout] Skipping prompt (token count: {prompt_token_count}) "
+                            f"exceeds max_model_len ({max_model_len}). This usually happens when "
+                            f"images/videos are large or the input text is too long."
+                        )
+                        return []
+                except Exception as e:
+                    logger.warning(
+                        f"[Rollout] Error checking prompt length: {str(e)}, assuming prompt is valid"
+                    )
+
                 n_generation = sampling_params.n
 
                 # Manually control the generation of n requests to avoid long results slowing down generation speed in FINAL_ONLY mode
@@ -304,6 +335,7 @@ class vLLMRolloutAsync(vLLMRollout):
                 ]
                 results = await asyncio.gather(*tasks)
                 completions = [result for result in results if result is not None]
+
         except Exception as e:
             logger.error(f"[Rollout] Failed in rollout generation: {str(e)}")
             import traceback

--- a/cosmos_rl/rollout/vllm_rollout/vllm_rollout_async.py
+++ b/cosmos_rl/rollout/vllm_rollout/vllm_rollout_async.py
@@ -291,16 +291,29 @@ class vLLMRolloutAsync(vLLMRollout):
                 max_model_len = self.config.policy.model_max_length
                 try:
                     if isinstance(cur_prompt, str):
-                        prompt_token_count = len(self.rollout_engine.llm_engine.tokenizer.encode(cur_prompt))
+                        prompt_token_count = len(
+                            self.rollout_engine.llm_engine.tokenizer.encode(cur_prompt)
+                        )
                     elif isinstance(cur_prompt, dict) and "prompt" in cur_prompt:
-                        prompt_token_count = len(self.rollout_engine.llm_engine.tokenizer.encode(cur_prompt["prompt"]))
+                        prompt_token_count = len(
+                            self.rollout_engine.llm_engine.tokenizer.encode(
+                                cur_prompt["prompt"]
+                            )
+                        )
                     elif hasattr(cur_prompt, "prompt"):
-                        prompt_token_count = len(self.rollout_engine.llm_engine.tokenizer.encode(cur_prompt.prompt))
+                        prompt_token_count = len(
+                            self.rollout_engine.llm_engine.tokenizer.encode(
+                                cur_prompt.prompt
+                            )
+                        )
                     else:
                         # For VLM inputs, try to get prompt_token_ids
                         if hasattr(cur_prompt, "prompt_token_ids"):
                             prompt_token_count = len(cur_prompt.prompt_token_ids)
-                        elif isinstance(cur_prompt, dict) and "prompt_token_ids" in cur_prompt:
+                        elif (
+                            isinstance(cur_prompt, dict)
+                            and "prompt_token_ids" in cur_prompt
+                        ):
                             prompt_token_count = len(cur_prompt["prompt_token_ids"])
                         else:
                             prompt_token_count = 0


### PR DESCRIPTION

Fixes issue #403 - vLLM now raises an error when decoder prompt length exceeds max_model_len, especially with large images/videos in VLM tasks. This fix filters out oversized prompts before passing them to vLLM, preventing errors while logging warnings about skipped samples.

Changes:
- Added prompt length validation in rollout_generation_single_turn()
- Added prompt length validation in async rollout_generation()
- Supports both LLM (string/dict prompts) and VLM (image/video inputs)
- Logs warnings when samples are skipped due to exceeding max_model_len
- Gracefully handles edge cases where token count cannot be determined