### PR TITLE
fix: honor `policy.model_gradient_checkpointing` in DeepSeek-V3

### DIFF
--- a/cosmos_rl/policy/model/deepseek_v3/parallelize.py
+++ b/cosmos_rl/policy/model/deepseek_v3/parallelize.py
@@ -320,7 +320,19 @@ def parallelize(
             assert "moe" in meshes
             _apply_ep(model_part, meshes["moe"]["ep"])
 
-        _apply_ac(model_part)
+        # Honor `policy.model_gradient_checkpointing` (default True).  The
+        # HF-models and GPT paths already branch on this flag; DeepSeek-V3 used
+        # to call `_apply_ac` unconditionally and silently override an explicit
+        # opt-out.  Letting users disable AC matters here because activation
+        # checkpointing under MoE + bf16 router + FSDP can produce
+        # non-deterministic token routing on the backward-time recompute (one
+        # token's expert assignment flips between the original forward and the
+        # recompute, shifting per-EP-rank dispatch counts and triggering
+        # `torch.utils.checkpoint.CheckpointError`).  TODO: address the MoE +
+        # AC determinism issue at the source (e.g. fp32 router matmul, or skip
+        # AC on MoE blocks only) and re-enable AC by default for this path.
+        if config.policy.model_gradient_checkpointing:
+            _apply_ac(model_part)
 
         _apply_fsdp(model_part, meshes, parallel_dims)
 

--- a/tests/configs/sft_integration_deepseek_simple.toml
+++ b/tests/configs/sft_integration_deepseek_simple.toml
@@ -25,7 +25,12 @@ sync_weight_interval = 1
 [policy]
 model_name_or_path = "yufanhuangNV/deepseek-v3-4layer"
 model_max_length = 1024
-model_gradient_checkpointing = true
+# Disabled to work around MoE token-routing nondeterminism under activation
+# checkpointing + bf16 router + FSDP, which causes
+# `torch.utils.checkpoint.CheckpointError` on the backward-time recompute.
+# Re-enable once the root cause (e.g. fp32 router matmul, or AC-skip on MoE
+# blocks only) is addressed.
+model_gradient_checkpointing = false
 
 [logging]
 logger = ['console']


### PR DESCRIPTION
## Summary

Two narrow changes that together stop the `build_and_test` CI hang we've been hitting on PRs that don't touch SFT/MoE/AC at all (most recently #688 and #689):

1. `cosmos_rl/policy/model/deepseek_v3/parallelize.py` — gate `_apply_ac(model_part)` on `config.policy.model_gradient_checkpointing` (default `True`). The HF-models path (`hf_models/__init__.py:127-139`) and the GPT path (`gpt/__init__.py:487-499`) already respect this flag; DeepSeek-V3 used to ignore it.
2. `tests/configs/sft_integration_deepseek_simple.toml` — set `model_gradient_checkpointing = false` for the `test_policy_overfit` integration test, which is the test that's been crashing.

Production behavior is unchanged for any config that doesn't set `model_gradient_checkpointing = false`.

## Concrete evidence (failed run on PR #689 / commit `24400eb`)

Job: `build_and_test` step 6 "Run tests".

Failing test, from the run-script banner:

    ================ RUN: python tests/test_policy_overfit.py ================

Auto-discover log line confirms the model:

    [Model] Imported BaseModel: DeepseekV3MoEModel from deepseek_v3

Tracebacks on `[rank6]` and `[rank7]` both end the same way:

    File "/workspace/cosmos-rl/tests/launch_test_worker.py", line 1008, in main_loop
        global_avg_loss, grad_norm = self.trainer.step_training(...)
    File "/workspace/cosmos-rl/tests/launch_test_worker.py", line 955, in train
        loss.backward()
    ...
    File "/opt/venv/cosmos_rl/lib/python3.12/site-packages/torch/utils/checkpoint.py", line 903, in check_recomputed_tensors_match
        raise CheckpointError(
    torch.utils.checkpoint.CheckpointError: Recomputed values for the following tensors have different metadata than during the forward pass.

Both line numbers fall inside the `train` / `main_loop` closures defined within `run_overfitting_policy` (lines 876–1020). The `[rank0]` log line `Training step 5/30` matches `N_STEPS = 30` in that same function (line 890). `[rank7]` plus `device(type='cuda', index=7)` ⇒ `world_size ≥ 8`; the only invocation that pairs `--mode test_overfit` with `world_size=8` is `tests/test_policy_overfit.py:33,76`. So the test, the model, and the test driver are pinned by the trace alone.

The `CheckpointError` shapes are the diagnostic part:

    rank 7: saved [7070, 7168] -> recomputed [7071, 7168]   (+1)
    rank 6: saved [9314, 7168] -> recomputed [9313, 7168]   (-1)

Same offset signs at positions 43, 46, 47, 48, with shapes:

| position | shape           | meaning                                          |
|----------|-----------------|--------------------------------------------------|
| 43       | `[N, 7168]` bf16 | DeepSeek-V3 hidden dim (`dim`)                  |
| 46       | `[N, 4096]` bf16 | MoE `2 * moe_inter_dim` (packed gate-up)        |
| 47       | `[N, 1]` fp32    | per-token routing weight (`permuted_probs`)     |
| 48       | `[N, 2048]` bf16 | `moe_inter_dim`                                 |

The `[N, 2048]` and `[N, 1]` fp32 tensors are the unambiguous fingerprint of MoE expert-side post-permutation / post-all-to-all activations. Together with the `+1` on rank 7 and `-1` on rank 6 — i.e. one token migrating between EP ranks while the global token count is conserved — this isolates the failing block to the **single MoE block (layer 3) in `deepseek-v3-4layer`** (`n_dense_layers=3`, so layers 0–2 are dense MLPs and would never produce a leading-dim drift inside a checkpointed forward).

## Root-cause hypothesis

`_apply_ac` wraps every Block in `ptd_checkpoint_wrapper(block, preserve_rng_state=False)`. PyTorch's checkpoint validator requires the recompute to reproduce the saved tensor metadata byte-for-byte. The DeepSeek `Gate` forward computes routing scores via:

    scores = F.linear(x, self.weight)              # bf16 @ bf16 -> bf16
    scores = scores.softmax(dim=-1, dtype=torch.float32)
    indices = torch.topk(scores, self.topk, dim=-1)[1]

Under FSDP the router weight is resharded between forward and backward and re-all-gathered for the recompute. Bf16 matmul accumulation order can shift the score of a borderline token by one ULP, which is enough to flip its top-`k` decision and reroute it from one EP rank's local experts to another's. That single flip propagates into divergent `tokens_per_expert`, divergent all-to-all input/output split sizes, and the `(+1, -1)` shape drift we observe.

## Why "stop the bleeding" rather than fix at the source

A principled fix is correct but requires 8-GPU verification, more code, and a deeper conversation about MoE memory budget. We don't need to land that to unblock #688 and #689. This PR makes the existing `model_gradient_checkpointing` knob actually do what its name says, and the failing test opts out of AC. No production config is changed.

## Out of scope (follow-up candidates, no separate issue yet — pick one when someone has 8-GPU time)

The underlying problem is "MoE + activation checkpointing + bf16 router under FSDP produces non-deterministic token routing on backward recompute". Candidate fixes, in order of likely effort:

- Run the `Gate` matmul (`F.linear(x, self.weight)`) in fp32 (cleanest; ~10 LOC in `cosmos_rl/policy/kernel/moe/moe.py:Gate.forward`). Removes the bf16-ULP source.
- Skip AC only on MoE blocks (`Block` where `layer_id >= n_dense_layers`) and keep AC for dense Blocks. Costs MoE-block memory but keeps the determinism guarantee.
- Save and reuse the routing decision across recompute via a custom checkpoint wrapper. Largest surgery; preserves AC on MoE.