### PR TITLE
fix: refresh apt index before installing cmake in Dockerfile package …

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -224,7 +224,7 @@ FROM pre-package AS package
 ARG COSMOS_RL_EXTRAS
 
 COPY . /workspace/cosmos_rl
-RUN apt install -y cmake && \
+RUN apt-get update && apt-get install -y cmake && \
     pip install /workspace/cosmos_rl${COSMOS_RL_EXTRAS:+[$COSMOS_RL_EXTRAS]} && \
     if [[ ",$COSMOS_RL_EXTRAS," == *,vla,* ]]; then \
         bash /workspace/cosmos_rl/tools/scripts/setup_vla.sh; \


### PR DESCRIPTION
  Fix Docker build failure in the `package` stage caused by a stale apt index.

  The stage ran `apt install -y cmake` without first refreshing the package index. On builds where the base image's cached index is stale or
  pruned, apt can't resolve the `cmake` package and the build fails. Switched to `apt-get update && apt-get install -y cmake` so the index is
  refreshed in the same `RUN` layer.

  ## Changes

  - `Dockerfile`: prepend `apt-get update` before `apt-get install -y cmake` in the `package` stage.
