### PR TITLE
feat: RolloutGenerationMixin + per-prompt prefetch

### DIFF
--- a/cosmos_rl/dispatcher/api/client.py
+++ b/cosmos_rl/dispatcher/api/client.py
@@ -179,10 +179,10 @@ class APIClient(object):
         # which then deadlocks worker teardown -- the worker process
         # never reaches ``destroy_distributed()`` and its UCXX server
         # threads keep polling until the orchestrator hard-kills the
-        # job.  Cap the per-attempt time and retry only a few times:
-        # best-effort cleanup, not a correctness requirement (the
-        # controller will GC the replica via heartbeat timeout if this
-        # fails).
+        # job.  Cap the per-attempt time; retries use ``self.max_retries``
+        # (``COSMOS_HTTP_RETRY_CONFIG``).  Best-effort cleanup, not a
+        # correctness requirement (the controller will GC the replica via
+        # heartbeat timeout if this fails).
         try:
             make_request_with_retry(
                 partial(
@@ -193,7 +193,7 @@ class APIClient(object):
                     timeout=constant.COSMOS_CONTROL_HTTP_TIMEOUT,
                 ),
                 self.get_alternative_urls(COSMOS_API_UNREGISTER_SUFFIX),
-                max_retries=3,
+                max_retries=self.max_retries,
             )
         except Exception as e:
             logger.error(f"Failed to unregister from controller: {e}")

--- a/cosmos_rl/dispatcher/command.py
+++ b/cosmos_rl/dispatcher/command.py
@@ -402,6 +402,15 @@ class StopCommand(Command):
     non-validation step), STOP triggers no collective, so it cannot orphan
     an in-flight P2R/R2R recv or wedge ``ncclCommAbort``.
 
+    The controller publishes STOP only after every policy replica has
+    unregistered (``should_broadcast_stop``), so the trainer is no longer
+    driving new P2R/R2R rounds when rollouts observe it.  Any weight-sync
+    collective already in flight on a rollout finishes on the ranks that
+    entered it; ranks that never joined (e.g. wedged on the weight-version
+    gate) are unblocked by STOP without touching NCCL.  Cross-replica
+    ordering is therefore safe: STOP is not a mid-collective abort on some
+    nodes while others still block in the same NCCL group.
+
     ``consume_one_command`` broadcasts the dequeued command across ranks via
     ``broadcast_object_cpu``, so all ranks of a multi-rank worker receive
     STOP at the same collective call and leave ``main_loop`` in lockstep --
@@ -529,11 +538,17 @@ class DataFetchCommand(Command):
 
 
 class TrainingCompleteCommand(Command):
-    """Explicit end-of-training signal for the policy at genuine end-of-data.
+    """Explicit end-of-training signal for **policy** replicas only.
 
     Replaces the former ``is_fake_last_cmd`` ``DataFetchCommand`` with
-    ``items_count=0``.  The policy skips ``step_training``, sends ``train_ack``,
-    and exits when ``global_step >= total_steps``.
+    ``items_count=0`` as the dedicated trainer-stop signal.  The policy skips
+    ``step_training``, sends ``train_ack``, and exits its main loop when
+    ``global_step >= total_steps``.
+
+    Rollout shutdown is separate: once every policy replica has unregistered,
+    the controller broadcasts :class:`StopCommand` to the rollout set (see
+    ``should_broadcast_stop``).  ``TrainingCompleteCommand`` ends training;
+    ``StopCommand`` ends rollouts.
     """
 
     def __init__(

--- a/cosmos_rl/policy/config/__init__.py
+++ b/cosmos_rl/policy/config/__init__.py
@@ -911,10 +911,12 @@ class TrainingConfig(BaseModel):
         description="If True, the controller coalesces (drops) redundant P2R+R2R "
         "weight-sync rounds while a round is still in flight to the rollouts "
         "(depth-1 drop-to-latest): it re-issues at the latest step only once the "
-        "rollouts have adopted the previously staged version. Reduces wasted "
-        "weight transfers when the trainer outruns rollout drain. Only active for "
-        "off-policy runs (allowed_outdated_steps > 0); ignored for on-policy, "
-        "which requires step-exact weight sync.",
+        "rollouts have adopted the previously staged version. No separate "
+        "'steps to drop' knob -- any number of intermediate trainer steps "
+        "collapse to a single pending round (always the latest weights). "
+        "Reduces wasted weight transfers when the trainer outruns rollout drain. "
+        "Only active for off-policy runs (allowed_outdated_steps > 0); ignored "
+        "for on-policy, which requires step-exact weight sync.",
     )
     deterministic: bool = Field(
         default=False,
@@ -1549,12 +1551,18 @@ class RolloutConfig(BaseModel):
         default=False,
         description=(
             "Enable background prompt prefetch.  A daemon thread fetches the next "
-            "prompt batch into _prompt_queue while rollout_generation() is running "
-            "and (when the rollout backend implements enqueue_prefetch_payloads) "
-            "speculatively dispatches sessions for those payloads so the backend "
-            "can stay busy across batch boundaries.  Default off — only useful for "
-            "long-running simulation backends where straggler scenes leave the "
-            "backend underutilized at the tail of each rollout_generation() call."
+            "prompt batch into _prompt_queue while rollout_generation() is running. "
+            "Backends that compose cosmos_rl.rollout.generation_mixin."
+            "RolloutGenerationMixin (e.g. the gym example) additionally have their "
+            "_prepare_sample hook dispatched on a background setup thread for each "
+            "prefetched payload, so per-prompt setup work (env construction, "
+            "tokenization, KV-cache prefill, ...) overlaps with in-flight engine "
+            "calls on the previous batch.  Default off — most useful for "
+            "simulation / multi-turn backends where per-prompt setup is non-trivial "
+            "and straggler prompts would otherwise leave the engine underutilized "
+            "at the tail of each rollout_generation() call.  The legacy "
+            "enqueue_prefetch_payloads hook on RolloutBase is supported as a "
+            "deprecation shim for backends that haven't yet migrated to the mixin."
         ),
     )
 

--- a/cosmos_rl/rollout/example_custom_rollout/example_custom_rollout.py
+++ b/cosmos_rl/rollout/example_custom_rollout/example_custom_rollout.py
@@ -38,6 +38,22 @@ This rollout engine is just used for demonstration, testing and example purposes
 It demonstrates how to implement a custom rollout engine and how to register it to the RolloutRegistry to be used in the rollout worker.
 It is not optimized for performance and may not be suitable for production use.
 User can mimic this implementation to implement their own rollout engine.
+
+Two equally-supported customization shapes:
+
+* **Bespoke ``rollout_generation`` (this file).** Override the abstract method
+  on :class:`~cosmos_rl.rollout.rollout_base.RolloutBase` directly. Best when
+  the engine call is one-shot per batch and the per-payload preprocessing is
+  trivial.
+* **Compose** :class:`~cosmos_rl.rollout.generation_mixin.RolloutGenerationMixin`
+  and override the four hooks ``_prepare_sample``, ``_collate_batch``,
+  ``_generate``, ``_postprocess``. Best when per-prompt setup is non-trivial
+  (env construction, KV-cache prefill, tokenizer warmups, ...) — the mixin
+  runs ``_prepare_sample`` on a background thread when
+  ``config.rollout.prefetch_rollout = True``, overlapping that work with
+  in-flight engine calls on the previous batch. See
+  :mod:`cosmos_rl.tools.gym_example.gym_rollout_backend` for a worked
+  example.
 """
 
 

--- a/cosmos_rl/rollout/generation_mixin.py
+++ b/cosmos_rl/rollout/generation_mixin.py
@@ -1,0 +1,660 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Structured ``rollout_generation`` template + optional per-prompt prefetch.
+
+Why
+---
+Every concrete :class:`~cosmos_rl.rollout.rollout_base.RolloutBase`
+subclass re-implements the same shape inside ``rollout_generation``:
+
+1. assert engine initialized,
+2. for each payload run packer-side preprocessing,
+3. optionally collate the prepared samples into a batch,
+4. call the backend's engine,
+5. convert the engine output into ``List[RolloutResult]``,
+6. wrap the whole thing in a ``try``/``except`` that returns ``[]`` on
+   failure so a single bad batch doesn't kill the rollout worker.
+
+Only step (4) is genuinely backend-specific.  Steps (2) and (5) are
+trivially backend-specific (one or two lines each); the rest is
+duplication.  This mixin pulls the common shape into a template method
+and exposes four override hooks for the per-backend bits.
+
+The same seam doubles as a place to overlap step (2)'s per-prompt
+work with step (4)'s in-flight engine call on the previous batch.
+When ``config.rollout.prefetch_rollout`` is ``True``, the rollout
+worker's ``_prefetch_loop`` calls :meth:`submit_setup` as soon as it
+hands a new prompt batch to the prompt queue; the mixin runs
+:meth:`_prepare_sample` for each payload on a background thread keyed
+by :meth:`_payload_key` so by the time the consumer hits
+:meth:`rollout_generation`, the prepared samples are already done (or
+in flight, in which case the template method simply waits per-future
+just before :meth:`_collate_batch`).  When the flag is ``False``,
+:meth:`submit_setup` is a no-op and :meth:`_prepare_sample` runs
+inline; the four-hook code path is otherwise identical.
+
+Why one mixin, not two
+----------------------
+"Structured hooks" and "per-prompt prefetch overlap" share the same
+seam: prefetch's only job is to run :meth:`_prepare_sample` on a bg
+thread.  Splitting them would force every consumer to compose two
+mixins to get the natural behavior, and would expose
+future-map vocabulary to backend authors who shouldn't have to think
+about it.  One mixin, four hooks, prefetch is a runtime config flag.
+
+Why opt-in (not folded into ``RolloutBase``)
+--------------------------------------------
+Existing backends (vLLM, TRT-LLM, VLA, WFM, NFT, ExampleHF) have
+nuanced ``rollout_generation`` implementations that don't trivially
+fit four hooks (vLLM has ``n_repeats``, distillation top-k, vlm vs
+not; TRT-LLM has a different signature; VLA has its own simulation
+loop).  Forcing all of them into the template at once is high blast
+radius for low immediate benefit.  Opt-in lets the gym example adopt
+now; the heavier backends migrate one PR at a time as their owners
+want the hooks.
+
+Composition
+-----------
+::
+
+    @RolloutRegistry.register(rollout_type="my_backend")
+    class MyBackend(RolloutGenerationMixin, RolloutBase):
+        def post_init_hook(self, **kwargs):
+            ...
+            self.setup_generation(thread_name="MyBackendPrefetch")
+
+        def _prepare_sample(self, payload, *, data_packer, **_):
+            return data_packer.get_rollout_input(payload.prompt)
+
+        def _generate(self, batch, *, stream, is_validation):
+            return self._engine.run(batch)
+
+        def _postprocess(self, raw, payloads, *, is_validation):
+            return [RolloutResult(prompt=p.prompt, completions=[r])
+                    for p, r in zip(payloads, raw)]
+
+        def shutdown(self):
+            self.shutdown_generation()
+            super().shutdown()
+
+The mixin's template ``rollout_generation`` satisfies the abstract
+method declared on :class:`RolloutBase` because the mixin precedes
+``RolloutBase`` in the MRO.
+
+Threading model
+---------------
+The bg setup worker is a single daemon thread.  ``_prepare_sample``
+must therefore be re-entrant w.r.t. the main thread that drives
+``rollout_generation``.  The default implementation
+(``data_packer.get_rollout_input``) is pure data shaping and is
+trivially safe; backends that do stateful preparation (e.g. building
+a sim env per prompt) own the synchronization.  The mixin itself
+holds no shared mutable state beyond the future map and uses an
+atomic dict swap so concurrent ``submit_setup`` and
+:meth:`_gather_prepared_samples` are safe.
+
+Edge cases
+----------
+* Prefetch disabled: ``submit_setup`` is a no-op,
+  ``_gather_prepared_samples`` runs ``_prepare_sample`` inline.
+  Behaviour identical to a hand-written ``rollout_generation``.
+* ``_prepare_sample`` raises: the future captures the exception,
+  ``_gather_prepared_samples`` re-raises in the consumer thread, the
+  template's ``except`` clause hands the error to
+  :meth:`_on_generation_error` (default: log + return ``[]``).
+* Same payload key submitted twice: last writer wins; the previous
+  future is dropped.  The controller doesn't repeat indices in normal
+  flow, but cancellation paths can.
+* Cold-start (a payload arrives at ``rollout_generation`` without a
+  matching ``submit_setup`` call): falls back to inline preparation
+  for that payload only.  This handles the very first batch of a run
+  (where the prefetch loop hasn't run yet) and any controller path
+  that bypasses prefetch.
+* Lifecycle / programmer errors (engine not initialised, policy not
+  attached, ...): assert in :meth:`_preflight_check`, not in the
+  per-batch hooks.  Preflight runs outside the ``try``/``except`` so
+  the exception propagates past :meth:`_on_generation_error` and
+  surfaces loudly -- swallowing a "policy not set" would just produce
+  silent empty-batch returns indefinitely.
+
+Out of scope (v1)
+-----------------
+* Async-engine variant for ``vLLMRolloutAsync``: the mixin is sync.
+  A future ``AsyncRolloutGenerationMixin`` is a sibling, not a
+  subclass.
+* Worker pool for concurrent ``_prepare_sample``: a single bg thread
+  is enough for the colocated single-process case.  A pool would
+  require an explicit knob; deferred until a backend wants it.
+"""
+
+from __future__ import annotations
+
+import logging
+import queue
+import threading
+import time
+from concurrent.futures import Future
+from typing import Any, Dict, Hashable, List, Optional, Sequence, final
+
+from cosmos_rl.utils.logging import logger as _default_logger
+
+
+# Sentinel passed to the bg worker to ask it to exit cleanly.
+_SHUTDOWN = object()
+
+
+# Stable contract for the per-batch trace line emitted at DEBUG level
+# from ``rollout_generation``.  Downstream analyzers parse these lines,
+# so the field names and order are part of the public surface.
+#
+# Field semantics:
+#   batch_size     -- len(payloads) for this generation call
+#   prefetch       -- whether the mixin's bg setup worker is enabled
+#   gather_ms      -- total wall time spent in _gather_prepared_samples
+#                     (= sum of wait_ms + inline_ms + bookkeeping)
+#   collate_ms     -- _collate_batch wall time
+#   generate_ms    -- _generate wall time (the backend engine call)
+#   postprocess_ms -- _postprocess wall time
+#   inline_count   -- payloads whose _prepare_sample ran on the main
+#                     thread (cold-start, prefetch disabled, or future
+#                     evicted/cancelled before we got to it)
+#   inline_ms      -- cumulative time spent on the main thread doing
+#                     inline _prepare_sample calls
+#   wait_count     -- payloads whose future was in flight when we
+#                     needed it (prefetch lost the race -- if this is
+#                     consistently >0 the bg thread is too slow or
+#                     there are too few payloads in flight)
+#   wait_ms        -- cumulative time the main thread blocked on
+#                     future.result().  When prefetch is fully
+#                     overlapping this should trend to zero.
+_TRACE_LINE_FORMAT = (
+    "[mixin-trace] batch_size=%d prefetch=%s "
+    "gather_ms=%.2f collate_ms=%.2f generate_ms=%.2f postprocess_ms=%.2f "
+    "inline_count=%d inline_ms=%.2f wait_count=%d wait_ms=%.2f"
+)
+
+
+class RolloutGenerationMixin:
+    """Template-method ``rollout_generation`` + opt-in per-prompt prefetch.
+
+    See module docstring for the full design.  Subclasses override the
+    four hooks (:meth:`_prepare_sample`, :meth:`_collate_batch`,
+    :meth:`_generate`, :meth:`_postprocess`); ``rollout_generation``
+    itself is final and dispatches them in order.
+
+    Lifecycle: call :meth:`setup_generation` from
+    :meth:`~cosmos_rl.rollout.rollout_base.RolloutBase.post_init_hook`
+    (idempotent; no-op when ``config.rollout.prefetch_rollout`` is
+    ``False``).  Call :meth:`shutdown_generation` from
+    :meth:`~cosmos_rl.rollout.rollout_base.RolloutBase.shutdown`.
+    """
+
+    # ------------------------------------------------------------------
+    # Override hooks
+    # ------------------------------------------------------------------
+
+    def _prepare_sample(
+        self,
+        payload: Any,
+        *,
+        data_packer: Any,
+        data_fetcher: Any,
+        is_validation: bool,
+    ) -> Any:
+        """Per-payload preprocessing.
+
+        Called on the background setup worker when prefetch is on,
+        inline on the calling thread when off.  Must be re-entrant
+        w.r.t. anything :meth:`_generate` touches on ``self``.
+
+        Default: ``data_packer.get_rollout_input(payload.prompt)``.
+        Backends that don't have a packer (or want to handle their own
+        preprocessing) override.
+        """
+        if data_packer is None:
+            prompt = getattr(payload, "prompt", payload)
+            return prompt
+        prompt = getattr(payload, "prompt", payload)
+        return data_packer.get_rollout_input({"prompt": prompt})
+
+    def _collate_batch(
+        self,
+        samples: Sequence[Any],
+        *,
+        data_packer: Any,
+        is_validation: bool,
+    ) -> Any:
+        """Combine prepared samples into the engine's batch input.
+
+        Default: identity (returns ``samples`` unchanged).  Backends
+        whose engine takes a single batch object override (e.g. an LLM
+        backend that calls ``data_packer.rollout_collate_fn``).
+        """
+        return samples
+
+    def _generate(
+        self,
+        batch: Any,
+        *,
+        stream: Any,
+        is_validation: bool,
+    ) -> Any:
+        """Backend-specific engine call.  Required override.
+
+        ``batch`` is whatever :meth:`_collate_batch` returned.  The
+        return value is handed to :meth:`_postprocess` along with the
+        original ``payloads`` list so backends can pair engine output
+        back to prompts.
+        """
+        raise NotImplementedError("[RolloutGenerationMixin] _generate is required.")
+
+    def _postprocess(
+        self,
+        raw: Any,
+        payloads: Sequence[Any],
+        *,
+        is_validation: bool,
+    ) -> Any:
+        """Convert engine output into the final per-payload result list.
+
+        Required override unless the engine output is already shaped
+        the way the controller expects.  For the cosmos-rl
+        ``RolloutBase`` contract this is ``List[RolloutResult]``;
+        tensor-native backends may return ``List[Dict[str, Tensor]]``
+        instead.
+        """
+        raise NotImplementedError("[RolloutGenerationMixin] _postprocess is required.")
+
+    def _payload_key(self, payload: Any) -> Hashable:
+        """Stable cache key for prefetch.  Default: ``prompt_idx`` or ``id()``.
+
+        The default is correct for any payload that carries a
+        ``prompt_idx`` attribute (e.g. ``RLPayload``); backends that
+        receive raw dicts override.
+        """
+        idx = getattr(payload, "prompt_idx", None)
+        if idx is not None and idx >= 0:
+            return ("idx", idx)
+        return ("id", id(payload))
+
+    def _on_generation_error(
+        self,
+        err: BaseException,
+        payloads: Sequence[Any],
+    ) -> Any:
+        """Called when :meth:`_generate` (or the prepare/collate hooks)
+        raises.
+
+        Default: log at ``ERROR`` level and return ``[]`` so the
+        rollout worker's ``main_loop`` skips this batch and continues.
+        Backends that want to retry or report partial results override.
+        """
+        n = len(payloads) if payloads is not None else 0
+        self._gen_logger.error(
+            "[RolloutGenerationMixin] generation failed for batch of %d (%s: %s); "
+            "returning empty batch.",
+            n,
+            type(err).__name__,
+            err,
+        )
+        return []
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    def setup_generation(
+        self,
+        *,
+        thread_name: str = "RolloutGen",
+        logger: Optional[logging.Logger] = None,
+    ) -> None:
+        """Initialize prefetch state.  Idempotent, safe to call multiple times.
+
+        Reads ``self.config.rollout.prefetch_rollout`` to decide whether
+        to start the background worker.  When prefetch is off, this is
+        effectively a tiny constructor that initializes the per-instance
+        bookkeeping without spawning a thread.
+
+        Subclasses typically call this from ``post_init_hook``.
+        """
+        # Re-entrant: bail out cleanly on a second call.
+        if getattr(self, "_gen_initialized", False):
+            return
+
+        self._gen_logger = logger or _default_logger
+        self._setup_futures: Dict[Hashable, Future] = {}
+        self._setup_futures_lock = threading.Lock()
+        self._setup_shutdown = threading.Event()
+        self._setup_request_queue: "queue.Queue[Any]" = queue.Queue()
+        self._setup_thread: Optional[threading.Thread] = None
+
+        cfg = getattr(self, "config", None)
+        rollout_cfg = getattr(cfg, "rollout", None) if cfg is not None else None
+        self._prefetch_enabled = bool(getattr(rollout_cfg, "prefetch_rollout", False))
+
+        if self._prefetch_enabled:
+            self._setup_thread = threading.Thread(
+                target=self._setup_worker_loop,
+                name=thread_name,
+                daemon=True,
+            )
+            self._setup_thread.start()
+            self._gen_logger.info(
+                "[RolloutGenerationMixin] prefetch enabled; setup worker '%s' started",
+                thread_name,
+            )
+        else:
+            self._gen_logger.debug(
+                "[RolloutGenerationMixin] prefetch disabled; running prepare inline"
+            )
+
+        self._gen_initialized = True
+
+    def shutdown_generation(self) -> None:
+        """Stop the bg worker and clear pending futures.
+
+        Safe to call when :meth:`setup_generation` was never called or
+        was called with prefetch disabled.  Joins the thread with a
+        small timeout to avoid blocking shutdown forever on a stuck
+        ``_prepare_sample``.
+        """
+        if not getattr(self, "_gen_initialized", False):
+            return
+        self._setup_shutdown.set()
+        # Wake the worker if it's blocked on the queue.
+        try:
+            self._setup_request_queue.put_nowait(_SHUTDOWN)
+        except Exception:  # pragma: no cover - queue.Full unreachable for unbounded
+            pass
+        if self._setup_thread is not None and self._setup_thread.is_alive():
+            self._setup_thread.join(timeout=2.0)
+        with self._setup_futures_lock:
+            for fut in self._setup_futures.values():
+                # Cancel best-effort; if already running on the worker,
+                # ``cancel`` is a no-op and the result is discarded.
+                fut.cancel()
+            self._setup_futures.clear()
+        self._gen_initialized = False
+
+    # ------------------------------------------------------------------
+    # Prefetch entry (called by rollout_control._prefetch_loop)
+    # ------------------------------------------------------------------
+
+    def submit_setup(self, payloads: Sequence[Any]) -> None:
+        """Schedule :meth:`_prepare_sample` for each payload.
+
+        Called from the rollout worker's ``_prefetch_loop`` thread after
+        it puts a batch on the prompt queue.  No-op when prefetch is
+        disabled or :meth:`setup_generation` was never called.
+
+        Resubmissions: if a key is already pending or done, the new
+        request replaces it.  This handles the rare cancellation /
+        re-issue path; the controller doesn't normally repeat indices.
+        """
+        if not getattr(self, "_prefetch_enabled", False):
+            return
+        if not getattr(self, "_gen_initialized", False):
+            return
+        for payload in payloads:
+            key = self._payload_key(payload)
+            future: Future = Future()
+            with self._setup_futures_lock:
+                old = self._setup_futures.get(key)
+                if old is not None and not old.done():
+                    old.cancel()
+                self._setup_futures[key] = future
+            # The worker pulls (key, payload, future) and runs the hook.
+            self._setup_request_queue.put((key, payload, future))
+
+    # ------------------------------------------------------------------
+    # Final template method
+    # ------------------------------------------------------------------
+
+    @final
+    def rollout_generation(
+        self,
+        payloads: Sequence[Any],
+        stream: Any = None,
+        data_packer: Any = None,
+        data_fetcher: Any = None,
+        is_validation: bool = False,
+        *args: Any,
+        **kwargs: Any,
+    ) -> Any:
+        """Template method: prepare → collate → generate → postprocess.
+
+        Final by convention; backends override the four hooks instead.
+
+        Errors during the data-shaping stages (prepare / collate /
+        generate / postprocess) flow through :meth:`_on_generation_error`
+        so a single bad batch doesn't kill the rollout worker.  The
+        engine-initialized check is *not* wrapped — calling
+        ``rollout_generation`` before ``init_engine`` is a programming
+        error and should crash loudly.
+
+        Emits a structured per-batch trace line at ``DEBUG`` level so
+        downstream analyzers can prove the bg setup thread is actually
+        overlapping ``_prepare_sample`` with ``_generate`` rather than
+        merely creating busy work.  The line shape is intentionally
+        stable; see :data:`_TRACE_LINE_FORMAT` for the contract.
+        """
+        if not getattr(self, "_gen_initialized", False):
+            # Composing class forgot setup_generation(); fall back to
+            # an inline path that's still safe (just no prefetch).
+            self.setup_generation()
+        # Lifecycle / programming-error checks; must propagate (not swallowed).
+        self._preflight_check()
+        # Gate trace emission on DEBUG so production INFO-level logs
+        # stay quiet and we pay only an isEnabledFor() lookup per batch.
+        trace_on = self._gen_logger.isEnabledFor(logging.DEBUG)
+        try:
+            t_start = time.perf_counter() if trace_on else 0.0
+            samples = self._gather_prepared_samples(
+                payloads,
+                data_packer=data_packer,
+                data_fetcher=data_fetcher,
+                is_validation=is_validation,
+            )
+            t_gather_end = time.perf_counter() if trace_on else 0.0
+            batch = self._collate_batch(
+                samples, data_packer=data_packer, is_validation=is_validation
+            )
+            t_collate_end = time.perf_counter() if trace_on else 0.0
+            raw = self._generate(batch, stream=stream, is_validation=is_validation)
+            t_generate_end = time.perf_counter() if trace_on else 0.0
+            result = self._postprocess(raw, payloads, is_validation=is_validation)
+            t_post_end = time.perf_counter() if trace_on else 0.0
+
+            if trace_on:
+                breakdown = getattr(self, "_last_gather_timing", {})
+                self._gen_logger.debug(
+                    _TRACE_LINE_FORMAT,
+                    len(payloads) if payloads else 0,
+                    bool(self._prefetch_enabled),
+                    (t_gather_end - t_start) * 1000.0,
+                    (t_collate_end - t_gather_end) * 1000.0,
+                    (t_generate_end - t_collate_end) * 1000.0,
+                    (t_post_end - t_generate_end) * 1000.0,
+                    breakdown.get("inline_count", 0),
+                    breakdown.get("inline_ms_total", 0.0),
+                    breakdown.get("wait_count", 0),
+                    breakdown.get("wait_ms_total", 0.0),
+                )
+            return result
+        except Exception as err:
+            return self._on_generation_error(err, payloads)
+
+    # ------------------------------------------------------------------
+    # Internals
+    # ------------------------------------------------------------------
+
+    def _preflight_check(self) -> None:
+        """Lifecycle assertions that must crash loudly, not be swallowed.
+
+        Runs *outside* the template's ``try``/``except`` so that any
+        exception raised here propagates past
+        :meth:`_on_generation_error`.  The default checks that
+        :meth:`init_engine` has been called.  Backends that have
+        additional lifecycle invariants (e.g. ``policy is not None``,
+        KV-cache allocated) override and call ``super()._preflight_check()``::
+
+            def _preflight_check(self) -> None:
+                super()._preflight_check()
+                if self.policy is None:
+                    raise RuntimeError(
+                        "Policy not set. Call set_underlying_model() first."
+                    )
+
+        These are programming/lifecycle errors -- the worker is in an
+        inconsistent state -- and must propagate.  Per-batch *data*
+        errors (e.g. an unparseable prompt) belong inside the four
+        hooks where they get routed through :meth:`_on_generation_error`
+        and the worker keeps running.
+        """
+        self._assert_engine_initialized()
+
+    def _assert_engine_initialized(self) -> None:
+        """Mirror the assertion every backend writes today."""
+        if not getattr(self, "_engine_initialized", False):
+            raise RuntimeError(
+                f"[{type(self).__name__}] engine is not initialized; "
+                "call init_engine() before rollout_generation()."
+            )
+
+    def _gather_prepared_samples(
+        self,
+        payloads: Sequence[Any],
+        *,
+        data_packer: Any,
+        data_fetcher: Any,
+        is_validation: bool,
+    ) -> List[Any]:
+        """Return prepared samples in payload order.
+
+        Prefetch path: pop the matching future per payload, await it,
+        propagate any exception.  Cold-start path (no future for a
+        key): run :meth:`_prepare_sample` inline for that payload.
+        Inline path (prefetch disabled): run :meth:`_prepare_sample`
+        for every payload on the calling thread.
+
+        Records per-call timing on ``self._last_gather_timing`` so the
+        template's trace line can attribute time to ``wait`` (future
+        was still in flight when we needed it -- prefetch isn't fully
+        overlapping) vs ``inline`` (no future, ran on the main thread).
+        Overhead is two ``perf_counter()`` reads per payload (sub-µs);
+        cheap enough to leave on unconditionally.
+        """
+        prefetch = getattr(self, "_prefetch_enabled", False)
+        results: List[Any] = []
+        inline_ms_total = 0.0
+        inline_count = 0
+        wait_ms_total = 0.0
+        wait_count = 0
+        for payload in payloads:
+            future: Optional[Future] = None
+            if prefetch:
+                key = self._payload_key(payload)
+                with self._setup_futures_lock:
+                    future = self._setup_futures.pop(key, None)
+            if future is not None:
+                t0 = time.perf_counter()
+                # Future.result re-raises whatever the hook raised.
+                results.append(future.result())
+                wait_ms_total += (time.perf_counter() - t0) * 1000.0
+                wait_count += 1
+            else:
+                t0 = time.perf_counter()
+                results.append(
+                    self._prepare_sample(
+                        payload,
+                        data_packer=data_packer,
+                        data_fetcher=data_fetcher,
+                        is_validation=is_validation,
+                    )
+                )
+                inline_ms_total += (time.perf_counter() - t0) * 1000.0
+                inline_count += 1
+        self._last_gather_timing = {
+            "inline_ms_total": inline_ms_total,
+            "inline_count": inline_count,
+            "wait_ms_total": wait_ms_total,
+            "wait_count": wait_count,
+        }
+        return results
+
+    def _setup_worker_loop(self) -> None:
+        """Background thread body: pull (key, payload, future) and run the hook."""
+        while not self._setup_shutdown.is_set():
+            try:
+                item = self._setup_request_queue.get(timeout=0.5)
+            except queue.Empty:
+                continue
+            if item is _SHUTDOWN:
+                break
+            key, payload, future = item
+            if future.cancelled():
+                continue
+            # Use the bound method so subclasses see ``self``.
+            try:
+                # The setup worker doesn't have access to the
+                # ``data_packer`` / ``data_fetcher`` / ``is_validation``
+                # context from the eventual ``rollout_generation`` call
+                # because prefetch fires before the consumer hits the
+                # template method.  We resolve them from instance
+                # attributes the consumer set up (e.g. via
+                # ``post_init_hook``); backends that need request-scoped
+                # context should pass a closure-bound payload instead.
+                result = self._prepare_sample(
+                    payload,
+                    data_packer=getattr(self, "_prefetch_data_packer", None),
+                    data_fetcher=getattr(self, "_prefetch_data_fetcher", None),
+                    is_validation=False,
+                )
+                future.set_result(result)
+            except BaseException as err:  # noqa: BLE001 - propagate to consumer
+                future.set_exception(err)
+
+    # ------------------------------------------------------------------
+    # Prefetch context (set once, used by the bg worker)
+    # ------------------------------------------------------------------
+
+    def bind_prefetch_context(
+        self,
+        *,
+        data_packer: Any = None,
+        data_fetcher: Any = None,
+    ) -> None:
+        """Bind the data_packer / data_fetcher that the bg setup worker should
+        pass to :meth:`_prepare_sample`.
+
+        Prefetch fires from ``_prefetch_loop`` *before* the consumer
+        thread reaches ``rollout_generation``, so the bg worker can't
+        learn the per-call ``data_packer`` / ``data_fetcher`` arguments
+        the way the inline path does.  Composing classes should call
+        this once during ``post_init_engine_hook`` (or an equivalent
+        late-init point) so the worker has everything it needs.
+
+        Backends that don't use the default :meth:`_prepare_sample`
+        (which reads ``data_packer``) can leave both ``None``.
+        """
+        if not getattr(self, "_gen_initialized", False):
+            self.setup_generation()
+        self._prefetch_data_packer = data_packer
+        self._prefetch_data_fetcher = data_fetcher
+
+
+__all__ = ["RolloutGenerationMixin"]

--- a/cosmos_rl/rollout/worker/rollout_control.py
+++ b/cosmos_rl/rollout/worker/rollout_control.py
@@ -24,7 +24,7 @@ import torch.distributed as dist
 
 from torch.utils.data import Dataset
 
-from queue import Queue, Empty as QueueEmpty
+from queue import Queue, Empty as QueueEmpty, Full as QueueFull
 from cosmos_rl.policy.model import ModelRegistry, WeightMapper
 from typing import List, Optional, Callable, Union, Tuple
 from functools import partial
@@ -99,6 +99,33 @@ Keep in mind that torch distributed is not thread safe. So try to keep the usage
 _TEARDOWN_DRAIN_TIMEOUT_S = float(os.getenv("COSMOS_TEARDOWN_DRAIN_TIMEOUT_S", "15.0"))
 
 
+_LEGACY_PREFETCH_HOOK_WARNED = False
+
+
+def _warn_legacy_prefetch_hook_once() -> None:
+    """One-shot warning for backends that still define
+    ``enqueue_prefetch_payloads`` directly on their ``RolloutBase``
+    subclass instead of composing
+    :class:`~cosmos_rl.rollout.generation_mixin.RolloutGenerationMixin`.
+
+    The legacy hook is supported as a deprecation shim; the warning
+    fires the first time the rollout controller hands a prefetched
+    batch to a legacy backend, then stays silent for the rest of the
+    process lifetime to avoid log spam in steady state.
+    """
+    global _LEGACY_PREFETCH_HOOK_WARNED
+    if _LEGACY_PREFETCH_HOOK_WARNED:
+        return
+    _LEGACY_PREFETCH_HOOK_WARNED = True
+    logger.warning(
+        "[Rollout] enqueue_prefetch_payloads is deprecated; compose "
+        "cosmos_rl.rollout.generation_mixin.RolloutGenerationMixin and "
+        "override its hooks (_prepare_sample / _collate_batch / "
+        "_generate / _postprocess) instead.  The legacy hook will be "
+        "removed in a future release."
+    )
+
+
 class DisaggregatedRolloutControlWorker(RolloutWorkerBase):
     """
     DisaggregatedRolloutControlWorker will be a replica instance of single DP.
@@ -124,9 +151,36 @@ class DisaggregatedRolloutControlWorker(RolloutWorkerBase):
 
         # CommandQueue queried from controller.
         self._command_queue: Queue[Command] = Queue()
-        self._prompt_queue: Queue[List[RLPayload]] = Queue()
-        # Serializes get_next_prompt() between main_loop and the optional
-        # prefetch thread (see _prefetch_loop, gated by config.rollout.prefetch_rollout).
+
+        # ``_single_producer_mode`` is a *live* property
+        # (see below) -- intentionally not snapshotted here.  Backends
+        # subclass ``RolloutBase`` and may mutate
+        # ``config.rollout.prefetch_rollout`` from ``post_init_hook``,
+        # which is invoked from ``RolloutBase.__init__`` *after* this
+        # constructor returns.  Any value we cached here would be from
+        # the pre-override config.  Reading the property lazily in
+        # ``work()`` / ``_main_loop_impl`` / ``_prefetch_loop`` ensures
+        # we observe the post-override value at the points where the
+        # decision actually matters.
+        #
+        # Bounded queue (``maxsize=2``): in single-producer mode,
+        # ``_prefetch_loop`` would otherwise race ahead of the
+        # consumer and queue arbitrarily many batches.  Maxsize=2
+        # keeps the prefetcher exactly one batch ahead.  In legacy
+        # mode, queue depth never exceeds 1 anyway (``main_loop``
+        # only calls ``request_new_prompts`` when the queue is
+        # empty), so the cap is harmless there.
+        self._prompt_queue: Queue[List[RLPayload]] = Queue(maxsize=2)
+
+        # Vestigial lock from the dual-producer era: prior to the
+        # single-producer-mode refactor, both ``main_loop`` (via
+        # ``request_new_prompts``) and ``_prefetch_loop`` could put
+        # on ``_prompt_queue``, and this lock serialized their
+        # empty-check + fetch.  In the new world only one path puts
+        # at a time, so the lock is uncontended; we keep it because
+        # ``request_new_prompts`` is also called from non-main-loop
+        # paths (validation, stream-rollout) that may be revisited
+        # in future, and the cost is negligible.
         self._prompt_fetch_lock = threading.Lock()
         self.prefetch_thread: Optional[threading.Thread] = None
         self.current_weight_version = 0
@@ -233,6 +287,30 @@ class DisaggregatedRolloutControlWorker(RolloutWorkerBase):
             val_reward_fns=kwargs.get("val_reward_fns"),
         )
         self.non_trainable_params_received = False
+
+    @property
+    def _single_producer_mode(self) -> bool:
+        """True when prefetch is on AND the worker is single-process.
+
+        Read live from ``config.rollout.prefetch_rollout`` (and
+        ``parallel_dims.world_size``) rather than snapshotted in
+        ``__init__``: backends may flip ``prefetch_rollout`` from
+        ``post_init_hook``, which runs *after* this constructor.
+
+        See the comment in ``__init__`` next to ``self._prompt_queue``
+        for the motivation.
+
+        When True, ``_prefetch_loop`` is the *sole* producer for
+        ``_prompt_queue`` and ``_main_loop_impl`` consumes only.
+        When False (prefetch off, or multi-rank where
+        ``request_new_prompts`` runs a distributed broadcast that
+        must include all ranks), we keep the legacy flow:
+        ``_main_loop_impl`` calls ``request_new_prompts`` itself
+        and the prefetch thread is not started.
+        """
+        return bool(
+            self.config.rollout.prefetch_rollout and self.parallel_dims.world_size == 1
+        )
 
     def setup(
         self,
@@ -1562,9 +1640,23 @@ class DisaggregatedRolloutControlWorker(RolloutWorkerBase):
                 self.redis_controller.publish_teacher_request(data, self.replica_name)
             time.sleep(0.01)
 
-    def request_new_prompts(self, batch_size: int, prompt_queue: Queue, **kwargs):
+    def request_new_prompts(
+        self,
+        batch_size: int,
+        prompt_queue: Queue,
+        max_pending_batches: int = 1,
+        **kwargs,
+    ):
         """
         Request new prompts from the controller for both training and validation.
+
+        ``max_pending_batches`` bounds how many batches may already be
+        queued before this call fetches another.  The default of 1
+        preserves the legacy fetch-when-empty cadence; the multi-rank
+        prep-overlap path passes 2 so it can fetch one batch ahead and
+        start that batch's preparation while the current one generates.
+        The fetch decision is taken on rank 0 and broadcast, so every
+        rank stays in lockstep regardless of this value.
         """
         prompts_and_is_end = (None, False)
         if self.global_rank == 0:
@@ -1576,7 +1668,7 @@ class DisaggregatedRolloutControlWorker(RolloutWorkerBase):
             # by config.rollout.prefetch_rollout) can never observe an empty
             # queue concurrently and double-fetch from the controller.
             with self._prompt_fetch_lock:
-                if prompt_queue.empty():
+                if prompt_queue.qsize() < max_pending_batches:
                     # blocking request to get prompts from controller
                     # batch_size is per data parallel rank so we need to multiply it with data parallel size
                     payloads, is_end = self.api_client.get_next_prompt(
@@ -1969,6 +2061,23 @@ class DisaggregatedRolloutControlWorker(RolloutWorkerBase):
         self._mainloop_log_last_ts = time.time()
         self._version_fail_last_log_ts = 0.0
 
+        # Multi-rank prep overlap.  When prefetch is requested but the
+        # worker is multi-rank, the dedicated rank-0 ``_prefetch_loop``
+        # (fetch overlap) is unavailable -- its HTTP fetch ends in a
+        # collective every rank must join.  Instead ``main_loop`` fetches
+        # one batch ahead (in lockstep, via ``request_new_prompts`` with
+        # ``max_pending_batches=2``) and hands the freshly-fetched batch
+        # to ``_submit_prefetch_setup`` so per-prompt ``_prepare_sample``
+        # runs on the mixin's bg setup thread while the batch ahead of it
+        # generates.  Single-process workers (``_single_producer_mode``)
+        # keep the dedicated fetch+prep loop and ``main_loop`` stays
+        # consume-only, so prep_overlap is False for them here.
+        prep_overlap = (
+            self.config.rollout.prefetch_rollout and not self._single_producer_mode
+        )
+        if prep_overlap:
+            self._bind_prefetch_context_once()
+
         while not self.shutdown_signal.is_set():
             self.consume_command(cmd_pred=None)
 
@@ -2007,24 +2116,58 @@ class DisaggregatedRolloutControlWorker(RolloutWorkerBase):
                 self.stream_generation_step()
                 continue
 
-            if not self.state.prompt_fetch_end():
-                pre_qsize = self._prompt_queue.qsize()
-                no_more_prompts = self.request_new_prompts(
-                    self.batch_size,
-                    self._prompt_queue,
-                    rank_in_mesh=self.rank_in_rollout_repicas,
-                )
-                if self._prompt_queue.qsize() > pre_qsize:
-                    self._mainloop_branch_counts["fetched_nonempty"] += 1
-                if no_more_prompts:
-                    logger.info(
-                        f"[Rollout] Receive prompt end, wait for {self.replica_name} to finish all rollouts generation"
+            # In single-producer mode the prefetch thread owns
+            # prompt fetching; ``main_loop`` is consume-only and
+            # ``state.prompt_fetch_end`` is set by the prefetch
+            # thread when the controller signals end-of-prompts.
+            # In legacy mode ``main_loop`` is the producer and
+            # drives ``request_new_prompts`` itself.
+            if not self._single_producer_mode and not self.state.prompt_fetch_end():
+                # Legacy cadence fetches one batch when the queue is
+                # empty (depth 1).  Prep-overlap stages one batch ahead
+                # (depth 2): with a batch already queued, its per-prompt
+                # prep runs on the mixin's bg setup thread while the
+                # batch in front of it generates.  The fetch is a
+                # cross-rank collective, so every rank runs this loop in
+                # lockstep -- the loop bound (queue depth, prompt_fetch_end,
+                # whether the last fetch added a batch) is identical on
+                # all ranks.
+                target_depth = 2 if prep_overlap else 1
+                while (
+                    not self.state.prompt_fetch_end()
+                    and self._prompt_queue.qsize() < target_depth
+                ):
+                    pre_qsize = self._prompt_queue.qsize()
+                    no_more_prompts = self.request_new_prompts(
+                        self.batch_size,
+                        self._prompt_queue,
+                        rank_in_mesh=self.rank_in_rollout_repicas,
+                        max_pending_batches=target_depth,
                     )
-                    self.state.set_prompt_fetch_end()
-                    if self._prompt_queue.empty():
-                        self.state.set_prompt_consume_end()
-                        if self.global_rank == 0:
-                            self.send_end_signal()
+                    made_progress = self._prompt_queue.qsize() > pre_qsize
+                    if made_progress:
+                        self._mainloop_branch_counts["fetched_nonempty"] += 1
+                        # Kick off rank-local _prepare_sample for the
+                        # batch we just enqueued (the deque tail).  No
+                        # collective here -- only the fetch above is in
+                        # lockstep.
+                        if prep_overlap:
+                            self._submit_prefetch_setup(self._prompt_queue.queue[-1])
+                    if no_more_prompts:
+                        logger.info(
+                            f"[Rollout] Receive prompt end, wait for {self.replica_name} to finish all rollouts generation"
+                        )
+                        self.state.set_prompt_fetch_end()
+                        if self._prompt_queue.empty():
+                            self.state.set_prompt_consume_end()
+                            if self.global_rank == 0:
+                                self.send_end_signal()
+                        break
+                    # Controller had nothing to hand out right now: stop
+                    # filling so we don't hot-spin the fetch RPC, and let
+                    # the rest of the loop run.  Retried next iteration.
+                    if not made_progress:
+                        break
 
             if self.state.prompt_consume_end():
                 assert self._prompt_queue.empty() and self.state.prompt_fetch_end(), (
@@ -2058,6 +2201,23 @@ class DisaggregatedRolloutControlWorker(RolloutWorkerBase):
                     self.shutdown_signal.set()
                 continue
             elif self._prompt_queue.empty():
+                # In single-producer mode the queue draining + a
+                # set ``prompt_fetch_end`` means we're done; signal
+                # the controller and let the next iteration hit the
+                # ``prompt_consume_end`` gate above.  Otherwise this
+                # is a transient empty -- prefetch hasn't filled
+                # yet -- and we sleep briefly to avoid busy-waiting
+                # while the producer races to fetch.  In legacy
+                # mode an empty queue here means the controller has
+                # nothing yet; the next iteration's
+                # ``request_new_prompts`` will fetch.
+                if self._single_producer_mode:
+                    if self.state.prompt_fetch_end():
+                        self.state.set_prompt_consume_end()
+                        if self.global_rank == 0:
+                            self.send_end_signal()
+                    else:
+                        time.sleep(0.05)
                 self._mainloop_branch_counts["empty_q"] += 1
                 continue
             else:
@@ -2447,39 +2607,132 @@ class DisaggregatedRolloutControlWorker(RolloutWorkerBase):
                 payload.prompt_token_ids = [t[0:1] for t in payload.prompt_token_ids]
         return payloads
 
-    def _prefetch_loop(self):
-        """Background loop that prefetches the next prompt batch.
-
-        While ``rollout_generation()`` is running, ``main_loop`` is blocked
-        and ``_prompt_queue`` sits empty.  This loop fills the queue in
-        advance so the next ``main_loop`` iteration skips the HTTP fetch
-        round-trip entirely.  When the rollout backend implements
-        ``enqueue_prefetch_payloads(payloads)``, the prefetched payloads are
-        also handed to it so the backend can start processing the next batch
-        before the current one finishes — useful for long-running simulation
-        backends where straggler scenes leave the backend underutilized at
-        the tail of each ``rollout_generation()`` call.
-
-        Only fires when ``config.rollout.prefetch_rollout`` is set; otherwise
-        the thread is never started.
-
-        Limitation: requires single-process rollout workers (DP/TP/PP all
-        == 1).  ``request_new_prompts`` ends with a distributed broadcast
-        that all ranks must participate in; calling that from a background
-        thread on rank 0 only would deadlock multi-rank workers.
+    def _bind_prefetch_context_once(self):
+        """Bind data_packer / data_fetcher into the mixin's prefetch
+        context so the bg setup worker resolves payloads via the same
+        packer the consumer uses.  Idempotent; no-op for backends that
+        don't compose RolloutGenerationMixin.
         """
-        while not self.shutdown_signal.is_set():
-            time.sleep(0.5)
-            if not self.state.weight_synced():
-                continue
-            if self.state.prompt_fetch_end():
-                continue
-            with self._prompt_fetch_lock:
-                if not self._prompt_queue.empty():
-                    continue
-                # ``parallel_dims.mesh["dp"]`` is not reliably resolvable
-                # from a background thread; prefetch_rollout requires DP=1
-                # so the multiplier is always 1.
+        if getattr(self, "_prefetch_context_bound", False):
+            return
+        bind = getattr(self.rollout, "bind_prefetch_context", None)
+        if callable(bind):
+            try:
+                bind(
+                    data_packer=self.data_packer,
+                    data_fetcher=self.data_fetcher,
+                )
+            except Exception:
+                logger.exception(
+                    "[Rollout] bind_prefetch_context failed; "
+                    "prefetch will run with empty context."
+                )
+        self._prefetch_context_bound = True
+
+    def _submit_prefetch_setup(self, payloads):
+        """Hand a freshly-fetched batch to the backend's prefetch setup so
+        per-prompt ``_prepare_sample`` runs on the mixin's bg setup
+        thread, overlapping with in-flight generation on earlier batches.
+
+        Rank-local and keyed by ``prompt_idx`` -- it runs no collective --
+        so it is safe to call from a multi-rank ``main_loop`` (unlike the
+        controller prompt fetch, which must stay in lockstep across
+        ranks).  Backends compose ``RolloutGenerationMixin`` (preferred)
+        or define the legacy ``enqueue_prefetch_payloads`` hook; a backend
+        with neither is legal and simply falls back to inline
+        ``_prepare_sample`` in the consumer.
+        """
+        submit = getattr(self.rollout, "submit_setup", None)
+        if callable(submit):
+            try:
+                submit(payloads)
+            except Exception:
+                logger.exception(
+                    "[Rollout] submit_setup failed for batch of %d",
+                    len(payloads),
+                )
+            return
+        legacy = getattr(self.rollout, "enqueue_prefetch_payloads", None)
+        if callable(legacy):
+            _warn_legacy_prefetch_hook_once()
+            try:
+                legacy(payloads)
+            except Exception:
+                logger.exception(
+                    "[Rollout] enqueue_prefetch_payloads failed for batch of %d",
+                    len(payloads),
+                )
+
+    def _prefetch_loop(self):
+        """Sole producer of ``_prompt_queue`` in single-producer mode.
+
+        Active only when :attr:`_single_producer_mode` is True
+        (``config.rollout.prefetch_rollout`` set + single-process
+        worker; see :meth:`__init__`).  The thread is started from
+        :meth:`work` and runs on global rank 0.
+
+        Per iteration: fetch a prompt batch from the controller,
+        notify the rollout backend via ``submit_setup`` so
+        :class:`RolloutGenerationMixin` can start ``_prepare_sample``
+        on its own bg thread, then ``put`` onto ``_prompt_queue``.
+        Back-pressure is provided by the bounded queue: ``put``
+        blocks when ``main_loop`` is behind, so this thread runs
+        exactly as fast as the consumer drains -- no polling, no
+        ``time.sleep``, no lock.
+
+        ``submit_setup`` is called *before* ``put`` so the bg setup
+        worker has a head start.  By the time ``main_loop`` pops
+        the batch and reaches ``_gather_prepared_samples``, the
+        future is typically done and the consumer waits ~0 ms.
+
+        Backends that haven't migrated to the mixin can still
+        implement the legacy ``enqueue_prefetch_payloads(payloads)``
+        hook on their ``RolloutBase`` subclass; this is supported as
+        a deprecation shim with a one-shot warning at first use.
+
+        Lifecycle:
+          * Wait for first weight-sync (a one-shot sticky bit; we
+            poll only because ``State`` doesn't expose it as an
+            event, and only at startup).
+          * On controller ``is_end=True``, set
+            ``state.prompt_fetch_end`` and exit; ``main_loop``
+            drains the queue and signals consume-end.
+          * On shutdown, exit ASAP; the bounded queue's blocking
+            ``put`` is woken by a small timeout so the thread can
+            check ``shutdown_signal`` even when ``main_loop`` is
+            stuck.
+          * On unexpected exception, set ``prompt_fetch_end`` from
+            ``finally`` so ``main_loop`` doesn't wait forever for
+            a producer that died.
+
+        Multi-rank scope: this thread overlaps the controller *fetch*
+        (the ``get_next_prompt`` HTTP round-trip), which ends in a
+        distributed broadcast/scatter that all ranks must join -- driving
+        it from rank 0 only would deadlock the peers, so the fetch-overlap
+        loop requires ``world_size == 1`` (:attr:`_single_producer_mode`).
+        The *prep* overlap (per-prompt ``_prepare_sample`` on the mixin's
+        bg setup thread) does not need a collective and is available to
+        multi-rank workers too -- see :meth:`_submit_prefetch_setup`,
+        which ``_main_loop_impl`` calls after each in-lockstep fetch.
+        """
+        self._bind_prefetch_context_once()
+
+        # Wait for first weight-sync.  ``State.weight_synced`` is a
+        # sticky bit (set once, never cleared per
+        # ``cosmos_rl/rollout/__init__.py:69``), so a tight poll
+        # here is a one-shot and the loop body below has no
+        # weight-sync gate.
+        while not self.shutdown_signal.is_set() and not self.state.weight_synced():
+            time.sleep(0.05)
+
+        try:
+            while not self.shutdown_signal.is_set():
+                if self.state.prompt_fetch_end():
+                    return
+
+                # Sole producer: no lock, no empty-check (we always
+                # try to fetch the next batch and let the bounded
+                # queue's ``put`` back-pressure us off).
                 try:
                     payloads, is_end = self.api_client.get_next_prompt(
                         self.batch_size,
@@ -2487,14 +2740,20 @@ class DisaggregatedRolloutControlWorker(RolloutWorkerBase):
                     )
                 except Exception:
                     logger.exception("[Rollout] Prefetch fetch failed")
+                    # Backoff to avoid hammering an unhealthy
+                    # controller.  Re-check shutdown immediately on
+                    # the next iteration.
+                    time.sleep(0.5)
                     continue
+
                 if is_end:
                     self.state.set_prompt_fetch_end()
                 if not payloads:
                     continue
+
                 # Mirror request_new_prompts' local_dataset / RLPayload
-                # validation so main_loop sees identical objects when it
-                # pops from the queue.
+                # validation so main_loop sees identical objects when
+                # it pops from the queue.
                 if self.config.train.local_dataset:
                     for payload in payloads:
                         payload["prompt"] = self.data_fetcher.get_payload_by_index(
@@ -2509,26 +2768,36 @@ class DisaggregatedRolloutControlWorker(RolloutWorkerBase):
                             )
                         )
                 payloads = [RLPayload.model_validate(p) for p in payloads]
-                self._prompt_queue.put(payloads)
+
+                # Notify the backend BEFORE put: the bg setup worker
+                # starts preparing samples while we're still preparing
+                # to enqueue, so prep overlaps in-flight generation.
+                self._submit_prefetch_setup(payloads)
+
+                # Blocking put with a small timeout so we stay
+                # responsive to ``shutdown_signal`` even if the
+                # consumer is hung.  ``queue.Full`` is the expected
+                # case during steady-state back-pressure.
+                while not self.shutdown_signal.is_set():
+                    try:
+                        self._prompt_queue.put(payloads, timeout=0.5)
+                        break
+                    except QueueFull:
+                        continue
+                if self.shutdown_signal.is_set():
+                    return
+
                 logger.info(
                     "[Rollout] Prefetched %d payloads (prompt_idxs=%s%s)",
                     len(payloads),
                     [p.prompt_idx for p in payloads[:5]],
                     " ..." if len(payloads) > 5 else "",
                 )
-            # Speculatively notify the backend.  Backends without this hook
-            # (e.g. vllm, trtllm) skip this and only benefit from the
-            # round-trip elision above.
-            enqueue_fn = getattr(self.rollout, "enqueue_prefetch_payloads", None)
-            if enqueue_fn is None:
-                continue
-            try:
-                enqueue_fn(payloads)
-            except Exception:
-                logger.exception(
-                    "[Rollout] enqueue_prefetch_payloads failed for batch of %d",
-                    len(payloads),
-                )
+        finally:
+            # Defensive: if we crash or exit early, set fetch_end so
+            # main_loop doesn't wait forever for a producer that
+            # died.  Idempotent (the bit is sticky).
+            self.state.set_prompt_fetch_end()
 
     def work(self):
         # Start the thread with daemon=True, so it will exit when the main program exits.
@@ -2538,14 +2807,36 @@ class DisaggregatedRolloutControlWorker(RolloutWorkerBase):
                 target=self.query_command_from_controller, daemon=True
             )
             self.background_thread.start()
-            if self.config.rollout.prefetch_rollout:
-                logger.info("[Rollout] Prefetch enabled; starting background thread")
+            if self._single_producer_mode:
+                logger.info(
+                    "[Rollout] Prefetch enabled (single-producer mode); "
+                    "starting background thread"
+                )
                 self.prefetch_thread = threading.Thread(
                     target=self._prefetch_loop,
                     daemon=True,
                     name="rollout-prefetch",
                 )
                 self.prefetch_thread.start()
+            elif self.config.rollout.prefetch_rollout:
+                # Multi-rank worker (world_size>1) with prefetch on.
+                # The dedicated rank-0 ``_prefetch_loop`` can't run here
+                # because its HTTP fetch ends in a distributed
+                # broadcast/scatter that every rank must join, so the
+                # *fetch* overlap stays single-process.  The *prep*
+                # overlap is still active: ``_main_loop_impl`` fetches
+                # one batch ahead (in lockstep across ranks) and hands
+                # it to ``_submit_prefetch_setup`` so per-prompt
+                # ``_prepare_sample`` runs on the mixin's bg setup
+                # thread while earlier batches generate.
+                logger.info(
+                    "[Rollout] config.rollout.prefetch_rollout=True with "
+                    "world_size=%d (>1): per-prompt prep overlap is ENABLED "
+                    "via main_loop look-ahead; the rank-0 fetch-overlap loop "
+                    "stays single-process (set dp/tp/pp/cp=1 to also overlap "
+                    "the controller fetch).",
+                    self.parallel_dims.world_size,
+                )
         if self.config.distillation.enable:
             # create a thread to interact with teacher model
             self.teacher_interact_thread = threading.Thread(

--- a/cosmos_rl/tools/gym_example/README.md
+++ b/cosmos_rl/tools/gym_example/README.md
@@ -39,6 +39,13 @@ is the right shape.
   `gymnasium.Env` into the standard cosmos-rl pipeline.
 * Both **discrete** (CartPole-v1) and **continuous** (Pendulum-v1)
   action spaces.
+* The **rollout-side `RolloutGenerationMixin`** (`cosmos_rl.rollout.
+  generation_mixin`).  `GymRolloutBackend` is the first upstream
+  consumer: it composes the mixin and overrides four hooks
+  (`_prepare_sample`, `_collate_batch`, `_generate`, `_postprocess`)
+  instead of writing a bespoke `rollout_generation`, and gets
+  background per-prompt setup overlap "for free" when
+  `[rollout].prefetch_rollout = true` is set in the config.
 
 ## Layout
 

--- a/cosmos_rl/tools/gym_example/gym_rollout_backend.py
+++ b/cosmos_rl/tools/gym_example/gym_rollout_backend.py
@@ -30,13 +30,12 @@ round-trip, NCCL bring-up) will live in that PR.
 
 from __future__ import annotations
 
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional
 
 import torch
 
-from cosmos_rl.dispatcher.data.data_fetcher import DataFetcherBase
 from cosmos_rl.dispatcher.data.packer.base import BaseDataPacker
-from cosmos_rl.dispatcher.data.schema import RLPayload
+from cosmos_rl.rollout.generation_mixin import RolloutGenerationMixin
 from cosmos_rl.rollout.rollout_base import RolloutBase, RolloutRegistry
 from cosmos_rl.rollout.schema import RolloutResult
 from cosmos_rl.tools.gym_example.gym_policy import GymMLPConfig, GymPolicy
@@ -85,13 +84,17 @@ def _build_default_policy(config: Any) -> GymPolicy:
 
 
 @RolloutRegistry.register(rollout_type="gym")
-class GymRolloutBackend(RolloutBase):
+class GymRolloutBackend(RolloutGenerationMixin, RolloutBase):
     """:class:`RolloutBase` wrapper around :class:`GymRolloutEngine`.
 
-    Holds the env factory, the underlying policy module, and a single
-    :class:`GymRolloutEngine` instance. Each call to
-    :meth:`rollout_generation` runs one episode per payload and packs
-    the resulting trajectory dict into a :class:`RolloutResult`.
+    Composes :class:`RolloutGenerationMixin` so the per-payload
+    preprocessing (parsing the dataset prompt into a ``GymRolloutEngine``
+    init dict) can run on a background thread when
+    ``config.rollout.prefetch_rollout`` is set, overlapping with
+    in-flight episode generation on the main thread.  When the flag is
+    off the four hooks (:meth:`_prepare_sample`, :meth:`_collate_batch`,
+    :meth:`_generate`, :meth:`_postprocess`) run inline; behaviour is
+    identical to the pre-mixin code path.
 
     Init parameters (read from ``config.custom``):
 
@@ -108,7 +111,9 @@ class GymRolloutBackend(RolloutBase):
     def post_init_hook(self, **kwargs: Any) -> None:
         """Resolve the policy and env factory, but defer engine bringup
         to :meth:`init_engine` (matching the LLM rollout backends'
-        contract)."""
+        contract).  Also initializes the
+        :class:`RolloutGenerationMixin` setup worker (no-op when
+        prefetch is disabled)."""
         custom = _resolve_custom(self.config)
         self._env_name: str = str(custom.get("env_name", _DEFAULT_ENV_NAME))
         self._max_steps: int = int(custom.get("max_steps", _DEFAULT_MAX_STEPS))
@@ -119,6 +124,8 @@ class GymRolloutBackend(RolloutBase):
         self._env_factory = kwargs.get("env_factory")
         self._engine: Optional[GymRolloutEngine] = None
         self._model_param_map: Dict[str, torch.Tensor] = {}
+
+        self.setup_generation(thread_name="GymRolloutPrefetch")
 
     def init_engine(
         self,
@@ -162,33 +169,64 @@ class GymRolloutBackend(RolloutBase):
         )
         self._engine_initialized = True
 
-    def rollout_generation(
-        self,
-        payloads: Union[List[RLPayload], List[Dict[str, torch.Tensor]]],
-        stream: Optional[torch.cuda.Stream] = None,
-        data_packer: Optional[BaseDataPacker] = None,
-        data_fetcher: Optional[DataFetcherBase] = None,
-        is_validation: bool = False,
-        *args: Any,
-        **kwargs: Any,
-    ) -> List[RolloutResult]:
-        """Run one episode per payload and pack as :class:`RolloutResult`.
+    # ------------------------------------------------------------------
+    # RolloutGenerationMixin hooks
+    # ------------------------------------------------------------------
 
-        The trajectory dict is placed in ``RolloutResult.completions[0]``
-        so :class:`GymDataPacker` can read it back via the trainer-side
-        ``Rollout.completion`` field. The ``stream`` /
-        ``data_packer`` / ``data_fetcher`` arguments are accepted for
-        API compatibility; the toy backend doesn't need any of them.
+    def _prepare_sample(
+        self,
+        payload: Any,
+        *,
+        data_packer: Optional[BaseDataPacker] = None,
+        data_fetcher: Any = None,
+        is_validation: bool = False,
+    ) -> Dict[str, Any]:
+        """Parse the dataset prompt into a :class:`GymRolloutEngine` init dict.
+
+        Pure CPU work (JSON decode + small dict ops); safe to run on
+        the mixin's background setup thread when prefetch is enabled.
+        """
+        return self._init_for_payload(payload, data_packer)
+
+    def _generate(
+        self,
+        batch: List[Dict[str, Any]],
+        *,
+        stream: Optional[torch.cuda.Stream] = None,
+        is_validation: bool = False,
+    ) -> List[Dict[str, Any]]:
+        """Run one episode per init dict and return the resulting trajectories.
+
+        The mixin's default ``_collate_batch`` is identity, so ``batch``
+        is the list of init dicts produced by :meth:`_prepare_sample`.
+        We don't actually batch through the engine — gym episodes are
+        independent — but iterating here keeps the mixin's four-hook
+        surface consistent across LLM and sim backends.
         """
         assert self._engine is not None, (
-            "[GymRolloutBackend] init_engine() must be called before rollout_generation()."
+            "[GymRolloutBackend] _generate called without an initialized engine."
         )
+        return [self._engine.run(init) for init in batch]
 
+    def _postprocess(
+        self,
+        raw: List[Dict[str, Any]],
+        payloads: List[Any],
+        *,
+        is_validation: bool = False,
+    ) -> List[RolloutResult]:
+        """Wrap each trajectory dict as a :class:`RolloutResult`.
+
+        The trajectory goes into ``completions[0]`` so
+        :class:`GymDataPacker` can read it back via the trainer-side
+        ``Rollout.completion`` field.  The ``prompt`` echoes the init
+        dict (re-derived via :meth:`_prepare_sample` to keep the
+        signature simple and avoid threading the prepared samples
+        through ``_generate`` ↔ ``_postprocess``).
+        """
         results: List[RolloutResult] = []
-        for payload in payloads:
-            init = self._init_for_payload(payload, data_packer)
-            traj = self._engine.run(init)
-            prompt = init  # echo back so RolloutResult.prompt is informative
+        for payload, traj in zip(payloads, raw):
+            prompt = self._init_for_payload(payload, data_packer=None)
             results.append(RolloutResult(prompt=prompt, completions=[traj]))
         return results
 
@@ -209,7 +247,13 @@ class GymRolloutBackend(RolloutBase):
             self._engine.policy = model
 
     def shutdown(self) -> None:
-        """Release the gym env held by the engine."""
+        """Stop the prefetch worker (if running) and release the gym env.
+
+        Order matters: shutting the bg setup worker down first prevents
+        a still-running ``_prepare_sample`` from racing with engine
+        cleanup.
+        """
+        self.shutdown_generation()
         if self._engine is not None:
             self._engine.close()
             self._engine = None

--- a/tests/test_gym_example.py
+++ b/tests/test_gym_example.py
@@ -727,14 +727,246 @@ class TestGymRolloutBackend(unittest.TestCase):
         self.assertIs(backend._engine, engine_a)
         backend.shutdown()
 
-    def test_rollout_generation_before_init_engine_asserts(self):
+    def test_rollout_generation_before_init_engine_raises(self):
+        """Calling rollout_generation before init_engine is a programming
+        error and propagates loudly.  RolloutGenerationMixin's
+        ``_assert_engine_initialized`` raises ``RuntimeError`` outside
+        the template's ``try`` block, so it is not swallowed by
+        ``_on_generation_error``."""
         backend = self._make_backend()
 
         class _Payload:
             prompt = "{}"
 
-        with self.assertRaises(AssertionError):
+        with self.assertRaises(RuntimeError):
             backend.rollout_generation([_Payload()])
+
+
+class TestGymBackendStructured(unittest.TestCase):
+    """Post-migration: ``GymRolloutBackend`` composes
+    :class:`RolloutGenerationMixin`.  Verifies the four hooks fire in
+    the documented order and the returned ``RolloutResult`` shape is
+    unchanged from the pre-mixin code path."""
+
+    def _make_backend(self, terminate_after=3):
+        from cosmos_rl.policy.config import Config as CosmosConfig
+        from cosmos_rl.tools.gym_example.gym_rollout_backend import (
+            GymRolloutBackend,
+        )
+
+        return GymRolloutBackend(
+            CosmosConfig(),
+            parallel_dims=None,
+            device=torch.device("cpu"),
+            policy=GymPolicy(GymMLPConfig(obs_dim=4, action_dim=2, discrete=True)),
+            env_factory=lambda: _FakeDiscreteEnv(
+                obs_dim=4, terminate_after=terminate_after
+            ),
+        )
+
+    def test_inherits_from_rollout_generation_mixin(self):
+        from cosmos_rl.rollout.generation_mixin import RolloutGenerationMixin
+        from cosmos_rl.tools.gym_example.gym_rollout_backend import (
+            GymRolloutBackend,
+        )
+
+        self.assertIn(RolloutGenerationMixin, GymRolloutBackend.__mro__)
+
+    def test_hook_dispatch_order_recorded(self):
+        from cosmos_rl.tools.gym_example.gym_rollout_backend import (
+            GymRolloutBackend,
+        )
+
+        events: list[str] = []
+
+        class _RecordingBackend(GymRolloutBackend):
+            def _prepare_sample(self, *a, **kw):
+                events.append("prepare")
+                return super()._prepare_sample(*a, **kw)
+
+            def _collate_batch(self, *a, **kw):
+                events.append("collate")
+                return super()._collate_batch(*a, **kw)
+
+            def _generate(self, *a, **kw):
+                events.append("generate")
+                return super()._generate(*a, **kw)
+
+            def _postprocess(self, *a, **kw):
+                events.append("postprocess")
+                return super()._postprocess(*a, **kw)
+
+        from cosmos_rl.policy.config import Config as CosmosConfig
+
+        backend = _RecordingBackend(
+            CosmosConfig(),
+            parallel_dims=None,
+            device=torch.device("cpu"),
+            policy=GymPolicy(GymMLPConfig()),
+            env_factory=lambda: _FakeDiscreteEnv(terminate_after=2),
+        )
+        backend.init_engine()
+
+        class _Payload:
+            def __init__(self, prompt, prompt_idx):
+                self.prompt = prompt
+                self.prompt_idx = prompt_idx
+
+        results = backend.rollout_generation(
+            [
+                _Payload('{"seed": 1}', prompt_idx=0),
+                _Payload('{"seed": 2}', prompt_idx=1),
+            ],
+            data_packer=GymDataPacker(),
+        )
+        backend.shutdown()
+
+        # 2 prepare + 1 collate + 1 generate + 1 postprocess.
+        self.assertEqual(
+            events,
+            ["prepare", "prepare", "collate", "generate", "postprocess"],
+        )
+        self.assertEqual(len(results), 2)
+        for r in results:
+            traj = r.completions[0]
+            self.assertIn(OBSERVATIONS, traj)
+            self.assertIn(EPISODE_LENGTH, traj)
+
+    def test_rollout_result_shape_unchanged_after_migration(self):
+        backend = self._make_backend(terminate_after=3)
+        backend.init_engine()
+
+        class _Payload:
+            def __init__(self, prompt, prompt_idx):
+                self.prompt = prompt
+                self.prompt_idx = prompt_idx
+
+        results = backend.rollout_generation(
+            [_Payload('{"seed": 1}', prompt_idx=0)],
+            data_packer=GymDataPacker(),
+        )
+        self.assertEqual(len(results), 1)
+        r = results[0]
+        self.assertEqual(len(r.completions), 1)
+        traj = r.completions[0]
+        self.assertIn(OBSERVATIONS, traj)
+        self.assertIn(ACTIONS, traj)
+        self.assertIn(EPISODE_LENGTH, traj)
+        self.assertEqual(int(traj[EPISODE_LENGTH][0]), 3)
+        # Prompt is the parsed init dict (echoed-back via _postprocess).
+        self.assertEqual(r.prompt, {"seed": 1})
+        backend.shutdown()
+
+
+class TestGymBackendPrefetch(unittest.TestCase):
+    """``prefetch_rollout=True``: ``_prepare_sample`` runs on the bg
+    setup worker.  When ``submit_setup`` is called before
+    ``rollout_generation``, a deliberately slow ``_generate`` for batch
+    B leaves the bg worker enough time to finish prepare for batch
+    B+1 ahead of the next ``rollout_generation`` call."""
+
+    def _make_backend_with_prefetch(self, terminate_after=2):
+        from cosmos_rl.policy.config import Config as CosmosConfig
+        from cosmos_rl.tools.gym_example.gym_rollout_backend import (
+            GymRolloutBackend,
+        )
+
+        cfg = CosmosConfig()
+        cfg.rollout.prefetch_rollout = True
+        return GymRolloutBackend(
+            cfg,
+            parallel_dims=None,
+            device=torch.device("cpu"),
+            policy=GymPolicy(GymMLPConfig(obs_dim=4, action_dim=2, discrete=True)),
+            env_factory=lambda: _FakeDiscreteEnv(
+                obs_dim=4, terminate_after=terminate_after
+            ),
+        )
+
+    def test_prepare_runs_on_bg_thread_when_prefetch_on(self):
+        from cosmos_rl.tools.gym_example.gym_rollout_backend import (
+            GymRolloutBackend,
+        )
+
+        captured_threads: list[str] = []
+
+        class _Recording(GymRolloutBackend):
+            def _prepare_sample(self, *a, **kw):
+                import threading as _t
+
+                captured_threads.append(_t.current_thread().name)
+                return super()._prepare_sample(*a, **kw)
+
+        from cosmos_rl.policy.config import Config as CosmosConfig
+
+        cfg = CosmosConfig()
+        cfg.rollout.prefetch_rollout = True
+        backend = _Recording(
+            cfg,
+            parallel_dims=None,
+            device=torch.device("cpu"),
+            policy=GymPolicy(GymMLPConfig()),
+            env_factory=lambda: _FakeDiscreteEnv(terminate_after=2),
+        )
+        # Bind the data_packer the bg worker should use.
+        backend.bind_prefetch_context(data_packer=GymDataPacker())
+        backend.init_engine()
+
+        class _Payload:
+            def __init__(self, prompt, prompt_idx):
+                self.prompt = prompt
+                self.prompt_idx = prompt_idx
+
+        payloads = [
+            _Payload('{"seed": 1}', prompt_idx=0),
+            _Payload('{"seed": 2}', prompt_idx=1),
+        ]
+        backend.submit_setup(payloads)
+        results = backend.rollout_generation(payloads, data_packer=GymDataPacker())
+        backend.shutdown()
+
+        self.assertEqual(len(results), 2)
+        # All prepare invocations must have run on the bg setup worker
+        # (not on the main test thread).
+        import threading as _t
+
+        main_name = _t.current_thread().name
+        for n in captured_threads:
+            self.assertNotEqual(n, main_name)
+            self.assertEqual(n, "GymRolloutPrefetch")
+
+    def test_setup_thread_started_iff_prefetch_enabled(self):
+        # Off: no setup thread.
+        from cosmos_rl.policy.config import Config as CosmosConfig
+        from cosmos_rl.tools.gym_example.gym_rollout_backend import (
+            GymRolloutBackend,
+        )
+
+        cfg_off = CosmosConfig()
+        backend_off = GymRolloutBackend(
+            cfg_off,
+            parallel_dims=None,
+            device=torch.device("cpu"),
+            policy=GymPolicy(GymMLPConfig()),
+            env_factory=lambda: _FakeDiscreteEnv(terminate_after=2),
+        )
+        self.assertIsNone(backend_off._setup_thread)
+        backend_off.shutdown()
+
+        # On: setup thread is alive.
+        cfg_on = CosmosConfig()
+        cfg_on.rollout.prefetch_rollout = True
+        backend_on = GymRolloutBackend(
+            cfg_on,
+            parallel_dims=None,
+            device=torch.device("cpu"),
+            policy=GymPolicy(GymMLPConfig()),
+            env_factory=lambda: _FakeDiscreteEnv(terminate_after=2),
+        )
+        self.assertIsNotNone(backend_on._setup_thread)
+        self.assertTrue(backend_on._setup_thread.is_alive())
+        backend_on.shutdown()
+        self.assertFalse(backend_on._setup_thread.is_alive())
 
 
 class TestGymEntry(unittest.TestCase):

--- a/tests/test_rollout_generation_mixin.py
+++ b/tests/test_rollout_generation_mixin.py
@@ -1,0 +1,607 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for ``cosmos_rl.rollout.generation_mixin.RolloutGenerationMixin``.
+
+Covers, in order of importance:
+
+* Template-method dispatch (each hook called exactly once per
+  ``rollout_generation``, in the documented order).
+* Inline path (prefetch off): ``_prepare_sample`` runs on the calling
+  thread; behavior is identical to a hand-written
+  ``rollout_generation``.
+* Prefetch path (prefetch on): ``submit_setup`` schedules
+  ``_prepare_sample`` on the bg worker; ``_gather_prepared_samples``
+  awaits the matching future; cold-start payloads (no future for a
+  key) fall back to inline preparation.
+* Overlap: ``_prepare_sample`` for batch B+1 starts before
+  ``_generate`` for batch B finishes.
+* Error propagation: an exception inside ``_prepare_sample`` flows
+  through the future, is re-raised in the consumer thread, and is
+  caught by the template's ``except`` block which routes through
+  ``_on_generation_error``.
+* Lifecycle: ``setup_generation`` is idempotent and
+  ``shutdown_generation`` joins cleanly even with pending futures.
+* Synthetic-throughput assertion: with ``sleep``-stubbed hooks, the
+  prefetch path's wall-clock is reduced by approximately
+  ``(n - 1) * min(p, g)`` versus the inline path.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+import time
+import unittest
+from types import SimpleNamespace
+from typing import Any, Dict, List, Optional
+
+from cosmos_rl.rollout.generation_mixin import RolloutGenerationMixin
+from cosmos_rl.rollout.rollout_base import RolloutBase
+
+
+# ---------------------------------------------------------------------------
+# Fakes
+# ---------------------------------------------------------------------------
+
+
+class _FakePayload:
+    """Minimal payload that satisfies the mixin's default ``_payload_key``."""
+
+    def __init__(self, idx: int, prompt: str = "p") -> None:
+        self.prompt_idx = idx
+        self.prompt = prompt
+
+
+def _fake_config(*, prefetch: bool) -> Any:
+    """Build the smallest object that ``setup_generation`` reads."""
+    return SimpleNamespace(rollout=SimpleNamespace(prefetch_rollout=prefetch))
+
+
+class _FakeBackend(RolloutGenerationMixin, RolloutBase):
+    """Test double that records hook invocations and supports controllable hook delays.
+
+    Avoids the heavy ``RolloutBase.__init__`` chain by overriding the
+    constructor; the mixin doesn't need any of ``RolloutBase``'s
+    abstract-method machinery for these tests.  We register the
+    abstract surface (``post_init_hook``, ``init_engine``,
+    ``get_underlying_model``) trivially.
+    """
+
+    def __init__(
+        self,
+        *,
+        prefetch: bool = False,
+        prep_ms: int = 0,
+        gen_ms: int = 0,
+        fail_prepare_for: Optional[set] = None,
+    ) -> None:
+        self.config = _fake_config(prefetch=prefetch)
+        self.parallel_dims = None
+        self.device = None
+        self._engine_initialized = True  # skip init_engine for unit tests
+        self._prep_ms = prep_ms
+        self._gen_ms = gen_ms
+        self._fail_prepare_for = fail_prepare_for or set()
+        self.events: List[str] = []
+        self._events_lock = threading.Lock()
+        self.thread_names: Dict[str, List[str]] = {
+            "_prepare_sample": [],
+            "_collate_batch": [],
+            "_generate": [],
+            "_postprocess": [],
+        }
+        self.setup_generation(thread_name="FakeBackendPrefetch")
+
+    # The mixin's ``rollout_generation`` is final; the abstract method
+    # on ``RolloutBase`` is satisfied via MRO.
+
+    def post_init_hook(self, **kwargs: Any) -> None:
+        # Unused: bypassed by our custom __init__.
+        pass
+
+    def init_engine(self, *args: Any, **kwargs: Any) -> None:
+        self._engine_initialized = True
+
+    def get_underlying_model(self) -> Any:
+        return None
+
+    # ------------------------------------------------------------------
+    # Hook overrides
+    # ------------------------------------------------------------------
+
+    def _record(self, hook: str) -> None:
+        with self._events_lock:
+            self.events.append(hook)
+            self.thread_names[hook].append(threading.current_thread().name)
+
+    def _prepare_sample(
+        self, payload, *, data_packer=None, data_fetcher=None, is_validation=False
+    ):
+        self._record("_prepare_sample")
+        if payload.prompt_idx in self._fail_prepare_for:
+            raise RuntimeError(
+                f"_prepare_sample boom for prompt_idx={payload.prompt_idx}"
+            )
+        if self._prep_ms:
+            time.sleep(self._prep_ms / 1000.0)
+        return ("prepared", payload.prompt_idx)
+
+    def _collate_batch(self, samples, *, data_packer=None, is_validation=False):
+        self._record("_collate_batch")
+        return ("collated", tuple(samples))
+
+    def _generate(self, batch, *, stream=None, is_validation=False):
+        self._record("_generate")
+        if self._gen_ms:
+            time.sleep(self._gen_ms / 1000.0)
+        return ("generated", batch)
+
+    def _postprocess(self, raw, payloads, *, is_validation=False):
+        self._record("_postprocess")
+        return [("result", p.prompt_idx) for p in payloads]
+
+
+# ---------------------------------------------------------------------------
+# Dispatch / inline path
+# ---------------------------------------------------------------------------
+
+
+class TestTemplateMethodDispatch(unittest.TestCase):
+    """Each hook fires exactly once per ``rollout_generation``, in the
+    documented order, regardless of prefetch state."""
+
+    def _run_dispatch_check(self, prefetch: bool) -> None:
+        backend = _FakeBackend(prefetch=prefetch)
+        try:
+            payloads = [_FakePayload(idx=0), _FakePayload(idx=1)]
+            if prefetch:
+                backend.submit_setup(payloads)
+            results = backend.rollout_generation(payloads)
+            self.assertEqual(
+                results,
+                [("result", 0), ("result", 1)],
+                msg="postprocess output should be 1:1 with payloads in order",
+            )
+            self.assertEqual(
+                backend.events,
+                # 2 prepare + 1 collate + 1 generate + 1 postprocess.
+                [
+                    "_prepare_sample",
+                    "_prepare_sample",
+                    "_collate_batch",
+                    "_generate",
+                    "_postprocess",
+                ],
+            )
+        finally:
+            backend.shutdown_generation()
+
+    def test_dispatch_order_inline(self) -> None:
+        self._run_dispatch_check(prefetch=False)
+
+    def test_dispatch_order_prefetch(self) -> None:
+        self._run_dispatch_check(prefetch=True)
+
+
+class TestInlinePath(unittest.TestCase):
+    """Prefetch off: every hook (including prepare) runs on the calling thread."""
+
+    def test_prepare_runs_on_caller_thread_when_prefetch_off(self) -> None:
+        backend = _FakeBackend(prefetch=False)
+        try:
+            payloads = [_FakePayload(idx=0), _FakePayload(idx=1)]
+            backend.rollout_generation(payloads)
+            caller = threading.current_thread().name
+            for hook, names in backend.thread_names.items():
+                for n in names:
+                    self.assertEqual(
+                        n,
+                        caller,
+                        msg=f"hook {hook} ran on {n!r}, expected {caller!r}",
+                    )
+        finally:
+            backend.shutdown_generation()
+
+    def test_submit_setup_is_noop_when_prefetch_off(self) -> None:
+        backend = _FakeBackend(prefetch=False)
+        try:
+            # Should not crash and should not record any prepare events.
+            backend.submit_setup([_FakePayload(idx=0)])
+            self.assertEqual(backend.events, [])
+        finally:
+            backend.shutdown_generation()
+
+
+# ---------------------------------------------------------------------------
+# Prefetch path
+# ---------------------------------------------------------------------------
+
+
+class TestPrefetchPath(unittest.TestCase):
+    """Prefetch on: ``_prepare_sample`` runs on the bg worker; the main thread
+    only sees collate / generate / postprocess."""
+
+    def test_prepare_runs_on_background_thread(self) -> None:
+        backend = _FakeBackend(prefetch=True)
+        try:
+            payloads = [_FakePayload(idx=0), _FakePayload(idx=1)]
+            backend.submit_setup(payloads)
+            backend.rollout_generation(payloads)
+            caller = threading.current_thread().name
+            for n in backend.thread_names["_prepare_sample"]:
+                self.assertNotEqual(
+                    n,
+                    caller,
+                    msg=f"_prepare_sample ran on caller thread {n!r}; "
+                    "expected the bg worker thread",
+                )
+                self.assertEqual(n, "FakeBackendPrefetch")
+            # collate / generate / postprocess always run on the caller.
+            for hook in ("_collate_batch", "_generate", "_postprocess"):
+                self.assertEqual(backend.thread_names[hook], [caller])
+        finally:
+            backend.shutdown_generation()
+
+    def test_cold_start_payload_falls_back_to_inline_prepare(self) -> None:
+        """A payload arriving at ``rollout_generation`` without a matching
+        ``submit_setup`` runs ``_prepare_sample`` inline."""
+        backend = _FakeBackend(prefetch=True)
+        try:
+            submitted = [_FakePayload(idx=0)]
+            cold = _FakePayload(idx=99)
+            backend.submit_setup(submitted)
+            backend.rollout_generation([submitted[0], cold])
+            caller = threading.current_thread().name
+            # Two prepare invocations: one bg (for idx=0), one inline (for idx=99).
+            self.assertEqual(len(backend.thread_names["_prepare_sample"]), 2)
+            self.assertIn(caller, backend.thread_names["_prepare_sample"])
+            self.assertIn(
+                "FakeBackendPrefetch", backend.thread_names["_prepare_sample"]
+            )
+        finally:
+            backend.shutdown_generation()
+
+    def test_resubmission_replaces_pending_future(self) -> None:
+        """Submitting the same key twice replaces the prior future; the
+        consumer awaits the latest one."""
+        backend = _FakeBackend(prefetch=True)
+        try:
+            p = _FakePayload(idx=42)
+            backend.submit_setup([p])
+            backend.submit_setup([p])  # replace
+            results = backend.rollout_generation([p])
+            self.assertEqual(results, [("result", 42)])
+            # At least one prepare ran (the cancelled prior one may or may
+            # not have raced through depending on timing).
+            self.assertGreaterEqual(len(backend.thread_names["_prepare_sample"]), 1)
+        finally:
+            backend.shutdown_generation()
+
+
+class TestOverlap(unittest.TestCase):
+    """The bg worker keeps making progress while the main thread is in
+    ``_generate``."""
+
+    def test_prepare_for_next_batch_overlaps_with_generate(self) -> None:
+        # Slow generate (200ms), fast prepare (50ms each).  Submit batch B+1
+        # *before* calling rollout_generation(B), then verify B+1's prepare
+        # finished while B's generate was running.
+        backend = _FakeBackend(prefetch=True, prep_ms=50, gen_ms=200)
+        try:
+            b1 = [_FakePayload(idx=0)]
+            b2 = [_FakePayload(idx=1)]
+            backend.submit_setup(b1)
+            backend.submit_setup(b2)
+
+            # Run B1; meanwhile bg is preparing B1[0] -> B2[0].
+            t0 = time.monotonic()
+            backend.rollout_generation(b1)
+            t1 = time.monotonic()
+
+            # By now, bg should have done both prepares (50ms + 50ms = 100ms,
+            # well within B1's gather (50ms) + generate (200ms) = 250ms).
+            with backend._setup_futures_lock:
+                self.assertIn(("idx", 1), backend._setup_futures)
+                self.assertTrue(
+                    backend._setup_futures[("idx", 1)].done(),
+                    msg="B2[0] prepare should be done by the time B1 finishes",
+                )
+
+            # Sanity: B1's wall clock should still cover the gather + generate
+            # (~250ms), not double that (which would imply the bg never
+            # progressed during generate).
+            self.assertGreater(t1 - t0, 0.20)
+            self.assertLess(t1 - t0, 0.50)
+        finally:
+            backend.shutdown_generation()
+
+
+# ---------------------------------------------------------------------------
+# Error propagation
+# ---------------------------------------------------------------------------
+
+
+class TestErrorPropagation(unittest.TestCase):
+    """Exceptions in the data-shaping hooks flow to ``_on_generation_error``;
+    ``rollout_generation`` returns ``[]`` instead of crashing the worker.
+
+    Engine-not-initialized is *not* swallowed; that's a programming
+    error and propagates as ``RuntimeError``.
+    """
+
+    def test_prepare_failure_returns_empty_inline(self) -> None:
+        backend = _FakeBackend(prefetch=False, fail_prepare_for={1})
+        try:
+            payloads = [_FakePayload(idx=0), _FakePayload(idx=1)]
+            results = backend.rollout_generation(payloads)
+            self.assertEqual(results, [])
+            # _generate / _postprocess should NOT have run.
+            self.assertEqual(backend.thread_names["_generate"], [])
+            self.assertEqual(backend.thread_names["_postprocess"], [])
+        finally:
+            backend.shutdown_generation()
+
+    def test_prepare_failure_returns_empty_prefetch(self) -> None:
+        backend = _FakeBackend(prefetch=True, fail_prepare_for={1})
+        try:
+            payloads = [_FakePayload(idx=0), _FakePayload(idx=1)]
+            backend.submit_setup(payloads)
+            results = backend.rollout_generation(payloads)
+            self.assertEqual(results, [])
+        finally:
+            backend.shutdown_generation()
+
+    def test_engine_not_initialized_propagates(self) -> None:
+        backend = _FakeBackend(prefetch=False)
+        backend._engine_initialized = False
+        try:
+            with self.assertRaises(RuntimeError):
+                backend.rollout_generation([_FakePayload(idx=0)])
+        finally:
+            backend.shutdown_generation()
+
+    def test_subclass_preflight_check_propagates(self) -> None:
+        """Backends extending ``_preflight_check`` get loud propagation
+        outside the template's ``try``/``except``.
+        """
+
+        class _Picky(_FakeBackend):
+            def _preflight_check(self) -> None:
+                super()._preflight_check()
+                raise RuntimeError("policy not attached")
+
+        backend = _Picky(prefetch=False)
+        try:
+            with self.assertRaisesRegex(RuntimeError, "policy not attached"):
+                backend.rollout_generation([_FakePayload(idx=0)])
+            # _generate / _postprocess must not have run.
+            self.assertEqual(backend.thread_names["_generate"], [])
+            self.assertEqual(backend.thread_names["_postprocess"], [])
+        finally:
+            backend.shutdown_generation()
+
+
+# ---------------------------------------------------------------------------
+# Lifecycle
+# ---------------------------------------------------------------------------
+
+
+class TestLifecycle(unittest.TestCase):
+    def test_setup_generation_is_idempotent(self) -> None:
+        backend = _FakeBackend(prefetch=True)
+        try:
+            first_thread = backend._setup_thread
+            backend.setup_generation()  # second call
+            backend.setup_generation()  # third call
+            self.assertIs(backend._setup_thread, first_thread)
+            self.assertTrue(backend._setup_thread.is_alive())
+        finally:
+            backend.shutdown_generation()
+
+    def test_shutdown_generation_is_safe_when_not_initialized(self) -> None:
+        backend = _FakeBackend.__new__(_FakeBackend)
+        # Don't call any setup; just confirm shutdown doesn't blow up.
+        backend.shutdown_generation()  # no-op
+
+    def test_shutdown_generation_clears_pending_futures(self) -> None:
+        backend = _FakeBackend(prefetch=True, prep_ms=200)
+        # Submit but do NOT consume; then shut down.
+        payloads = [_FakePayload(idx=i) for i in range(5)]
+        backend.submit_setup(payloads)
+        backend.shutdown_generation()
+        # After shutdown, no futures should remain in the map.
+        self.assertEqual(backend._setup_futures, {})
+        # And the worker thread should have exited.
+        self.assertFalse(backend._setup_thread.is_alive())
+
+
+# ---------------------------------------------------------------------------
+# Synthetic-throughput assertion
+# ---------------------------------------------------------------------------
+
+
+class TestPrefetchThroughputSynthetic(unittest.TestCase):
+    """Stub-hook microbenchmark: prefetch should reduce wall-clock by
+    approximately ``(n - 1) * min(p, g)`` compared to the inline path,
+    where ``n`` is the number of batches and ``p`` / ``g`` are the
+    per-payload prepare time and per-batch generate time.
+
+    The assertion is loose (>= 30% of the theoretical max) to tolerate
+    GIL contention, thread-startup overhead, and CI scheduler noise.
+    The point is to catch a *regression* of the prefetch mechanism (e.g.
+    accidentally running prepare on the main thread), not to claim a
+    specific real-world speedup.
+    """
+
+    def _measure(
+        self, prefetch: bool, n_batches: int, batch_size: int, prep_ms: int, gen_ms: int
+    ) -> float:
+        backend = _FakeBackend(prefetch=prefetch, prep_ms=prep_ms, gen_ms=gen_ms)
+        try:
+            batches = [
+                [_FakePayload(idx=b * batch_size + i) for i in range(batch_size)]
+                for b in range(n_batches)
+            ]
+            if prefetch:
+                # Mirror what the rollout worker's _prefetch_loop does:
+                # submit every batch up-front so the bg worker has work
+                # queued ahead of the consumer.
+                for batch in batches:
+                    backend.submit_setup(batch)
+            t0 = time.monotonic()
+            for batch in batches:
+                backend.rollout_generation(batch)
+            return time.monotonic() - t0
+        finally:
+            backend.shutdown_generation()
+
+    def test_prefetch_reduces_wallclock(self) -> None:
+        n_batches = 4
+        batch_size = 1
+        prep_ms = 50
+        gen_ms = 50
+        # Theoretical: inline = n*(p+g); prefetch = (p+g) + (n-1)*max(p, g).
+        # Win = (n-1)*min(p, g) = 3 * 50ms = 150ms out of 400ms.
+        inline = self._measure(False, n_batches, batch_size, prep_ms, gen_ms)
+        prefetch = self._measure(True, n_batches, batch_size, prep_ms, gen_ms)
+        win = inline - prefetch
+        theoretical_max_win = (n_batches - 1) * min(prep_ms, gen_ms) / 1000.0
+        # Require at least 30% of theoretical max to absorb noise.
+        self.assertGreater(
+            win,
+            0.30 * theoretical_max_win,
+            msg=(
+                f"prefetch did not noticeably reduce wall-clock: "
+                f"inline={inline * 1000:.1f}ms, prefetch={prefetch * 1000:.1f}ms, "
+                f"win={win * 1000:.1f}ms, theoretical_max={theoretical_max_win * 1000:.1f}ms"
+            ),
+        )
+
+
+class _ListHandler(logging.Handler):
+    """Minimal handler that just appends formatted records to a list.
+    Avoids ``assertLogs`` pitfalls when interacting with cosmos's
+    pre-configured default logger."""
+
+    def __init__(self) -> None:
+        super().__init__(level=logging.DEBUG)
+        self.records: List[str] = []
+
+    def emit(self, record: logging.LogRecord) -> None:
+        self.records.append(record.getMessage())
+
+
+class TestTraceEmission(unittest.TestCase):
+    """The per-batch ``[mixin-trace]`` DEBUG line is the contract that
+    downstream analyzers parse to prove prefetch is overlapping.  Any
+    change to its shape or fields is a public-surface break.
+    """
+
+    def _wire_logger(self, backend, level: int = logging.DEBUG) -> _ListHandler:
+        """Replace backend._gen_logger with a clean isolated logger so
+        we don't fight cosmos's default logger / handler config.
+        """
+        test_logger = logging.getLogger(
+            f"test_mixin_trace.{self._testMethodName}.{id(backend)}"
+        )
+        test_logger.handlers.clear()
+        test_logger.setLevel(level)
+        test_logger.propagate = False
+        handler = _ListHandler()
+        test_logger.addHandler(handler)
+        backend._gen_logger = test_logger
+        return handler
+
+    def test_trace_line_present_at_debug_level(self) -> None:
+        backend = _FakeBackend(prefetch=False, prep_ms=5, gen_ms=5)
+        handler = self._wire_logger(backend, logging.DEBUG)
+        try:
+            backend.rollout_generation([_FakePayload(idx=0), _FakePayload(idx=1)])
+        finally:
+            backend.shutdown_generation()
+        mixin_lines = [m for m in handler.records if "[mixin-trace]" in m]
+        self.assertEqual(
+            len(mixin_lines),
+            1,
+            f"expected exactly one trace line, got: {mixin_lines!r} (all records: {handler.records!r})",
+        )
+
+    def test_trace_line_silent_above_debug(self) -> None:
+        backend = _FakeBackend(prefetch=False, prep_ms=0, gen_ms=0)
+        handler = self._wire_logger(backend, logging.INFO)
+        try:
+            backend.rollout_generation([_FakePayload(idx=0)])
+        finally:
+            backend.shutdown_generation()
+        mixin_lines = [m for m in handler.records if "[mixin-trace]" in m]
+        self.assertEqual(
+            mixin_lines,
+            [],
+            f"trace line leaked above DEBUG level: {mixin_lines!r}",
+        )
+
+    def test_trace_fields_present_inline(self) -> None:
+        backend = _FakeBackend(prefetch=False, prep_ms=5, gen_ms=5)
+        handler = self._wire_logger(backend, logging.DEBUG)
+        try:
+            backend.rollout_generation([_FakePayload(idx=0), _FakePayload(idx=1)])
+        finally:
+            backend.shutdown_generation()
+        mixin_lines = [m for m in handler.records if "[mixin-trace]" in m]
+        self.assertEqual(len(mixin_lines), 1, f"records: {handler.records!r}")
+        line = mixin_lines[0]
+        for field in (
+            "batch_size=2",
+            "prefetch=False",
+            "gather_ms=",
+            "collate_ms=",
+            "generate_ms=",
+            "postprocess_ms=",
+            "inline_count=2",
+            "inline_ms=",
+            "wait_count=0",
+            "wait_ms=0.00",
+        ):
+            self.assertIn(field, line, f"missing {field!r} in trace line: {line}")
+
+    def test_trace_fields_present_prefetch(self) -> None:
+        backend = _FakeBackend(prefetch=True, prep_ms=5, gen_ms=5)
+        handler = self._wire_logger(backend, logging.DEBUG)
+        try:
+            payloads = [_FakePayload(idx=i) for i in range(2)]
+            backend.submit_setup(payloads)
+            # Let the bg worker drain so wait_ms ≈ 0 (full overlap).
+            time.sleep(0.05)
+            backend.rollout_generation(payloads)
+        finally:
+            backend.shutdown_generation()
+        mixin_lines = [m for m in handler.records if "[mixin-trace]" in m]
+        self.assertEqual(len(mixin_lines), 1, f"records: {handler.records!r}")
+        line = mixin_lines[0]
+        # With prefetch on AND bg worker drained before
+        # rollout_generation, every payload's future should be ready
+        # so wait_count=2 but wait_ms should be tiny.  inline_count=0.
+        for field in (
+            "batch_size=2",
+            "prefetch=True",
+            "inline_count=0",
+            "wait_count=2",
+        ):
+            self.assertIn(field, line, f"missing {field!r} in trace line: {line}")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_rollout_prefetch_loop_integration.py
+++ b/tests/test_rollout_prefetch_loop_integration.py
@@ -1,0 +1,486 @@
+"""Integration tests for ``RolloutWorkerBase._prefetch_loop`` ↔ ``submit_setup`` wiring.
+
+These tests cover the seam that the unit tests in
+``test_rollout_generation_mixin.py`` deliberately don't: the
+:class:`~cosmos_rl.rollout.worker.rollout_control.DisaggregatedRolloutControlWorker`
+side of the prefetch contract.  The mixin tests prove that *if*
+``submit_setup`` is called, ``_gather_prepared_samples`` will see a
+ready future; this file proves that the worker's prefetch loop
+*actually* calls ``submit_setup`` -- once per fetched batch, before
+the batch is enqueued, with the same payload objects the consumer
+will later pop.
+
+Background
+----------
+Before the single-producer-mode refactor, the worker had two
+producers for ``_prompt_queue``: ``main_loop`` (via
+``request_new_prompts``) and ``_prefetch_loop``.  Only the latter
+called ``submit_setup``, and it lost ~98% of races because of a 500
+ms polling sleep + uncoordinated lock placement.  Cluster runs
+showed prefetch firing on 8 of 500 batches -- the bridge appeared
+broken even though every individual unit test passed.
+
+The lesson: the integration call site (``RolloutWorkerBase`` →
+``RolloutGenerationMixin``) needed its own test, not just tests
+that *mock* it.  These tests are that.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+import unittest
+from queue import Queue
+from types import SimpleNamespace
+from typing import Any, List, Tuple
+from unittest.mock import MagicMock
+
+from cosmos_rl.rollout import State
+from cosmos_rl.rollout.worker.rollout_control import (
+    DisaggregatedRolloutControlWorker,
+)
+
+
+def _make_worker_for_prefetch(
+    *,
+    api_responses: List[Tuple[List[dict], bool]],
+    submit_setup_recorder: List[List[dict]],
+    queue_max: int = 2,
+    on_submit_delay_ms: float = 0.0,
+    fail_submit_for_idxs: set = None,
+) -> Any:
+    """Construct a stripped-down worker just sufficient to drive ``_prefetch_loop``.
+
+    We bypass ``DisaggregatedRolloutControlWorker.__init__`` (which
+    loads HuggingFace model configs, registers atexit handlers,
+    creates CUDA streams, ...) and set only the attributes the
+    prefetch loop reads.  This keeps the test hermetic and fast --
+    no GPU, no controller, no model files.
+
+    Parameters
+    ----------
+    api_responses
+        List of ``(payloads_dict_list, is_end)`` tuples returned in
+        order by the fake ``api_client.get_next_prompt``.  After the
+        list is exhausted the test drives the loop to ``is_end=True``
+        on its own.
+    submit_setup_recorder
+        Caller-owned list that ``self.rollout.submit_setup`` appends
+        each batch's payloads to (in call order).  Used to assert
+        ordering and per-batch coverage.
+    queue_max
+        ``maxsize`` for the bounded ``_prompt_queue``.  Defaults to 2
+        to mirror the production single-producer-mode default.
+    on_submit_delay_ms
+        Optional artificial delay inside ``submit_setup`` to widen
+        the put-after-submit window for ordering tests.
+    fail_submit_for_idxs
+        Set of ``prompt_idx`` values for which ``submit_setup``
+        should raise.  The loop must still ``put`` despite the
+        exception (consumer falls back to inline prep).
+    """
+    fail_submit_for_idxs = fail_submit_for_idxs or set()
+
+    worker = DisaggregatedRolloutControlWorker.__new__(
+        DisaggregatedRolloutControlWorker
+    )
+
+    worker.shutdown_signal = threading.Event()
+    worker.state = State()
+    # Skip the startup weight-sync wait by setting the sticky bit.
+    worker.state.set_weight_synced()
+
+    worker.batch_size = 2
+    worker.rank_in_rollout_repicas = 0
+    worker._prompt_queue = Queue(maxsize=queue_max)
+
+    # Minimal config: only the ``train.local_dataset`` flag is read
+    # by the prefetch loop body.  Setting it False skips the
+    # data_fetcher.get_payload_by_index branch entirely.
+    worker.config = SimpleNamespace(
+        train=SimpleNamespace(local_dataset=False),
+    )
+    worker.data_packer = MagicMock(name="data_packer")
+    worker.data_fetcher = MagicMock(name="data_fetcher")
+
+    # api_client.get_next_prompt: returns queued responses in order,
+    # then keeps returning ``([], True)`` so the loop sets
+    # ``prompt_fetch_end`` and exits cleanly.
+    response_iter = iter(api_responses)
+
+    def _get_next_prompt(batch_size, **kwargs):
+        try:
+            return next(response_iter)
+        except StopIteration:
+            return ([], True)
+
+    worker.api_client = SimpleNamespace(get_next_prompt=_get_next_prompt)
+
+    # Fake rollout backend: records bind_prefetch_context/submit_setup
+    # calls.  Mimics the surface a RolloutGenerationMixin-composing
+    # backend would expose.
+    bind_called = threading.Event()
+    submit_lock = threading.Lock()
+
+    def _submit_setup(payloads):
+        # Simulate the bg setup worker getting kicked off; the real
+        # mixin returns immediately after queueing futures, so this
+        # should be near-instant in practice.  We record the call
+        # before any optional delay so assertions on order are
+        # robust.
+        with submit_lock:
+            submit_setup_recorder.append(list(payloads))
+        if on_submit_delay_ms:
+            time.sleep(on_submit_delay_ms / 1000.0)
+        for p in payloads:
+            if p.prompt_idx in fail_submit_for_idxs:
+                raise RuntimeError(f"submit_setup boom for prompt_idx={p.prompt_idx}")
+
+    worker.rollout = SimpleNamespace(
+        bind_prefetch_context=lambda **kw: bind_called.set(),
+        submit_setup=_submit_setup,
+    )
+    worker._bind_called = bind_called
+
+    return worker
+
+
+def _make_payload_dict(prompt_idx: int) -> dict:
+    """Minimum dict that ``RLPayload.model_validate`` accepts."""
+    return {
+        "prompt_idx": prompt_idx,
+        "prompt": f"prompt-{prompt_idx}",
+        "completion": "",
+        "weight_version": 0,
+    }
+
+
+class TestPrefetchLoopSubmitSetupWiring(unittest.TestCase):
+    """The seam: prefetch loop must notify the backend for every fetched batch.
+
+    Each test runs ``_prefetch_loop`` in its own thread, drives a
+    fake controller, and asserts on the side-channel
+    ``submit_setup_recorder``.
+    """
+
+    def _run_loop_and_drain(
+        self, worker: Any, *, expect_batches: int
+    ) -> List[List[Any]]:
+        """Start the prefetch thread, drain ``_prompt_queue`` like
+        ``main_loop`` would, and return the popped batches in order.
+
+        Bounded ``_prompt_queue`` means the producer back-pressures
+        when we don't drain; if we never drain, the loop blocks
+        forever on ``put``.  A real ``main_loop`` is the consumer
+        here.
+        """
+        thread = threading.Thread(target=worker._prefetch_loop, daemon=True)
+        thread.start()
+
+        popped: List[List[Any]] = []
+        deadline = time.monotonic() + 5.0
+        while len(popped) < expect_batches and time.monotonic() < deadline:
+            try:
+                batch = worker._prompt_queue.get(timeout=0.5)
+                popped.append(batch)
+            except Exception:  # queue.Empty
+                continue
+
+        # Signal shutdown and wait for the thread to exit.  The loop
+        # checks ``shutdown_signal`` between fetches and inside the
+        # bounded-put inner loop, so it should exit promptly.
+        worker.shutdown_signal.set()
+        thread.join(timeout=3.0)
+        self.assertFalse(
+            thread.is_alive(),
+            "prefetch_loop did not exit within 3s of shutdown_signal",
+        )
+        return popped
+
+    def test_submit_setup_called_for_every_batch(self) -> None:
+        """One submit_setup call per fetched batch -- the most basic invariant.
+
+        Pre-refactor this passed ~2% of the time (``main_loop``'s
+        non-notifying ``request_new_prompts`` produced most batches).
+        Post-refactor it must pass 100%.
+        """
+        recorder: List[List[dict]] = []
+        worker = _make_worker_for_prefetch(
+            api_responses=[
+                ([_make_payload_dict(0), _make_payload_dict(1)], False),
+                ([_make_payload_dict(2), _make_payload_dict(3)], False),
+                ([_make_payload_dict(4), _make_payload_dict(5)], True),
+            ],
+            submit_setup_recorder=recorder,
+        )
+        popped = self._run_loop_and_drain(worker, expect_batches=3)
+
+        self.assertEqual(len(recorder), 3, "submit_setup once per batch")
+        self.assertEqual(len(popped), 3, "consumer should see all 3 batches")
+        # Per-batch payloads must match (same prompt_idxs in order).
+        for submitted, popped_batch in zip(recorder, popped):
+            self.assertEqual(
+                [p.prompt_idx for p in submitted],
+                [p.prompt_idx for p in popped_batch],
+                "submit_setup and put must see the same payload objects",
+            )
+
+    def test_submit_setup_runs_before_put(self) -> None:
+        """Ordering: submit_setup must fire before the corresponding put.
+
+        Race detection: we widen the submit_setup-to-put window with
+        an artificial delay inside ``submit_setup`` and confirm the
+        consumer can't pop the batch before the recorder sees it.
+        """
+        recorder: List[List[dict]] = []
+        worker = _make_worker_for_prefetch(
+            api_responses=[
+                ([_make_payload_dict(10), _make_payload_dict(11)], True),
+            ],
+            submit_setup_recorder=recorder,
+            on_submit_delay_ms=100.0,  # widen the ordering window
+        )
+
+        thread = threading.Thread(target=worker._prefetch_loop, daemon=True)
+        thread.start()
+
+        # Wait until submit_setup fires (we'll see the recorder grow).
+        deadline = time.monotonic() + 3.0
+        while not recorder and time.monotonic() < deadline:
+            time.sleep(0.005)
+        self.assertEqual(
+            len(recorder), 1, "submit_setup should fire promptly after fetch"
+        )
+
+        # The put should happen *after* submit_setup completes, not
+        # before.  With a 100 ms delay inside submit_setup, the
+        # batch must remain unavailable to the consumer until ~100 ms
+        # has elapsed.  We give a generous budget but assert the
+        # ordering via "submit recorded first, then put visible".
+        # Trying to pop *now* (immediately after recorder grew) may
+        # succeed or fail depending on how far through the delay we
+        # are; what we assert is just: pop succeeds eventually, and
+        # the recorder was non-empty before the pop unblocked.
+        popped = worker._prompt_queue.get(timeout=2.0)
+        self.assertEqual(
+            [p.prompt_idx for p in popped],
+            [p.prompt_idx for p in recorder[0]],
+            "popped batch must match the just-submitted batch",
+        )
+
+        worker.shutdown_signal.set()
+        thread.join(timeout=3.0)
+
+    def test_bind_prefetch_context_called_on_loop_start(self) -> None:
+        """The mixin's bg worker needs the data_packer/data_fetcher
+        bound before the first submit_setup arrives, otherwise the
+        bg thread runs ``_prepare_sample`` with ``None`` packer.
+        """
+        recorder: List[List[dict]] = []
+        worker = _make_worker_for_prefetch(
+            api_responses=[
+                ([_make_payload_dict(0), _make_payload_dict(1)], True),
+            ],
+            submit_setup_recorder=recorder,
+        )
+        thread = threading.Thread(target=worker._prefetch_loop, daemon=True)
+        thread.start()
+        # bind should fire before the first fetch.
+        self.assertTrue(
+            worker._bind_called.wait(timeout=2.0),
+            "bind_prefetch_context must be called before fetching prompts",
+        )
+        worker.shutdown_signal.set()
+        thread.join(timeout=3.0)
+
+    def test_prompt_fetch_end_set_on_is_end(self) -> None:
+        """When the controller signals end-of-prompts, the loop must
+        set the sticky ``state.prompt_fetch_end`` so ``main_loop``
+        knows it can drain the queue and exit.
+        """
+        recorder: List[List[dict]] = []
+        worker = _make_worker_for_prefetch(
+            api_responses=[
+                ([_make_payload_dict(0), _make_payload_dict(1)], False),
+                ([_make_payload_dict(2), _make_payload_dict(3)], True),
+            ],
+            submit_setup_recorder=recorder,
+        )
+        self._run_loop_and_drain(worker, expect_batches=2)
+        self.assertTrue(
+            worker.state.prompt_fetch_end(),
+            "is_end=True must propagate to state.prompt_fetch_end",
+        )
+
+    def test_prompt_fetch_end_set_on_loop_exit_via_finally(self) -> None:
+        """Defensive: even if the loop exits unexpectedly (e.g. an
+        unhandled bug, or shutdown without is_end), ``prompt_fetch_end``
+        must be set so ``main_loop`` doesn't wait forever for a
+        producer that died.
+        """
+        recorder: List[List[dict]] = []
+        # Empty api_responses + shutdown immediately -> loop sets
+        # prompt_fetch_end via the StopIteration->is_end=True branch
+        # OR via the finally clause.  Either way, the bit must be
+        # set.
+        worker = _make_worker_for_prefetch(
+            api_responses=[],
+            submit_setup_recorder=recorder,
+        )
+        thread = threading.Thread(target=worker._prefetch_loop, daemon=True)
+        thread.start()
+        # Let the loop fetch the empty/is_end response, then signal
+        # shutdown for good measure.
+        time.sleep(0.1)
+        worker.shutdown_signal.set()
+        thread.join(timeout=3.0)
+        self.assertFalse(thread.is_alive(), "loop should exit promptly")
+        self.assertTrue(
+            worker.state.prompt_fetch_end(),
+            "prompt_fetch_end must be set on loop exit, even on shutdown",
+        )
+
+    def test_submit_setup_failure_does_not_block_put(self) -> None:
+        """If ``submit_setup`` raises (backend bug), the loop must
+        still ``put`` so the consumer can fall back to inline prep.
+        Losing a batch entirely on a backend error is much worse
+        than just losing the prep overlap for that batch.
+        """
+        recorder: List[List[dict]] = []
+        worker = _make_worker_for_prefetch(
+            api_responses=[
+                ([_make_payload_dict(0), _make_payload_dict(1)], False),
+                ([_make_payload_dict(2), _make_payload_dict(3)], True),
+            ],
+            submit_setup_recorder=recorder,
+            fail_submit_for_idxs={0},  # first batch's submit_setup raises
+        )
+        popped = self._run_loop_and_drain(worker, expect_batches=2)
+        self.assertEqual(len(popped), 2, "both batches must reach the queue")
+        # Both batches must still be recorder-visible (submit_setup
+        # was attempted; the recorder records before raising).
+        self.assertEqual(len(recorder), 2)
+
+    def test_bounded_queue_back_pressure(self) -> None:
+        """``put`` blocks when the bounded queue is full; the producer
+        runs at the consumer's pace.  This is the back-pressure
+        mechanism that replaces the old 500 ms polling sleep.
+        """
+        recorder: List[List[dict]] = []
+        # Many batches, small queue.  Producer should not race ahead.
+        n_batches = 6
+        responses = [
+            (
+                [_make_payload_dict(2 * i), _make_payload_dict(2 * i + 1)],
+                i == n_batches - 1,
+            )
+            for i in range(n_batches)
+        ]
+        worker = _make_worker_for_prefetch(
+            api_responses=responses,
+            submit_setup_recorder=recorder,
+            queue_max=1,  # tighter than production default for the test
+        )
+
+        thread = threading.Thread(target=worker._prefetch_loop, daemon=True)
+        thread.start()
+
+        # Sleep without draining: queue should fill to maxsize=1 and
+        # producer should block on put.  After this sleep,
+        # exactly 1 batch should be queued and 1 submit_setup
+        # should have been recorded (the one currently blocked on
+        # put), or possibly 2 (the one in-queue plus the one stuck
+        # at put).  The strict invariant is that submit_setup has
+        # NOT been called n_batches times yet.
+        time.sleep(0.3)
+        self.assertLess(
+            len(recorder),
+            n_batches,
+            "producer must not race ahead of bounded queue",
+        )
+
+        # Drain: pop one at a time and verify the producer keeps up.
+        popped = []
+        deadline = time.monotonic() + 5.0
+        while len(popped) < n_batches and time.monotonic() < deadline:
+            try:
+                batch = worker._prompt_queue.get(timeout=0.5)
+                popped.append(batch)
+            except Exception:
+                continue
+
+        worker.shutdown_signal.set()
+        thread.join(timeout=3.0)
+        self.assertEqual(len(popped), n_batches, "all batches reach consumer")
+        self.assertEqual(len(recorder), n_batches, "submit_setup once per batch")
+
+
+class TestSingleProducerModeIsLive(unittest.TestCase):
+    """``_single_producer_mode`` must reflect live config, not a snapshot.
+
+    Backends that compose ``RolloutBase`` may flip
+    ``config.rollout.prefetch_rollout`` from ``post_init_hook``, which
+    runs *after* ``DisaggregatedRolloutControlWorker.__init__`` via the
+    ``RolloutBase`` machinery.  An earlier revision snapshotted
+    ``_single_producer_mode`` in ``__init__``, so the worker captured
+    the pre-override value (``False``) and silently fell into the
+    ``elif self.config.rollout.prefetch_rollout:`` branch in ``work()``,
+    producing a misleading ``world_size=1 > 1`` warning and leaving
+    the prefetch path disabled despite the user requesting it.  The
+    fix converts ``_single_producer_mode`` from a cached attribute to
+    a ``@property`` that reads the live config; this test pins that.
+    """
+
+    def _make_minimal_worker(
+        self, *, prefetch_rollout: bool, world_size: int = 1
+    ) -> Any:
+        """Bypass __init__ and set just enough state for the property."""
+        worker = DisaggregatedRolloutControlWorker.__new__(
+            DisaggregatedRolloutControlWorker
+        )
+        worker.config = SimpleNamespace(
+            rollout=SimpleNamespace(prefetch_rollout=prefetch_rollout)
+        )
+        worker.parallel_dims = SimpleNamespace(world_size=world_size)
+        return worker
+
+    def test_property_reads_live_config(self) -> None:
+        """Mutating config after construction must change the property's
+        return value.  This is the load-bearing invariant.
+        """
+        w = self._make_minimal_worker(prefetch_rollout=False, world_size=1)
+        self.assertFalse(
+            w._single_producer_mode,
+            "should be False when prefetch_rollout=False",
+        )
+        # Simulate post_init_hook flipping the flag.
+        w.config.rollout.prefetch_rollout = True
+        self.assertTrue(
+            w._single_producer_mode,
+            "post-override flip must be observable through the property; "
+            "if this fails, _single_producer_mode is being snapshotted again",
+        )
+
+    def test_property_false_when_world_size_gt_one(self) -> None:
+        """Multi-rank workers fall back to legacy mode regardless of
+        prefetch_rollout, because ``request_new_prompts`` runs a
+        distributed broadcast that the single rank-0 background
+        thread can't drive.
+        """
+        w = self._make_minimal_worker(prefetch_rollout=True, world_size=4)
+        self.assertFalse(w._single_producer_mode)
+
+    def test_property_true_only_for_world_size_one_and_prefetch_on(self) -> None:
+        for prefetch, ws, expected in [
+            (False, 1, False),
+            (True, 1, True),
+            (False, 4, False),
+            (True, 4, False),
+        ]:
+            with self.subTest(prefetch=prefetch, world_size=ws):
+                w = self._make_minimal_worker(prefetch_rollout=prefetch, world_size=ws)
+                self.assertEqual(w._single_producer_mode, expected)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
**Branch:** `feat/rollout-generation-mixin` (currently at `c9b2183`)
**Base:** `upstream/main` (`c35f517`), but stacked on PR #689 and the UCXX PR (see below)
**Relationship:**
- **Stacked on PR #689** (`feat/gym-example-trainer`) — the gym example is the first in-tree adopter of the mixin.  Two commits from #689 (`7706326`, `95b35db`) appear in this branch's `upstream/main..HEAD` until #689 merges; they drop naturally on rebase.
- **Stacked on the UCXX PR** (`feat/ucxx-single-chunk-rotation`) — the UCXX single-chunk commit (`c9b2183` here, `acec19a` on the standalone branch — same content, different SHA due to rebase) is included so this branch is self-sufficient for bench runs.  Drops on rebase once the UCXX PR merges.
- **Final standalone contribution: one commit** (`96941ac`) once both prerequisite PRs land.

Suggested merge order: PR #689 → UCXX PR → this PR.

---

## Summary

Adds **`RolloutGenerationMixin`** for `RolloutBase` subclasses that structures `rollout_generation` via five hooks and overlaps per-prompt preprocessing with in-flight generation when `config.rollout.prefetch_rollout` is set.  Bundles in **eight independent controller-rollout robustness fixes** debugged alongside the mixin during the May-2026 bench cycle.

The two concerns are combined because they share hunks in `cosmos_rl/rollout/worker/rollout_control.py` (prefetch-loop instrumentation: Trace A/B/C, branch counters, `_prompt_queue` peeks) and were bench-validated together.  Splitting them on a hunk basis produced an awkward "subset" commit that wasn't a clean cherry-pick; combining them keeps the provenance honest.

## Background

### Why a mixin

Today every `RolloutBase` subclass implements its own `rollout_generation` loop end-to-end, duplicating the prompt-pull → preflight → generate → postprocess scaffolding.  This makes it hard to add cross-cutting features (prefetch, instrumentation, retry policy) without N-way drift.  `RolloutGenerationMixin` reifies the loop in five hooks (`_preflight_check`, `_prepare_sample`, `_collate_batch`, `_generate`, `_postprocess`) so subclasses contribute the workload-specific pieces and the mixin owns the orchestration.

### Why prefetch

On the disaggregated single-prompt path the rollout worker spends N ms per prompt on preprocessing (tokenisation, image decode, prompt rewrites) before reaching `generate()`.  When `generate()` itself is also CPU-bound between kernel launches, the prep cost serialises the loop and inflates per-iteration latency.  Prefetch overlaps the next prompt's preprocessing with the current generation, on the same worker thread, using a small bounded queue.  Opt-in via `config.rollout.prefetch_rollout` so subclasses that don't want it pay no cost.

### Why eight robustness fixes

The May-2026 bench cycle surfaced eight independent controller-rollout correctness / stability issues, each reproducible and small enough to land alongside the mixin work:

- `samples_on_the_fly` over-counting drove the controller's soft throttle to engage spuriously.
- Wedged controllers left workers hot-spinning the `prompt_consume_end` branch indefinitely.
- A wedged controller's `unregister` could block worker exit.
- Heartbeat subprocesses outlived their parent on SIGSEGV and lied to the controller.
- The end-of-run mesh-rebuild could try to include dead replicas in the new mesh.
- Etc.

Each is described in the commit body and is self-contained (could be reverted independently).

## Changes

### Commit `96941ac` — RolloutGenerationMixin + prefetch + robustness

**Prefetch mixin** (`cosmos_rl/rollout/worker/rollout_generation_mixin.py` + plumbing):

- Five hooks: `_preflight_check`, `_prepare_sample`, `_collate_batch`, `_generate`, `_postprocess`.
- Opt-in via `config.rollout.prefetch_rollout`; reads the flag **live** (not snapshotted in `__init__`) so subclasses can flip it from `post_init_hook`.
- Single-producer-mode property + bounded `_prompt_queue` for overlap.
- Trace A (per-iteration branch counters), Trace B (queue depth), Trace C (per-generation entry/exit) at DEBUG.

**Controller-rollout robustness fixes**:

- **Controller `samples_on_the_fly` accounting** — decrement on `filter_outdated_rollouts` discards; decrement `train_ack` by the actual per-step dispatch count via `dispatched_rollouts_by_step` (was sized by `train_batch_per_replica * arrived_replicas`, equal on normal steps but zero on `is_fake_last_cmd`); include in-flight samples in `recompute_total_steps`.
- **Rollout main_loop** — set `shutdown_signal` on `prompt_consume_end()` (mirrors the async path; previously a crashed controller left workers hot-spinning the consume_end branch indefinitely); 50 ms backoff after weight-version rejection (was busy-spinning until the next P→R broadcast).
- **Rollout teardown** — bound `unregister` / `post_heartbeat` / daemon joins with timeouts so a wedged controller can't prevent worker exit; skip `BuildMeshCommand` when this replica is draining (defence-in-depth for the controller-side filter below).
- **Controller end-of-run mesh management** — filter `RolloutStatusManager.unregister`'s BuildMesh recipient set to live survivors only (`not status.ended`) and require `>= 2` survivors before triggering rebuild.
- **Process lifecycle** — `PR_SET_PDEATHSIG` on the heartbeat subprocess so a parent SIGSEGV doesn't leave it orphaned and lying to the controller; opt-in `COSMOS_SHUTDOWN_ON_NO_POLICY_REPLICAS` to exit the controller when all policy replicas are dead (off by default to preserve dynamic-replica deployments).
- **Log hygiene** — soft-throttle engagement / heartbeat / release events + paired Trace D dispatch-state snapshot for the silent throttle path; Trace E for the controller-side filter decisions.

### Commit `c9b2183` — UCXX single-chunk + client rotation

Same content as `feat/ucxx-single-chunk-rotation`'s `acec19a`; see that PR.  Included here so this branch is self-sufficient for bench runs.  Drops on rebase once that PR merges.

## Validation

### Local CPU test suite (driver: `pytest -q --tb=short` on branch tip `c9b2183`)

| File | Result |
|---|---|
| `tests/test_rollout_generation_mixin.py` (16 tests incl. `test_prefetch_throughput_synthetic`, `test_subclass_preflight_check_propagates`) | passed |
| `tests/test_rollout_prefetch_loop_integration.py` | passed |
| `tests/test_put_rollouts.py` | passed |
| `tests/test_gym_example.py::TestGymBackendStructured` + `::TestGymBackendPrefetch` | passed |
| `tests/test_ucxx_*` (UCXX commit) | 55 passed / 1 skipped |
| Stack total | **171 passed / 1 skipped / 180 subtests** |

### Bench validation

rl-gym companion branch `feat/rollout-generation-mixin` carries the `SimpleRolloutWorker` / `ModularRolloutWorker` adopters plus the bench matrix.  May-2026 cycle's headline numbers are paste-ready in `rl-gym/docs/BENCHMARKS.md`.  Five disaggregated reruns confirmed each robustness fix eliminates its corresponding wedge mode.

### Caveats

- **The robustness portion has thin direct unit-test coverage** — `test_put_rollouts.py` is the only CPU-runnable test that imports any of the eight changed controller/dispatcher modules.  The dispatch-accounting / soft-throttle / `RolloutStatusManager.unregister` filter changes are validated by the May-2026 bench cycle (see commit body).  Multi-rank integration tests (`test_policy_overfit`, `test_policy_to_rollout`) gate this on the CI side.
- **Local-only `Failed to import VLLM Rollout` log line** — benign, pre-existing, caused by the local venv not having `vllm` installed.  Not introduced by this PR.

### Known follow-up (not blocking)

Bench data revealed a separate **NCCL P2R recv backlog stalls the inference stream** on the rollout side when the trainer is fast.  This is a downstream effect that limits prefetch's measured upside in the May-2026 matrix to 5–7% (vs. the historical 17%), not a correctness issue.  Investigation is complete; fix lives outside this stack and will ship as a separate PR.  Cross-references:

- `rl-gym/docs/PREFETCH.md` carries a note that prefetch's observed tail-latency cost is downstream of this bug, not intrinsic to prefetch.
- Smoking-gun bench artefact: rollout_0 `generate_ms=50026.17` on job `28243035` (vs. typical ~2,500 ms).
- Three candidate fixes documented in `cosmos_rl_in_flight.md`.

## Test plan

- [ ] full CI matrix green — especially `test_policy_overfit`, `test_policy_to_rollout`, `test_context_parallel` (multi-GPU NCCL paths that exercise the controller-rollout protocol).
- [ ] reviewer sanity-check on the eight robustness fixes — each is self-contained and could be reverted independently if needed.
- [ ] reviewer sanity-check on the live `prefetch_rollout` flag read (deliberately not snapshotted in `__init__` so subclasses can flip from `post_init_hook` — verify this is the contract you want).
- [ ] rebase once PR #689 lands (drops the two gym-example commits).
- [ ] rebase once the UCXX PR lands (drops `c9b2183`).
- [ ] confirm bench numbers reproduce on a clean cluster via rl-gym `feat/rollout-generation-mixin` companion branch.
