### PR TITLE
feat: controller-rollout robustness + explicit StopCommand shutdown + UCXX teardown

### DIFF
--- a/cosmos_rl/colocated/controller.py
+++ b/cosmos_rl/colocated/controller.py
@@ -267,6 +267,17 @@ class ColocatedController(Controller):
             bool: Whether weight synchronization is needed.
         """
         step = self.current_step
+        if step >= self.total_steps and not self.config.validation.enable:
+            logger.info(
+                "[Controller] Colocated training reached final step %s/%s; "
+                "skipping final weight sync and stopping rollout locally.",
+                step,
+                self.total_steps,
+            )
+            self.rollout.shutdown_signal.set()
+            self.rollout.shutdown_mp_signal.set()
+            return False
+
         # All replicas have been reduced, trigger allreduce
         need_sync_weight = step % self.config.train.sync_weight_interval == 0
         # If the current step is the last step, we need to sync weight always to act as ending signal

--- a/cosmos_rl/comm/base.py
+++ b/cosmos_rl/comm/base.py
@@ -468,6 +468,60 @@ class CommMixin:
         )
 
     def heartbeat_trigger(self, shutdown_signal: threading.Event):
+        # Ensure this daemon process dies when its parent dies, including
+        # on abnormal parent termination (SIGSEGV, SIGKILL, OOM-kill).
+        # ``mp.Process(daemon=True)`` only kills the child via
+        # ``atexit`` handlers in the parent; any signal that bypasses
+        # ``atexit`` (notably SIGSEGV in C extensions) leaves the daemon
+        # orphaned and reparented to init.  An orphaned heartbeat keeps
+        # posting, so the controller's ``maintain_life_status`` never
+        # marks the replica dead and the whole job waits for the
+        # orchestrator's wall-clock timeout.
+        #
+        # ``PR_SET_PDEATHSIG`` asks the kernel to deliver SIGKILL to this
+        # process when the parent dies (reparenting to init counts as
+        # parent death).  Linux-only; gracefully no-op on other OSes.
+        # See prctl(2) for kernel semantics.
+        try:
+            import os
+            import signal as _signal
+            import ctypes
+
+            PR_SET_PDEATHSIG = 1  # from <linux/prctl.h>
+            _libc = ctypes.CDLL("libc.so.6", use_errno=True)
+            # Capture the parent pid BEFORE the prctl call so we can
+            # detect the racy case where the parent died between
+            # mp.Process.start() and our first instruction.
+            _orig_ppid = os.getppid()
+            if _libc.prctl(PR_SET_PDEATHSIG, _signal.SIGKILL, 0, 0, 0) != 0:
+                logger.warning(
+                    "[heartbeat] prctl(PR_SET_PDEATHSIG) failed: errno=%d; "
+                    "daemon will not auto-die if parent crashes",
+                    ctypes.get_errno(),
+                )
+            elif os.getppid() != _orig_ppid:
+                # Parent died between mp.Process.start() and the prctl
+                # call.  ``PR_SET_PDEATHSIG`` only fires on the
+                # subsequent parent death, not for a death that already
+                # happened, so we have to exit explicitly here.
+                logger.warning(
+                    "[heartbeat] parent died during heartbeat startup "
+                    "(orig_ppid=%d current_ppid=%d); exiting",
+                    _orig_ppid,
+                    os.getppid(),
+                )
+                os._exit(0)
+        except Exception as e:
+            # Most likely: non-Linux dev environment (no libc.so.6 / no
+            # prctl).  Log once and continue; on Linux this branch
+            # should be unreachable.
+            logger.warning(
+                "[heartbeat] could not install PR_SET_PDEATHSIG (%s); "
+                "daemon will not auto-die if parent crashes -- expected "
+                "outside Linux, investigate if seen on cluster nodes",
+                e,
+            )
+
         while True:
             self.api_client.post_heartbeat(self.replica_name)
 

--- a/cosmos_rl/dispatcher/api/client.py
+++ b/cosmos_rl/dispatcher/api/client.py
@@ -173,6 +173,16 @@ class APIClient(object):
             raise e
 
     def unregister(self, replica_name: str):
+        # ``unregister`` is called on the shutdown path (handle_shutdown).
+        # ``requests.post`` with no ``timeout`` blocks forever when the
+        # controller is wedged (e.g. event loop frozen by another bug),
+        # which then deadlocks worker teardown -- the worker process
+        # never reaches ``destroy_distributed()`` and its UCXX server
+        # threads keep polling until the orchestrator hard-kills the
+        # job.  Cap the per-attempt time and retry only a few times:
+        # best-effort cleanup, not a correctness requirement (the
+        # controller will GC the replica via heartbeat timeout if this
+        # fails).
         try:
             make_request_with_retry(
                 partial(
@@ -183,12 +193,19 @@ class APIClient(object):
                     timeout=constant.COSMOS_CONTROL_HTTP_TIMEOUT,
                 ),
                 self.get_alternative_urls(COSMOS_API_UNREGISTER_SUFFIX),
-                max_retries=self.max_retries,
+                max_retries=3,
             )
         except Exception as e:
             logger.error(f"Failed to unregister from controller: {e}")
 
     def post_heartbeat(self, replica_name: str):
+        # Per-attempt timeout matters here too: the heartbeat daemon
+        # blocks shutdown_signal polling while inside ``requests.post``,
+        # so an unresponsive controller would keep the heartbeat
+        # process alive (and ``heartbeat_thread.join()`` hung) for the
+        # full configurable retry chain.  10s is generous relative to a
+        # healthy controller round-trip while still ensuring the daemon
+        # checks shutdown_signal at most every ~10s.
         try:
             make_request_with_retry(
                 partial(

--- a/cosmos_rl/dispatcher/command.py
+++ b/cosmos_rl/dispatcher/command.py
@@ -32,6 +32,7 @@ class CommandType(StrEnum):
     POLICY_TO_ROLLOUT_UNICAST = "POLICY_TO_ROLLOUT_UNICAST"
     ROLLOUT_TO_ROLLOUT_BROADCAST = "ROLLOUT_TO_ROLLOUT_BROADCAST"
     DATA_FETCH = "DATA_FETCH"
+    TRAINING_COMPLETE = "TRAINING_COMPLETE"
     ALL_REDUCE = "ALL_REDUCE"
     STOP = "STOP"
     VALIDATE = "VALIDATE"
@@ -80,6 +81,10 @@ class Command(ABC):
             sub_cls = RolloutToRolloutBroadcastCommand
         elif dict_v["command_type"] == CommandType.DATA_FETCH:
             sub_cls = DataFetchCommand
+        elif dict_v["command_type"] == CommandType.TRAINING_COMPLETE:
+            sub_cls = TrainingCompleteCommand
+        elif dict_v["command_type"] == CommandType.STOP:
+            sub_cls = StopCommand
 
         if sub_cls is None:
             raise ValueError(f"Unknown command type: {dict_v['command_type']}")
@@ -379,6 +384,50 @@ class RolloutToRolloutBroadcastCommand(Command):
         return cls(**dict_v)
 
 
+class StopCommand(Command):
+    """Explicit, NCCL-free end-of-job signal for a rollout replica.
+
+    Published over the redis command channel (``publish_command``) -- the
+    same path as every other dispatcher command -- so it is delivered to a
+    rollout via ``query_command_from_controller`` -> ``_command_queue`` ->
+    ``consume_command`` at the top of ``main_loop``.  Crucially this reaches
+    a rollout *regardless of whether it is fetching prompts*: a rank wedged
+    on the weight-version gate (head-of-queue prompt tagged at a weight
+    version that will never arrive once training is finished) never
+    re-fetches and therefore never observes the prompt-stream ``is_end`` --
+    STOP is the only signal that unblocks it.
+
+    Unlike the ``RolloutToRolloutBroadcastCommand`` stop (which rides on a
+    P2R->R2R weight-sync NCCL collective and is suppressed on the final
+    non-validation step), STOP triggers no collective, so it cannot orphan
+    an in-flight P2R/R2R recv or wedge ``ncclCommAbort``.
+
+    ``consume_one_command`` broadcasts the dequeued command across ranks via
+    ``broadcast_object_cpu``, so all ranks of a multi-rank worker receive
+    STOP at the same collective call and leave ``main_loop`` in lockstep --
+    so a multi-rank worker needs no separate drain-vote collective to exit
+    together.
+    """
+
+    def __init__(self, replica_name: str, **kwargs):
+        kwargs["scope"] = CommandScope.GLOBAL
+        kwargs["command_type"] = CommandType.STOP
+        super().__init__(**kwargs)
+        self.replica_name = replica_name
+
+    replica_name: str
+
+    @classmethod
+    def trigger(cls, replicas: List[Replica], redis_handler: RedisStreamHandler):
+        for replica in replicas:
+            cmd = cls(replica.name)
+            redis_handler.publish_command(cmd.pack(), replica.name)
+
+    @classmethod
+    def from_dict(cls, dict_v: Dict):
+        return cls(**dict_v)
+
+
 class DataFetchCommand(Command):
     """
     Used to fetch data from the controller.
@@ -455,6 +504,82 @@ class DataFetchCommand(Command):
         cmd = cls(
             replica.name,
             items_count,
+            global_step,
+            total_steps,
+            remain_samples_num,
+            do_save,
+            replica.sub_profiler_config.do_profile,
+            replica.sub_profiler_config.active_steps,
+            replica.sub_profiler_config.rank_filter,
+            replica.sub_profiler_config.record_shape,
+            replica.sub_profiler_config.profile_memory,
+            replica.sub_profiler_config.with_stack,
+            replica.sub_profiler_config.with_modules,
+        )
+        redis_handler.publish_command(cmd.pack(), replica.name)
+
+    def replica_should_stop(self):
+        if self.global_step is not None and self.total_steps is not None:
+            return self.global_step >= self.total_steps
+        return False
+
+    @classmethod
+    def from_dict(cls, dict_v: Dict):
+        return cls(**dict_v)
+
+
+class TrainingCompleteCommand(Command):
+    """Explicit end-of-training signal for the policy at genuine end-of-data.
+
+    Replaces the former ``is_fake_last_cmd`` ``DataFetchCommand`` with
+    ``items_count=0``.  The policy skips ``step_training``, sends ``train_ack``,
+    and exits when ``global_step >= total_steps``.
+    """
+
+    def __init__(
+        self,
+        replica_name: str,
+        global_step: int,
+        total_steps: int,
+        remain_samples_num: int,
+        do_save: bool = False,
+        do_profile: Optional[bool] = None,
+        active_steps: Optional[int] = None,
+        rank_filter: Optional[List[int]] = None,
+        record_shape: Optional[bool] = None,
+        profile_memory: Optional[bool] = None,
+        with_stack: Optional[bool] = None,
+        with_modules: Optional[bool] = None,
+        **kwargs,
+    ):
+        kwargs["scope"] = CommandScope.LOCAL
+        kwargs["command_type"] = CommandType.TRAINING_COMPLETE
+        super().__init__(**kwargs)
+        self.replica_name = replica_name
+        self.global_step = global_step
+        self.total_steps = total_steps
+        self.remain_samples_num = remain_samples_num
+        self.do_save = do_save
+        self.do_profile = do_profile
+        self.active_steps = active_steps
+        self.rank_filter = rank_filter
+        self.record_shape = record_shape
+        self.profile_memory = profile_memory
+        self.with_stack = with_stack
+        self.with_modules = with_modules
+
+    @classmethod
+    def trigger(
+        cls,
+        replica: Replica,
+        global_step: int,
+        total_steps: int,
+        remain_samples_num: int,
+        do_save: bool,
+        redis_handler: RedisStreamHandler,
+    ):
+        cmd = cls(
+            replica.name,
             global_step,
             total_steps,
             remain_samples_num,

--- a/cosmos_rl/dispatcher/controller.py
+++ b/cosmos_rl/dispatcher/controller.py
@@ -73,6 +73,12 @@ class Controller:
         # nccl error check
         self.post_ncclerror_policy_invoke_id = 0
         self.post_ncclerror_rollout_invoke_id = 0
+        # Soft-throttle dedup state (see _update_soft_throttle_state).
+        # ``_soft_throttle_engaged_since`` is None when not engaged, else
+        # wall-clock ts of entry; ``_soft_throttle_last_log_ts`` is the
+        # last time we emitted a heartbeat while engaged.
+        self._soft_throttle_engaged_since: Optional[float] = None
+        self._soft_throttle_last_log_ts: float = 0.0
 
     def _init_dist(self):
         self.config = None
@@ -242,6 +248,68 @@ maxmemory-policy allkeys-lfu
     ) -> Tuple[List[RLPayload], bool]:
         return await self._get_batched_prompt_impl(n, validation_step, rank_in_mesh)
 
+    _SOFT_THROTTLE_HEARTBEAT_S = 5.0
+
+    def _update_soft_throttle_state(
+        self,
+        *,
+        engaged: bool,
+        current_pending: int,
+        threshold: int,
+        allowed_outdated_steps: int,
+        rollouts_per_global_batch: int,
+    ) -> None:
+        """Emit entry / heartbeat / exit logs for the non-DAPO soft throttle.
+
+        The throttle silently returns ``payloads=[]`` to rollout workers
+        whenever ``samples_on_the_fly >= threshold`` and
+        ``outdated_rollout_fetch_batch_size == 0`` (the common config),
+        which is invisible in the controller log.  This helper makes the
+        transitions audible without flooding: log on entry, then once
+        every ``_SOFT_THROTTLE_HEARTBEAT_S`` seconds while still engaged,
+        plus a release line when the counter drops back below the
+        threshold.
+        """
+        now = time.time()
+        if engaged:
+            if self._soft_throttle_engaged_since is None:
+                self._soft_throttle_engaged_since = now
+                self._soft_throttle_last_log_ts = now
+                logger.info(
+                    "[Controller] Soft throttle ENGAGED: "
+                    "samples_on_the_fly=%d >= threshold=%d "
+                    "(allowed_outdated_steps=%d, "
+                    "rollouts_per_global_batch=%d); rollout workers will "
+                    "receive empty payload lists until the counter drops.",
+                    current_pending,
+                    threshold,
+                    allowed_outdated_steps,
+                    rollouts_per_global_batch,
+                )
+            elif (
+                now - self._soft_throttle_last_log_ts >= self._SOFT_THROTTLE_HEARTBEAT_S
+            ):
+                self._soft_throttle_last_log_ts = now
+                duration = now - self._soft_throttle_engaged_since
+                logger.info(
+                    "[Controller] Soft throttle still engaged after %.1fs: "
+                    "samples_on_the_fly=%d threshold=%d",
+                    duration,
+                    current_pending,
+                    threshold,
+                )
+        else:
+            if self._soft_throttle_engaged_since is not None:
+                duration = now - self._soft_throttle_engaged_since
+                self._soft_throttle_engaged_since = None
+                logger.info(
+                    "[Controller] Soft throttle RELEASED after %.1fs: "
+                    "samples_on_the_fly=%d < threshold=%d",
+                    duration,
+                    current_pending,
+                    threshold,
+                )
+
     async def _get_batched_prompt_impl(
         self,
         n: int,
@@ -254,6 +322,28 @@ maxmemory-policy allkeys-lfu
         # teardown.  Without this guard, global_batch_size becomes 0 and
         # downstream asserts / divisions crash the controller.
         if len(self.policy_status_manager) == 0:
+            if is_validation:
+                if self.data_fetcher.activated_val_iter is None:
+                    logger.warning(
+                        "[Controller] No policy replicas registered during "
+                        "validation prompt fetch for step %s, and no active "
+                        "validation dataloader remains; signaling validation "
+                        "end.",
+                        validation_step,
+                    )
+                    return [], True
+                logger.info(
+                    "[Controller] Serving validation prompt fetch for step %s "
+                    "after policy replicas unregistered; final validation must "
+                    "complete before rollout shutdown.",
+                    validation_step,
+                )
+                return self.data_fetcher.get_batched_prompt(
+                    n,
+                    validation_step,
+                    rank_in_mesh,
+                    weight_version=None,
+                )
             logger.warning(
                 "[Controller] No policy replicas registered. "
                 "Assuming training is finished; signaling end of rollouts."
@@ -288,18 +378,35 @@ maxmemory-policy allkeys-lfu
             # 1. Detect the current left pending rollouts in all policy replicas.
             # 2. Check the config.train.train_policy.allowed_outdated_steps.
             # 3. If the current pending rollouts is larger than the allowed outdated version count, reduce the number of prompts to generate.
-            if (
-                current_pending_rollouts
-                >= (self.config.train.train_policy.allowed_outdated_steps + 1)
-                * rollouts_per_global_batch
-            ) and self.config.train.train_policy.variant != "dapo":
+            allowed_outdated_steps = (
+                self.config.train.train_policy.allowed_outdated_steps
+            )
+            soft_throttle_threshold = (
+                allowed_outdated_steps + 1
+            ) * rollouts_per_global_batch
+            soft_throttle_engaged = (
+                current_pending_rollouts >= soft_throttle_threshold
+                and self.config.train.train_policy.variant != "dapo"
+            )
+            self._update_soft_throttle_state(
+                engaged=soft_throttle_engaged,
+                current_pending=current_pending_rollouts,
+                threshold=soft_throttle_threshold,
+                allowed_outdated_steps=allowed_outdated_steps,
+                rollouts_per_global_batch=rollouts_per_global_batch,
+            )
+            if soft_throttle_engaged:
+                original_n = n
                 n = min(
                     n,
                     self.config.train.train_policy.outdated_rollout_fetch_batch_size,
                 )
-                if n > 0:
+                # Only emit the legacy "n reduced from X to Y > 0" warning
+                # when the throttle clamps to a non-zero batch.  The n == 0
+                # case is now covered by _update_soft_throttle_state above.
+                if 0 < n < original_n:
                     logger.warning(
-                        f"[Controller] Current pending rollouts {current_pending_rollouts} is larger than the allowed outdated version count {self.config.train.train_policy.allowed_outdated_steps * len(self.policy_status_manager)}. Generate with batch {n}"
+                        f"[Controller] Current pending rollouts {current_pending_rollouts} is larger than the allowed outdated version count {allowed_outdated_steps * len(self.policy_status_manager)}. Generate with batch {n}"
                     )
             if (
                 self.config.train.train_policy.variant == "dapo"
@@ -466,6 +573,38 @@ maxmemory-policy allkeys-lfu
                 current_fetch_count * self.config.rollout.n_generation
             )
 
+        # Unified end-of-job signal: step-bounded runs (``max_num_steps`` <
+        # ``steps_by_dataset``) never exhaust the dataset, so ``is_end`` from
+        # the data fetcher only ever fires on epoch exhaustion (data-bounded).
+        # Without this, step-bounded rollouts have no NCCL-free way to stop and
+        # used to rely on a forced last-step weight sync ("ending signal") that
+        # races rollout teardown and wedges ``ncclCommAbort`` (see
+        # rollout_multirank_shutdown.md).  Asserting ``is_end`` once training is
+        # finished routes BOTH cases through the same prompt-stream
+        # ``prompt_consume_end`` stop path (keyed on ``prompt_fetch_end``);
+        # the explicit ``StopCommand`` broadcast is the cross-rank backstop
+        # for any rank that never observes ``is_end``.
+        #
+        # Safe against starvation: the controller advances ``current_step``
+        # only at dispatch time, and only after it has buffered enough rollouts
+        # for that step.  So by the time ``training_finished()`` is true every
+        # rollout the run needs has already been generated and handed to the
+        # policy; asserting ``is_end`` here only stops *surplus* speculative
+        # generation.
+        #
+        # Scoped to non-validation fetches AND non-validation runs: when
+        # validation is enabled the final validation is driven by the
+        # controller R2R broadcast (``is_final_validation``) and the rollout's
+        # self-terminate paths are intentionally disabled, so that case keeps
+        # its existing controller-broadcast shutdown untouched (symmetric with
+        # the ``trigger_weight_sync`` / STOP-broadcast validation gating).
+        if (
+            not is_validation
+            and not self.config.validation.enable
+            and self.policy_status_manager.training_finished()
+        ):
+            is_end = True
+
         return payloads_list, is_end
 
     async def set_profile(self, request: SetProfileRequest):
@@ -525,10 +664,25 @@ maxmemory-policy allkeys-lfu
 
         # Print pending rollouts inside all policy replicas
         pending_count = self.policy_status_manager.total_pending_rollouts()
+        in_flight_count = self.policy_status_manager.samples_on_the_fly
+        outdated_filtered_count = self.policy_status_manager.filter_records.get(
+            "outdated", 0
+        )
 
         elapsed_time_in_seconds = time.time() - self.begin_time
+        # ``pending_count`` is what's queued in rollout_buffer awaiting the
+        # trainer; ``in_flight_count`` (samples_on_the_fly) is the throttle
+        # input — prompts dispatched but not yet trained-on, including
+        # both rollouts mid-flight on workers and rollouts in the buffer.
+        # Drift in ``in_flight_count`` against ``outdated_filtered_count``
+        # is the leading indicator of soft-throttle pinning.
         logger.info(
-            f"[Controller] Stat: {self.stat_n_samples} samples, {self.stat_completion_tokens_count} completion tokens, {pending_count} pending rollouts, {elapsed_time_in_seconds} seconds elapsed"
+            f"[Controller] Stat: {self.stat_n_samples} samples, "
+            f"{self.stat_completion_tokens_count} completion tokens, "
+            f"{pending_count} pending rollouts, "
+            f"{in_flight_count} in-flight, "
+            f"{outdated_filtered_count} filtered (outdated), "
+            f"{elapsed_time_in_seconds:.2f}s elapsed"
         )
 
     """

--- a/cosmos_rl/dispatcher/data/data_fetcher.py
+++ b/cosmos_rl/dispatcher/data/data_fetcher.py
@@ -448,6 +448,7 @@ class ControllerDataFetcher(DataFetcherBase):
             0 if self.val_dataset is None else len(self.val_dataset.val_set)
         )
         self.val_iters: Dict[int, Iterator] = {}
+        self.activated_val_step: Optional[int] = None
         self.activated_val_iter: Optional[Iterator] = None
         self.activated_val_tqdm: Optional[tqdm] = None
 
@@ -639,11 +640,13 @@ class ControllerDataFetcher(DataFetcherBase):
                 f"[DataFetcher] Activating validation dataloader for step {validation_step}, with length {(self.val_datasize or len(self.val_dataloader))}"
             )
             self.val_iters[validation_step] = iter(self.val_dataloader)
-            self.activated_val_iter = self.val_iters[validation_step]
+        if self.activated_val_tqdm is None:
             self.activated_val_tqdm = tqdm(
                 desc="validation",
                 total=(self.val_datasize or len(self.val_dataloader)),
             )
+        self.activated_val_step = validation_step
+        self.activated_val_iter = self.val_iters[validation_step]
 
     def validation_get_dataloader(
         self, validation_step: Optional[int] = None
@@ -654,6 +657,7 @@ class ControllerDataFetcher(DataFetcherBase):
             return self.val_iters[validation_step]
 
     def clear_validation_status(self):
+        self.activated_val_step = None
         self.activated_val_iter = None
         if self.activated_val_tqdm is not None:
             self.activated_val_tqdm.clear()

--- a/cosmos_rl/dispatcher/run_web_panel.py
+++ b/cosmos_rl/dispatcher/run_web_panel.py
@@ -15,6 +15,8 @@
 
 import os
 import argparse
+import signal
+import time
 import uvicorn
 import toml
 from fastapi import FastAPI
@@ -27,6 +29,8 @@ import threading
 from fastapi.responses import HTMLResponse, JSONResponse
 from typing import Dict, List, Optional, Callable, Union, Iterable
 from cosmos_rl.dispatcher.controller import Controller
+from cosmos_rl.dispatcher.command import StopCommand
+from cosmos_rl.dispatcher.status import should_broadcast_stop
 import cosmos_rl.utils.constant as constant
 from cosmos_rl.dispatcher.protocol import MESH_NAMES
 from cosmos_rl.dispatcher.replica import Atom, Replica
@@ -48,11 +52,16 @@ from cosmos_rl.dispatcher.protocol import (
     IpcInfoRequest,
     QueryIpcInfoRequest,
     ResumeInfoRequest,
+    Role,
 )
 from cosmos_rl.policy.config import Config as CosmosConfig
 from cosmos_rl.utils.network_util import find_available_port
 from cosmos_rl.utils.logging import logger
-from cosmos_rl.utils.constant import COSMOS_ROLLOUT_SCAN_INTERVAL
+from cosmos_rl.utils.constant import (
+    COSMOS_HEARTBEAT_TIMEOUT,
+    COSMOS_ROLLOUT_SCAN_INTERVAL,
+    COSMOS_SHUTDOWN_ON_NO_POLICY_REPLICAS,
+)
 from cosmos_rl.utils.api_suffix import (
     COSMOS_API_PANEL_SUFFIX,
     COSMOS_API_STATUS_SUFFIX,
@@ -103,6 +112,10 @@ server = None
 # against the startup window where replica managers are empty but workers have
 # not connected yet (notably SFT controllers where ``not is_rl`` is always true).
 _replicas_were_registered = False
+# Set True on the first successful POLICY /register.  Unlike the monitor
+# thread's old local flag, this cannot miss short-lived policy replicas that
+# register, finish, and unregister between scan intervals.
+_policy_replicas_were_registered = False
 
 
 def _all_replicas_gone() -> bool:
@@ -144,6 +157,24 @@ def _maybe_finalize(reason: str) -> bool:
     if ready:
         global server
         if server is not None and not server.should_exit:
+            data_fetcher = getattr(
+                controller.policy_status_manager, "data_fetcher", None
+            )
+            config = getattr(controller, "config", None)
+            train = getattr(config, "train", None)
+            train_policy = getattr(train, "train_policy", None)
+            train_policy_type = getattr(train_policy, "type", None)
+            if (
+                train_policy_type != "sft"
+                and getattr(data_fetcher, "activated_val_iter", None) is not None
+            ):
+                logger.error(
+                    "[Controller] Finalizing while validation is still active "
+                    "(reason=%s). This violates strict final-validation "
+                    "completion and should only occur after abnormal worker "
+                    "loss.",
+                    reason,
+                )
             logger.info(
                 f"[Controller] All replicas are finished ({reason}); finalizing -- "
                 "shutting down controller."
@@ -153,6 +184,62 @@ def _maybe_finalize(reason: str) -> bool:
     return False
 
 
+def _await_rollout_checkout(
+    controller,
+    shutdown_event,
+    timeout_s: float = COSMOS_HEARTBEAT_TIMEOUT,
+    scan_interval_s: float = COSMOS_ROLLOUT_SCAN_INTERVAL,
+) -> bool:
+    """Block until every rollout replica has checked out, or shutdown is forced.
+
+    Gates the ``COSMOS_SHUTDOWN_ON_NO_POLICY_REPLICAS`` self-SIGTERM: the policy
+    being gone does not mean the rollout side is done -- replicas still need to
+    receive end-of-data, finish the final R2R broadcast (a collective over the
+    whole rollout set), post their end signal, and tear down.  SIGTERM-ing the
+    HTTP server before that strands stragglers on a dead controller and orphans
+    the broadcast peer of the replicas that did check out.
+
+    ``maintain_life_status`` is pumped each iteration so a genuinely crashed
+    rollout (one that stopped heartbeating) is reaped and drops out of
+    ``all_rollouts_ended`` on its own -- which is why no separate timeout knob
+    is needed for that case.  The ``timeout_s`` deadline (default
+    ``COSMOS_HEARTBEAT_TIMEOUT``, the same timescale used to declare a replica
+    dead) is the backstop for the abnormal wedged-but-still-heartbeating case.
+
+    Returns True if all rollouts checked out cleanly, False if the deadline or
+    an external shutdown signal forced shutdown first.
+    """
+    rsm = controller.rollout_status_manager
+    if len(rsm.rollout_replicas) == 0:
+        logger.info(
+            "[Controller] No rollout replicas registered; rollout checkout gate "
+            "has nothing to wait for."
+        )
+        return True
+    deadline = time.monotonic() + timeout_s
+    while not rsm.all_rollouts_ended():
+        rsm.maintain_life_status(controller.policy_status_manager)
+        if time.monotonic() > deadline:
+            n_total = len(rsm.rollout_replicas)
+            n_ended = sum(1 for r in rsm.rollout_replicas.values() if r.status.ended)
+            logger.warning(
+                "[ABNORMAL shutdown] Rollout checkout gate timed out after %ss: "
+                "only %d/%d rollout replicas posted end.  A rollout likely wedged "
+                "while still heartbeating; forcing controller shutdown.",
+                timeout_s,
+                n_ended,
+                n_total,
+            )
+            return False
+        if shutdown_event.wait(timeout=scan_interval_s):
+            return False
+    logger.info(
+        "[Controller] All rollout replicas checked out; proceeding with "
+        "coordinated controller shutdown."
+    )
+    return True
+
+
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     shutdown_event = threading.Event()
@@ -160,6 +247,7 @@ async def lifespan(app: FastAPI):
     loop = asyncio.get_running_loop()
 
     def monitor_replica_status():
+        stop_broadcast_sent = False
         while not shutdown_event.is_set():
             # Run in separate process
             controller.policy_status_manager.maintain_life_status()
@@ -170,6 +258,108 @@ async def lifespan(app: FastAPI):
             # that unregistered cleanly -- finalize the controller here too so a
             # dead/ungracefully-exiting replica can never strand it.
             _maybe_finalize("heartbeat-death reap")
+
+            # Authoritative end-of-job stop for the rollouts.  Tracked
+            # independently of the opt-in self-SIGTERM below.  A normal
+            # non-validation run ends with every policy replica
+            # unregistering immediately after its main loop completes, and a
+            # crashed policy is reaped by ``maintain_life_status``; either
+            # way ``n_policy == 0`` after we have seen policy replicas means
+            # no policy will read this run's rollout output again.  This is
+            # the correctly-ordered moment to stop rollouts: stopping on
+            # ``training_finished()`` instead would fire at dispatch time,
+            # before the policy has pulled the final outputs over UCXX.
+            n_policy = len(controller.policy_status_manager)
+            if should_broadcast_stop(
+                n_policy=n_policy,
+                had_policy_replicas=_policy_replicas_were_registered,
+                stop_broadcast_sent=stop_broadcast_sent,
+                validation_enabled=controller.config.validation.enable,
+                training_finished=controller.policy_status_manager.training_finished(),
+                all_rollouts_ended=controller.rollout_status_manager.all_rollouts_ended(),
+            ):
+                # Publish STOP over the redis command channel (NCCL-free) so
+                # it reaches every rollout via ``consume_command`` -- including
+                # a rank wedged on the weight-version gate that never
+                # re-fetches and so never observes the prompt-stream
+                # ``is_end``.  Validation runs are excluded: they keep the
+                # final weight sync and shut down via the existing R2R
+                # ``replica_should_stop`` broadcast.
+                #
+                # The ``training_finished()`` guard distinguishes genuine
+                # end-of-job from a transient ``n_policy == 0`` during
+                # dynamic policy rescaling (scale-to-zero / rolling restart),
+                # where ``current_step < total_steps`` -- exactly the
+                # legitimate-transient case that keeps the SIGTERM escalation
+                # below opt-in.  ``training_finished()`` stays True once set
+                # (``recompute_total_steps`` early-returns), so it remains
+                # valid after the policy has unregistered.
+                rollout_replicas = list(
+                    controller.rollout_status_manager.rollout_replicas.values()
+                )
+                # Guard the publish: this monitor thread also drives
+                # ``maintain_life_status`` (rollout reaping) and the
+                # no-policy SIGTERM escalation below.  An unguarded redis
+                # error here would kill the thread and take both backstops
+                # with it.  On failure we leave ``stop_broadcast_sent``
+                # False so the next tick retries.
+                try:
+                    if rollout_replicas:
+                        logger.info(
+                            "[Controller] Policy side finished; broadcasting "
+                            "STOP to %d rollout replica(s).",
+                            len(rollout_replicas),
+                        )
+                        StopCommand.trigger(
+                            rollout_replicas,
+                            redis_handler=controller.rollout_status_manager.redis_handler,
+                        )
+                    stop_broadcast_sent = True
+                except Exception:
+                    logger.exception(
+                        "[Controller] Failed to broadcast STOP to rollouts; "
+                        "will retry next scan."
+                    )
+
+            # Opt-in escalation of "all policy replicas dead" to a
+            # controller-wide shutdown.  Default OFF because
+            # cosmos-rl supports dynamic replica scaling -- intentional
+            # scale-to-zero (model swap, maintenance) and rolling
+            # restart (old replica unregisters before new one
+            # registers) both transit ``len(policy_replicas) == 0`` as
+            # a legitimate state.  Treating it as fatal there would
+            # kill the controller during normal operation and prevent
+            # the orchestrator from bringing replicas back.
+            #
+            # The escalation IS appropriate in deployments without
+            # auto-respawn (one trainer process per job, no
+            # replacement on death).  Without it, a trainer crash that
+            # the heartbeat thread correctly reports leaves the
+            # controller idle until the orchestrator's wall-clock
+            # timeout, which can burn significant cluster time.  Those
+            # deployments set ``COSMOS_SHUTDOWN_ON_NO_POLICY_REPLICAS=1``
+            # to enable the SIGTERM-self path below; FastAPI then runs
+            # its lifespan shutdown cleanly and the process exits,
+            # freeing the allocation immediately.
+            if COSMOS_SHUTDOWN_ON_NO_POLICY_REPLICAS:
+                if n_policy == 0 and _policy_replicas_were_registered:
+                    logger.warning(
+                        "[Controller] All policy replicas are dead and "
+                        "COSMOS_SHUTDOWN_ON_NO_POLICY_REPLICAS is set.  "
+                        "Initiating controller shutdown so the scheduling "
+                        "layer (SLURM, etc.) can release the job instead "
+                        "of waiting for the wall-clock timeout."
+                    )
+                    # Coordinated exit: 'no policy replicas' does NOT mean the
+                    # rollout side is finished.  Keep the HTTP API serving until
+                    # every rollout has checked out before self-terminating, so
+                    # stragglers don't wedge on a dead controller and the final
+                    # R2R broadcast isn't left with an orphaned peer.
+                    _await_rollout_checkout(controller, shutdown_event)
+                    shutdown_event.set()
+                    os.kill(os.getpid(), signal.SIGTERM)
+                    break
+
             if shutdown_event.wait(timeout=COSMOS_ROLLOUT_SCAN_INTERVAL):
                 break  # Exit early if shutdown signaled during sleep
 
@@ -225,13 +415,15 @@ async def meta():
 
 @app.post(COSMOS_API_REGISTER_SUFFIX)
 async def register(request: RegisterRequest):
-    global _replicas_were_registered
+    global _replicas_were_registered, _policy_replicas_were_registered
     try:
         await controller.register(
             Atom.from_register_request(request),
             role=request.role,
         )
         _replicas_were_registered = True
+        if request.role == Role.POLICY:
+            _policy_replicas_were_registered = True
         return {"message": "Registered"}
     except Exception as e:
         import traceback
@@ -486,48 +678,9 @@ async def put_rollout_group(rollout: RolloutRequest):
                 f"[Controller] Received rollout end signal from {rollout.src_replica_name}"
             )
             controller.rollout_status_manager.rollout_end(rollout.src_replica_name)
-            if controller.rollout_status_manager.all_rollouts_ended():
-                total_pending_rollouts = (
-                    controller.policy_status_manager.total_pending_rollouts()
-                )
-                logger.info(
-                    f"[Controller] All rollouts have ended, recompute total steps with {total_pending_rollouts} remaining rollouts..."
-                )
-                original_total_steps = controller.policy_status_manager.total_steps
-                controller.policy_status_manager.recompute_total_steps(
-                    explicit_num_remaining_samples=total_pending_rollouts
-                )
-                new_total_steps = controller.policy_status_manager.total_steps
-                if new_total_steps > controller.policy_status_manager.current_step:
-                    logger.info(
-                        "[Controller] There are still remaining steps, no op required"
-                    )
-                    # There are still remaining steps, no op required
-                    pass
-                else:
-                    if (
-                        controller.policy_status_manager.current_step
-                        == original_total_steps
-                    ):
-                        logger.info(
-                            "[Controller] No remaining steps, policy and rollouts happen to finish at the same time"
-                        )
-                        # No remaining steps, policy and rollouts happen to finish at the same time
-                        pass
-                    else:
-                        logger.info(
-                            "[Controller] Clear the rollout buffer, and trigger an extra `DataFetch`"
-                        )
-                        # Clear the rollout buffer
-                        controller.policy_status_manager.rollout_buffer.queue.clear()
-                        controller.policy_status_manager.total_steps = (
-                            controller.policy_status_manager.current_step + 1
-                        )
-
-                        # Trigger an extra `DataFetch & P2R/R2R`
-                        controller.policy_status_manager.try_trigger_data_fetch_and_training(
-                            is_fake_last_cmd=True
-                        )
+            controller.policy_status_manager.on_rollout_is_end(
+                controller.rollout_status_manager
+            )
 
             return {"message": "Rollout end signal received"}
 

--- a/cosmos_rl/dispatcher/status.py
+++ b/cosmos_rl/dispatcher/status.py
@@ -37,6 +37,122 @@ import numpy as np
 from cosmos_rl.utils.util import aggregate_report_data
 
 
+# Debug-only accounting log for ``samples_on_the_fly``. Only the mutation
+# sites that can drift from dispatch accounting call this helper; the
+# dispatch-side increment is intentionally not wrapped because prompt fetches
+# can be hot.
+def _log_samples_on_the_fly_mutation(
+    source: str,
+    before: int,
+    after: int,
+    *,
+    extra: str = "",
+) -> None:
+    delta = after - before
+    extra_str = f" {extra}" if extra else ""
+    logger.debug(
+        "[Controller samples_on_the_fly] source=%s before=%d delta=%+d after=%d%s",
+        source,
+        before,
+        delta,
+        after,
+        extra_str,
+    )
+
+
+def need_weight_sync(
+    *,
+    step: int,
+    total_steps: int,
+    sync_weight_interval: int,
+    validation_enabled: bool,
+    validation_freq: Optional[int],
+) -> bool:
+    """Pure decision: should the controller trigger a P2R/R2R weight sync
+    after training ``step``?
+
+    Weight sync after step N exists to ship the freshly trained weights to
+    the rollouts so they generate the rollouts trained at step N+1.  On the
+    **final** step there is no N+1, so the sync is never consumed -- and
+    issuing it anyway (the old ``or step == total_steps`` "ending signal")
+    raced rollout self-terminate at end-of-data: the policy's deferred final
+    P2R landed after the recipient rollout had already drained + aborted,
+    orphaning the P2R recv and wedging ``ncclCommAbort`` (see
+    rollout_multirank_shutdown.md).
+
+    So for non-validation runs we **never** sync on the final step; rollouts
+    stop via the unified prompt-stream ``is_end`` path
+    (``controller.get_batched_prompt`` forces ``is_end`` once training is
+    finished, feeding the ``prompt_consume_end`` fast path), with the
+    explicit ``StopCommand`` broadcast as the backstop for any rank that
+    never observes ``is_end`` (e.g. one wedged on the weight-version gate).
+
+    Validation-enabled runs are the exception: the final/periodic validation
+    is driven by the controller R2R broadcast and the rollout needs the
+    synced weights to run it, so the last-step sync is kept (mirrored by the
+    validation gating in the ``trigger_weight_sync`` exclusion and the STOP
+    broadcast suppression).
+    """
+    need = step % sync_weight_interval == 0
+    if validation_enabled:
+        if validation_freq:
+            need = need or (step % validation_freq == 0)
+        need = need or step == total_steps
+        return need
+    # Non-validation: suppress the sync entirely on the final step.
+    if step == total_steps:
+        return False
+    return need
+
+
+def should_broadcast_stop(
+    *,
+    n_policy: int,
+    had_policy_replicas: bool,
+    stop_broadcast_sent: bool,
+    validation_enabled: bool,
+    training_finished: bool,
+    all_rollouts_ended: bool,
+) -> bool:
+    """Pure decision: should the controller broadcast the end-of-job
+    ``StopCommand`` to the rollout set now?
+
+    STOP is the NCCL-free, authoritative end-of-job signal for the rollouts
+    (see :class:`~cosmos_rl.dispatcher.command.StopCommand`).  It must fire
+    exactly once, at the moment the policy side is genuinely done:
+
+    - ``n_policy == 0`` **and** ``had_policy_replicas``: every policy replica
+      has unregistered after finishing its main loop (or been reaped).  A
+      bare ``n_policy == 0`` at cold start -- before any policy has been
+      seen -- must not trigger it.
+    - ``training_finished`` **or** ``all_rollouts_ended``: distinguishes
+      genuine end-of-job from a transient ``n_policy == 0`` during dynamic
+      policy rescaling (scale-to-zero / rolling restart,
+      ``current_step < total_steps``), where stopping the rollouts would be
+      wrong.  ``all_rollouts_ended`` covers the post-``is_end`` case where
+      the buffer-only recompute still leaves ``total_steps > current_step``
+      (untrained buffer backlog the policy will never drain) so
+      ``training_finished()`` is false even though the policy has already
+      unregistered -- without this OR-guard STOP never fires and rollouts
+      wedge (the GRPO end-of-data failure in CI).
+    - ``not validation_enabled``: validation runs keep the final weight sync
+      and stop via the R2R ``replica_should_stop`` broadcast instead, so STOP
+      would race that path.
+    - ``not stop_broadcast_sent``: one-shot; once sent we never re-broadcast.
+
+    The caller still decides separately whether any rollout replicas remain
+    to receive it; this is purely the "are we at the stop point?" gate.
+    """
+    policy_side_done = training_finished or all_rollouts_ended
+    return (
+        n_policy == 0
+        and had_policy_replicas
+        and not stop_broadcast_sent
+        and not validation_enabled
+        and policy_side_done
+    )
+
+
 class ReplicaScalingEnum(StrEnum):
     """
     Enum for replica scaling event.
@@ -87,6 +203,17 @@ class PolicyStatus(StrEnum):
     VALIDATED = "validated"
 
 
+class JobPhase(StrEnum):
+    """Controller job phase for non-validation RL shutdown.
+
+    STOPPING and DONE remain implicit via ``stop_broadcast_sent``,
+    ``should_broadcast_stop``, and ``_maybe_finalize``.
+    """
+
+    RUNNING = "running"
+    DRAINING = "draining"
+
+
 class PolicyStatusManager:
     """
     A class to manage the status of a policy.
@@ -117,6 +244,21 @@ class PolicyStatusManager:
         self.remain_samples_num = 0
         self.samples_on_the_fly = 0
 
+        # Per-step record of how many rollouts the controller dispatched for
+        # each training step.  Populated at dispatch time by
+        # ``try_trigger_data_fetch_and_training`` (which knows the real count,
+        # including the ``TrainingCompleteCommand`` case where it is zero) and
+        # consumed by ``train_ack`` to compute the symmetric
+        # ``samples_on_the_fly`` decrement.  Without this, ``train_ack``
+        # decrements by ``train_batch_per_replica * arrived_replicas``
+        # unconditionally, which underflows the counter on the fake-last-cmd
+        # path (dispatched zero, decrements two) and trips the
+        # ``samples_on_the_fly >= 0`` assertion.  Keyed by ``current_step``
+        # value at dispatch (= ``global_step`` sent in DataFetchCommand =
+        # ``step`` received in train_ack); entries are popped on ack so the
+        # map size stays bounded by in-flight step count.
+        self.dispatched_rollouts_by_step: Dict[int, int] = {}
+
         self.status = {}
 
         self.train_report_data = RollingDict(maxlen=20)
@@ -135,6 +277,9 @@ class PolicyStatusManager:
 
         # Record filter rewards distribution for dynamic sampling
         self.filter_records = {}
+
+        # Non-validation RL: explicit end-of-data phase (see ``JobPhase``).
+        self.job_phase = JobPhase.RUNNING
 
         # For rank specific data dispatch
         self.rollout_buffer_per_rank: List[Queue] = []
@@ -274,6 +419,197 @@ class PolicyStatusManager:
             self.total_steps = min(steps_by_dataset, self.config.train.max_num_steps)
         else:
             self.total_steps = steps_by_dataset
+
+    def _total_steps_from_remaining_samples(self, num_remaining_samples: int) -> int:
+        """Compute ``total_steps`` from a sample count without mutating state."""
+        num_policy_replicas = len(self.get_all_atoms_arrived_replicas())
+        if num_policy_replicas == 0:
+            return self.total_steps
+        steps_by_dataset = self.current_step + num_remaining_samples // (
+            self.config.train.train_batch_per_replica * num_policy_replicas
+        )
+        if self.config.train.max_num_steps is not None:
+            return min(steps_by_dataset, self.config.train.max_num_steps)
+        return steps_by_dataset
+
+    def enter_draining_phase(self) -> None:
+        """Enter DRAINING on the first rollout HTTP ``is_end`` POST."""
+        if self.job_phase != JobPhase.RUNNING:
+            return
+        self.job_phase = JobPhase.DRAINING
+        logger.info("[Controller] Job phase RUNNING -> DRAINING")
+        self.recompute_total_steps(
+            explicit_num_remaining_samples=self.total_pending_rollouts()
+        )
+
+    def finish_draining_phase(
+        self,
+        rollout_status_manager: "RolloutStatusManager",
+    ) -> None:
+        """Final buffer reconcile when every rollout has POSTed ``is_end``."""
+        if not rollout_status_manager.all_rollouts_ended():
+            return
+        total_pending_rollouts = self.total_pending_rollouts()
+        logger.info(
+            "[Controller] DRAINING finish: recompute total steps with "
+            "%d remaining rollouts in buffer...",
+            total_pending_rollouts,
+        )
+        original_total_steps = self.total_steps
+        self.recompute_total_steps(
+            explicit_num_remaining_samples=total_pending_rollouts
+        )
+        new_total_steps = self.total_steps
+        if new_total_steps > self.current_step:
+            logger.info("[Controller] There are still remaining steps, no op required")
+            return
+        if self.current_step == original_total_steps and total_pending_rollouts == 0:
+            logger.info(
+                "[Controller] No remaining steps, policy and rollouts happen to "
+                "finish at the same time"
+            )
+            return
+        if not self.all_ready_or_reduced():
+            logger.info(
+                "[Controller] DRAINING: policy still has in-flight work at step "
+                "%d (statuses=%s); deferring TrainingComplete until train_ack",
+                self.current_step,
+                {name: r.status for name, r in self.policy_replicas.items()},
+            )
+            return
+        if self.current_step == original_total_steps:
+            logger.info(
+                "[Controller] No remaining steps with %d buffered rollouts; "
+                "clearing buffer and triggering TrainingComplete",
+                total_pending_rollouts,
+            )
+        else:
+            logger.info(
+                "[Controller] Clear the rollout buffer, and trigger TrainingComplete"
+            )
+        self.rollout_buffer.queue.clear()
+        self.total_steps = self.current_step + 1
+        self.trigger_training_complete()
+
+    def on_rollout_is_end(
+        self,
+        rollout_status_manager: "RolloutStatusManager",
+    ) -> None:
+        """Single entry for rollout HTTP ``is_end`` POST (not prompt fetch)."""
+        if self.config.validation.enable:
+            return
+        if self.job_phase == JobPhase.RUNNING:
+            self.enter_draining_phase()
+        self.finish_draining_phase(rollout_status_manager)
+
+    def should_weight_sync_after_train_ack(
+        self,
+        step: int,
+        rollout_status_manager: "RolloutStatusManager",
+    ) -> bool:
+        """Whether ``train_ack`` should schedule P2R/R2R for ``step``."""
+        if self.job_phase == JobPhase.DRAINING:
+            return False
+        need_sync_weight = need_weight_sync(
+            step=step,
+            total_steps=self.total_steps,
+            sync_weight_interval=self.config.train.sync_weight_interval,
+            validation_enabled=self.config.validation.enable,
+            validation_freq=(
+                self.config.validation.freq if self.config.validation.enable else None
+            ),
+        )
+        if rollout_status_manager.all_rollouts_ended():
+            # Validation runs can exhaust the training prompt stream (``is_end``)
+            # before the final ``train_ack`` lands.  ``status.ended`` only means
+            # "no more training prompts", not "validation + shutdown complete".
+            # Keep the final-step R2R so rollout receives ``validation_flag``
+            # and ``replica_should_stop``; suppressing it here wedged final
+            # validation at 0/N with the controller val dataloader activated.
+            if not (
+                self.config.validation.enable
+                and need_sync_weight
+                and step == self.total_steps
+            ):
+                return False
+        if need_sync_weight:
+            targets = self._weight_sync_rollout_targets(rollout_status_manager)
+            if not targets:
+                logger.warning(
+                    "[Controller] Suppressing weight sync for step=%s because "
+                    "there are no rollout replicas available to receive it "
+                    "(validation_enabled=%s total_steps=%s)",
+                    step,
+                    self.config.validation.enable,
+                    self.total_steps,
+                )
+                return False
+        return need_sync_weight
+
+    def trigger_training_complete(self) -> None:
+        """Dispatch ``TrainingCompleteCommand`` for the genuine final step."""
+        if self.data_fetcher.activated_val_iter is not None:
+            return
+
+        arrived_replicas = self.get_all_atoms_arrived_replicas()
+        if len(arrived_replicas) == 0:
+            return
+
+        if self.training_finished():
+            return
+
+        required_rollouts = 0
+        assert self.current_step + 1 == self.total_steps, (
+            "TrainingComplete should advance to the final step"
+        )
+
+        self.remain_samples_num -= required_rollouts
+        self.current_step += 1
+        self.dispatched_rollouts_by_step[self.current_step] = required_rollouts
+
+        if self.config.validation.enable and (
+            self.current_step % self.config.validation.freq == 0
+            or self.current_step == self.total_steps
+        ):
+            self.data_fetcher.validation_activate_dataloader(self.current_step)
+
+        do_save = self.check_checkpoint_saving(required_rollouts)
+
+        for replica in arrived_replicas:
+            command.TrainingCompleteCommand.trigger(
+                replica=replica,
+                global_step=self.current_step,
+                total_steps=self.total_steps,
+                remain_samples_num=self.remain_samples_num,
+                do_save=do_save,
+                redis_handler=self.redis_handler,
+            )
+            self.set_status(replica.name, PolicyStatus.RUNNING)
+
+    def _weight_sync_rollout_targets(
+        self,
+        rollout_status_manager: "RolloutStatusManager",
+    ) -> List[Replica]:
+        """Rollout replicas that can still service a P2R/R2R weight sync."""
+        exclude_ended = not self.config.validation.enable
+        sorted_replicas = sorted(
+            rollout_status_manager.get_all_atoms_arrived_replicas(),
+            key=lambda x: x.start_time,
+        )
+        return [
+            rollout_replica
+            for rollout_replica in sorted_replicas
+            if not (exclude_ended and rollout_replica.status.ended)
+        ]
+
+    def _expected_validation_rollout_count(self) -> int:
+        val_datasize = getattr(self.data_fetcher, "val_datasize", 0)
+        if not val_datasize and getattr(self.data_fetcher, "val_dataloader", None):
+            val_datasize = len(self.data_fetcher.val_dataloader)
+        return val_datasize * self.config.validation.n_generation
+
+    def _reported_validation_rollout_count(self, validation_step: int) -> int:
+        return sum(len(x) for x in self.val_report_data.get(validation_step, []))
 
     def get_status(self, name: str) -> PolicyStatus:
         """
@@ -631,14 +967,10 @@ class PolicyStatusManager:
             self.val_report_data[validation_step] = []
 
         self.val_report_data[validation_step].extend(validation_results)
-        n_items_of_this_step = sum(
-            len(x) for x in self.val_report_data[validation_step]
-        )
+        n_items_of_this_step = self._reported_validation_rollout_count(validation_step)
 
-        validation_finished = (
-            n_items_of_this_step
-            == (self.data_fetcher.val_datasize or len(self.data_fetcher.val_dataloader))
-            * self.config.validation.n_generation
+        validation_finished = n_items_of_this_step == (
+            self._expected_validation_rollout_count()
         )
 
         if self.data_fetcher.activated_val_tqdm:
@@ -840,15 +1172,30 @@ class PolicyStatusManager:
                 logger.debug(
                     f"[Controller] Filtered out outdated rollout with version {rollout.weight_version}, current step {self.current_step}, estimated step {estimated_step}, pending rollouts {self.total_pending_rollouts()}, preceeding rollouts in this batch {idx}, allowed_outdated_steps {self.config.train.train_policy.allowed_outdated_steps}"
                 )
-        # Update remaining samples number
-        self.remain_samples_num -= len(rollouts) - len(filtered_rollouts)
-        k = "outdated"
-        self.filter_records[k] = (
-            self.filter_records.get(k, 0) + len(rollouts) - len(filtered_rollouts)
-        )
 
         discarded_count = len(rollouts) - len(filtered_rollouts)
+
+        # Update remaining samples number
+        self.remain_samples_num -= discarded_count
+        k = "outdated"
+        self.filter_records[k] = self.filter_records.get(k, 0) + discarded_count
+
         if discarded_count > 0:
+            # Filtered rollouts were counted into ``samples_on_the_fly`` at
+            # dispatch time (controller._get_batched_prompt_impl) but are
+            # dropped here without ever reaching ``train_ack``, where the
+            # symmetric decrement lives.  Without this clamp the counter
+            # drifts upward on every filter event and eventually pins the
+            # soft throttle on permanently — the system loses its
+            # rollout-parallel regime and never autonomically recovers.
+            _sotf_before = self.samples_on_the_fly
+            self.samples_on_the_fly = max(0, self.samples_on_the_fly - discarded_count)
+            _log_samples_on_the_fly_mutation(
+                "filter_outdated",
+                _sotf_before,
+                self.samples_on_the_fly,
+                extra=f"discarded_count={discarded_count}",
+            )
             self._publish_payload_transport_cleanup(rollouts, filtered_rollouts)
 
         return filtered_rollouts
@@ -1009,21 +1356,56 @@ class PolicyStatusManager:
         self.set_status(replica_name, PolicyStatus.REDUCED)
 
         if self.all_reduced():
-            self.samples_on_the_fly -= self.config.train.train_batch_per_replica * len(
-                self.get_all_atoms_arrived_replicas()
+            _sotf_before = self.samples_on_the_fly
+            # Decrement by the actual rollout count we dispatched for this
+            # step (recorded in ``try_trigger_data_fetch_and_training``),
+            # NOT by ``train_batch_per_replica * arrived_replicas``.  The
+            # two are equal on normal steps but diverge on the
+            # ``TrainingCompleteCommand`` step, where the controller dispatches
+            # zero rollouts but the trainer still acks.  Without the
+            # symmetric lookup, that ack underflows the counter and trips
+            # the ``samples_on_the_fly >= 0`` assertion below.
+            _train_decrement = self.dispatched_rollouts_by_step.pop(step, 0)
+            if _train_decrement == 0 and step not in (
+                self.total_steps,
+                self.total_steps - 1,
+            ):
+                # Unexpected: a non-fake step popped 0.  Either the
+                # dispatch record was already consumed (double-ack) or a
+                # step number is mismatched.  Log loudly but do not crash;
+                # ``samples_on_the_fly`` stays balanced regardless.
+                logger.warning(
+                    "[Controller] train_ack for step=%d found no dispatch "
+                    "record (current_step=%d total_steps=%d).  "
+                    "Decrementing samples_on_the_fly by 0; this may "
+                    "indicate a double-ack or step-numbering bug.",
+                    step,
+                    self.current_step,
+                    self.total_steps,
+                )
+            self.samples_on_the_fly -= _train_decrement
+            _log_samples_on_the_fly_mutation(
+                "train_ack",
+                _sotf_before,
+                self.samples_on_the_fly,
+                extra=(
+                    f"step={step} replica={replica_name} "
+                    f"recorded_dispatch={_train_decrement}"
+                ),
             )
             assert self.samples_on_the_fly >= 0, (
                 "samples_on_the_fly should not be negative"
             )
-            # All replicas have been reduced, trigger allreduce
-            need_sync_weight = step % self.config.train.sync_weight_interval == 0
-            # If the current step is the last step, we need to sync weight always to act as ending signal
-            need_sync_weight = need_sync_weight or step == total_steps
-            # If validation is enabled, we need to sync weight every validation step
-            if self.config.validation.enable:
-                need_sync_weight = need_sync_weight or (
-                    step % self.config.validation.freq == 0
-                )
+            # All replicas have been reduced; decide whether to weight-sync.
+            # See ``need_weight_sync`` for the end-of-data rationale (the
+            # final-step sync is suppressed for non-validation runs because it
+            # is never consumed and races rollout teardown).
+            #
+            if rollout_status_manager.all_rollouts_ended():
+                self.finish_draining_phase(rollout_status_manager)
+            need_sync_weight = self.should_weight_sync_after_train_ack(
+                step, rollout_status_manager
+            )
 
             if profile_finished:
                 # Only reset the do_profile flag if the profile is finished
@@ -1207,7 +1589,10 @@ class PolicyStatusManager:
             # P->R & R->R
             if need_sync_weight:
                 self.trigger_weight_sync(
-                    any_loaded_replica, rollout_status_manager, step, total_steps
+                    any_loaded_replica,
+                    rollout_status_manager,
+                    step,
+                    self.total_steps,
                 )
             # Trigger next step training if data is available
             self.try_trigger_data_fetch_and_training()
@@ -1222,16 +1607,12 @@ class PolicyStatusManager:
         current_step: int,
         total_steps: int,
     ):
-        any_loaded_rollout_replica = None
-        valid_rollout_replicas = []
-        sorted_replicas = sorted(
-            rollout_status_manager.get_all_atoms_arrived_replicas(),
-            key=lambda x: x.start_time,
+        valid_rollout_replicas = self._weight_sync_rollout_targets(
+            rollout_status_manager
         )
-        for rollout_replica in sorted_replicas:
-            if any_loaded_rollout_replica is None:
-                any_loaded_rollout_replica = rollout_replica
-            valid_rollout_replicas.append(rollout_replica)
+        any_loaded_rollout_replica = (
+            valid_rollout_replicas[0] if valid_rollout_replicas else None
+        )
         if any_loaded_rollout_replica is None:
             return
         command.PolicyToRolloutUnicastCommand.trigger(
@@ -1308,7 +1689,7 @@ class PolicyStatusManager:
         # Only `do_save` when checkpointing is enabled
         return do_save and self.config.train.ckpt.enable_checkpoint
 
-    def try_trigger_data_fetch_and_training(self, is_fake_last_cmd=False):
+    def try_trigger_data_fetch_and_training(self):
         # If the validation dataloader is activated, do not trigger data fetch and training
         if self.data_fetcher.activated_val_iter is not None:
             return
@@ -1321,22 +1702,12 @@ class PolicyStatusManager:
         if self.training_finished():
             return
 
-        if is_fake_last_cmd:
-            required_rollouts = 0
-            all_ready_or_reduced = True
-            items_count = 0
-            assert self.current_step + 1 == self.total_steps, (
-                "The last command should be fake and next step should be the last step"
-            )
-        else:
-            items_count = self.config.train.train_batch_per_replica
-            required_rollouts = items_count * len(arrived_replicas)
-            all_ready_or_reduced = (
-                self.all_ready_or_reduced() and self.rollouts_enough_for_one_step()
-            )
+        items_count = self.config.train.train_batch_per_replica
+        required_rollouts = items_count * len(arrived_replicas)
+        all_ready_or_reduced = (
+            self.all_ready_or_reduced() and self.rollouts_enough_for_one_step()
+        )
 
-        # If the last command is fake, we need to trigger data fetch and training no matter
-        # whether there are enough rollouts or whether replicas are `ready` or `reduced`.
         if all_ready_or_reduced:
             rollouts_of_this_step: List[Rollout] = []
             # Decrease the consumed rollouts number.
@@ -1344,6 +1715,16 @@ class PolicyStatusManager:
 
             # From controller's perspective, the training step is already increased
             self.current_step += 1
+
+            # Record the actual rollout count dispatched for this step so
+            # ``train_ack`` can later decrement ``samples_on_the_fly`` by the
+            # symmetric amount.  ``required_rollouts`` is the authoritative
+            # count: ``train_batch_per_replica * len(arrived_replicas)`` on a
+            # normal step, ``0`` on the ``TrainingCompleteCommand`` step
+            # above).  Keyed by ``current_step`` which is exactly the
+            # ``global_step`` we send in DataFetchCommand below and the
+            # ``step`` the trainer echoes back via train_ack.
+            self.dispatched_rollouts_by_step[self.current_step] = required_rollouts
 
             if self.config.validation.enable and (
                 self.current_step % self.config.validation.freq == 0
@@ -1569,8 +1950,29 @@ class RolloutStatusManager:
             # Do not trigger rebuild mesh since everything is gonna be finished shortly
             logger.info(f"[Controller] Replica {replica_name} is stopping.")
             return
-        if replica.in_mesh and len(self.rollout_replicas) > 0:
-            self.trigger_rebuild_mesh(self.get_all_atoms_arrived_replicas())
+
+        # Restrict the BuildMesh recipient set to replicas that have NOT
+        # already signalled ``rollout_end`` (``status.ended``).  A
+        # replica that has POSTed its final batch is on its way out of
+        # ``main_loop`` and will stop draining its command queue, so
+        # including it in the rebuild leaves a live peer waiting on a
+        # collective that will never complete.  Also require
+        # ``len(live_survivors) >= 2`` before triggering -- a 1-member
+        # rebuild is pointless and skipping it makes the decision
+        # audible in the log.
+        live_survivors = [
+            r for r in self.get_all_atoms_arrived_replicas() if not r.status.ended
+        ]
+        if replica.in_mesh and len(live_survivors) >= 2:
+            self.trigger_rebuild_mesh(live_survivors)
+        elif replica.in_mesh:
+            logger.info(
+                "[Controller] Replica %s unregistering with %d live "
+                "survivor(s); skipping mesh rebuild "
+                "(graceful end-of-data path or last-replica teardown).",
+                replica_name,
+                len(live_survivors),
+            )
 
     def register(
         self,
@@ -1636,7 +2038,9 @@ class RolloutStatusManager:
         """
         Check if all rollouts have ended.
         """
-        return all([replica.status.ended for replica in self.rollout_replicas.values()])
+        return len(self.rollout_replicas) > 0 and all(
+            [replica.status.ended for replica in self.rollout_replicas.values()]
+        )
 
     def trigger_rebuild_mesh(
         self,

--- a/cosmos_rl/policy/config/__init__.py
+++ b/cosmos_rl/policy/config/__init__.py
@@ -1548,7 +1548,12 @@ class RolloutConfig(BaseModel):
 
         backends_to_check = ["vllm", "trtllm", "vllm_async"]
         if self.backend in backends_to_check:
-            _fields_no_need_to_check = ["n_init_replicas", "tp_size", "pp_size"]
+            _fields_no_need_to_check = [
+                "n_init_replicas",
+                "tp_size",
+                "pp_size",
+                "dp_shard_size",
+            ]
             for field_name, field_info in RolloutParallelismConfig.model_fields.items():
                 if field_name not in _fields_no_need_to_check:
                     default_value = field_info.default

--- a/cosmos_rl/policy/worker/rl_worker.py
+++ b/cosmos_rl/policy/worker/rl_worker.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
 import torch
 import atexit
 import time
@@ -41,6 +42,7 @@ from cosmos_rl.utils.parallelism_map import (
     ParallelTopoMapperGroup,
 )
 from cosmos_rl.utils.pynccl import (
+    bounded_drain_or_abort,
     nccl_group_start,
     nccl_group_end,
 )
@@ -51,12 +53,27 @@ from cosmos_rl.dispatcher.command import (
     PolicyToRolloutUnicastCommand,
     PolicyToPolicyUnicastCommand,
     DataFetchCommand,
+    TrainingCompleteCommand,
     WeightResumeCommand,
 )
 import cosmos_rl.utils.distributed as dist_util
 from cosmos_rl.utils import constant
 from cosmos_rl.policy.worker.base import PolicyWorkerBase
 from cosmos_rl.collective.collective import P2RCollectiveManager
+
+
+# Bounded window the policy lingers after its last training step to deliver the
+# controller's trailing final weight sync (validation-enabled runs only -- that
+# P2R/R2R drives the final validation on the rollouts).  Replaces a hardcoded
+# 30s sleep; the loop breaks as soon as the command arrives, and non-validation
+# runs skip the wait entirely (no trailing sync is issued -- see status.py /
+# controller.get_batched_prompt and rollout_multirank_shutdown.md).
+COSMOS_FINAL_WEIGHT_SYNC_WAIT_S = float(
+    os.getenv("COSMOS_FINAL_WEIGHT_SYNC_WAIT_S", "30.0")
+)
+COSMOS_P2R_STREAM_DRAIN_TIMEOUT_S = float(
+    os.getenv("COSMOS_P2R_STREAM_DRAIN_TIMEOUT_S", "120.0")
+)
 
 
 class RLPolicyWorker(PolicyWorkerBase):
@@ -489,7 +506,11 @@ class RLPolicyWorker(PolicyWorkerBase):
                             "Trainable synced params count must match at each weight sync."
                         )
 
-        # make sure all the send operations of all ranks are finished
+        bounded_drain_or_abort(
+            self.train_stream,
+            COSMOS_P2R_STREAM_DRAIN_TIMEOUT_S,
+            f"policy_P2R[{self.replica_name}@step{command.weight_step}]",
+        )
         time_eclapsed = time.time() - st
         logger.debug(
             f"[Policy] All {len(self.policy_to_rollout_insts)} at step {command.weight_step} send operations of finished in {time_eclapsed:.3f} seconds with {total_bytes_sent / (1024 * 1024)} MB sent. While {skipped_params_cnt} non-trainable splitted params skipped and {transferred_params_cnt} splitted params transferred."
@@ -522,34 +543,27 @@ class RLPolicyWorker(PolicyWorkerBase):
         assert self.replica_name == command.replica_name
         self.replica_batch_for_this_step = command.items_count
 
-        is_fake_step = self.replica_batch_for_this_step == 0
-        if not is_fake_step:
-            do_save_checkpoint = command.do_save
-            if (
-                self.signal_handler is not None
-                and any(self.signal_handler.signals_received())
-                and not hasattr(self, "signal_handled")
-            ):
-                logger.info("Signal received, preparing to save checkpoint...")
-                do_save_checkpoint = True
-                self.signal_handler.release()
-                self.signal_handled = True
+        do_save_checkpoint = command.do_save
+        if (
+            self.signal_handler is not None
+            and any(self.signal_handler.signals_received())
+            and not hasattr(self, "signal_handled")
+        ):
+            logger.info("Signal received, preparing to save checkpoint...")
+            do_save_checkpoint = True
+            self.signal_handler.release()
+            self.signal_handled = True
 
-            self.trainer.update_lr_schedulers(command.total_steps)
-            report_data = self.trainer.step_training(
-                rollouts=self.dispatch_rollouts(),
-                current_step=command.global_step,
-                total_steps=command.total_steps,
-                remain_samples_num=command.remain_samples_num,
-                do_save_checkpoint=do_save_checkpoint,
-                inter_policy_nccl=self.inter_policy_nccl,
-                is_master_replica=self.is_master_replica,
-            )
-        else:
-            report_data = {}
-            logger.info(
-                f"[Policy] No data to fetch for global step {command.global_step}, skip this step."
-            )
+        self.trainer.update_lr_schedulers(command.total_steps)
+        report_data = self.trainer.step_training(
+            rollouts=self.dispatch_rollouts(),
+            current_step=command.global_step,
+            total_steps=command.total_steps,
+            remain_samples_num=command.remain_samples_num,
+            do_save_checkpoint=do_save_checkpoint,
+            inter_policy_nccl=self.inter_policy_nccl,
+            is_master_replica=self.is_master_replica,
+        )
 
         # For profiling
         self.profiler.step()
@@ -565,6 +579,41 @@ class RLPolicyWorker(PolicyWorkerBase):
             )
 
         logger.debug(f"[Policy] Train ack sent for global step {command.global_step}.")
+        return command.replica_should_stop()
+
+    @CommMixin.register_policy_command_handler(TrainingCompleteCommand)
+    def execute_training_complete(self, command: TrainingCompleteCommand):
+        if command.do_profile:
+            self.profiler.start_dynamic(
+                active_steps=command.active_steps,
+                rank_filter=command.rank_filter,
+                record_shape=command.record_shape,
+                profile_memory=command.profile_memory,
+                with_stack=command.with_stack,
+                with_modules=command.with_modules,
+            )
+
+        assert self.replica_name == command.replica_name
+        self.replica_batch_for_this_step = 0
+        report_data = {}
+        logger.info(
+            f"[Policy] Training complete at global step {command.global_step}, skip training."
+        )
+
+        self.profiler.step()
+
+        if is_master_rank(self.parallel_dims, self.global_rank):
+            self.api_client.post_policy_train_ack(
+                self.replica_name,
+                command.global_step,
+                command.total_steps,
+                self.profiler.check_finished(),
+                report_data,
+            )
+
+        logger.debug(
+            f"[Policy] Train ack sent for training-complete step {command.global_step}."
+        )
         return command.replica_should_stop()
 
     async def fetch_command(self):
@@ -837,9 +886,23 @@ class RLPolicyWorker(PolicyWorkerBase):
         abort = False
         while True:
             abort_at_this_round = abort
-            if abort_at_this_round:
-                # Wait 30s to make sure the final potential P->R is received to finalize the Rollouts
-                time.sleep(30)
+            if abort_at_this_round and self.config.validation.enable:
+                # Validation-enabled runs: the controller issues a final P->R
+                # weight sync after the last train step to drive the rollouts'
+                # final validation.  Linger (bounded) until that command lands,
+                # breaking out as soon as it does instead of sleeping a fixed
+                # 30s.  Non-validation runs issue no trailing sync (status.py),
+                # and rollouts self-terminate via the unified prompt-stream
+                # is_end path, so they skip this wait and exit immediately --
+                # eliminating the old race where the deferred P->R arrived
+                # after the rollout had already aborted (orphaned P2R recv ->
+                # ncclCommAbort hang; see rollout_multirank_shutdown.md).
+                deadline = time.time() + COSMOS_FINAL_WEIGHT_SYNC_WAIT_S
+                while time.time() < deadline:
+                    self.broadcast_command()
+                    if len(self.command_buffer.queue) > 0:
+                        break
+                    time.sleep(0.1)
 
             self.broadcast_command()
             while len(self.command_buffer.queue) > 0:
@@ -849,7 +912,11 @@ class RLPolicyWorker(PolicyWorkerBase):
             if abort_at_this_round:
                 break
         logger.info("[Policy] Main loop finished. Shutdown background task event set.")
-        self.train_stream.synchronize()
+        bounded_drain_or_abort(
+            self.train_stream,
+            float(os.getenv("COSMOS_TEARDOWN_DRAIN_TIMEOUT_S", "15.0")),
+            f"policy_train_stream[{self.replica_name}]",
+        )
         self.handle_shutdown()
 
     def sync_all_states(

--- a/cosmos_rl/rollout/worker/llm_worker.py
+++ b/cosmos_rl/rollout/worker/llm_worker.py
@@ -106,6 +106,7 @@ class LLMRolloutWorker(WorkerBase):
             raise ValueError(f"Invalid rollout backend: {rollout_backend}")
 
     def destroy_worker(self):
+        logger.info("[Teardown] destroy_worker: deleting rollout_worker")
         if self.rollout_worker is not None:
             logger.info(
                 "[Rollout] destroy_worker: deleting rollout_worker (vLLM shutdown)"
@@ -113,6 +114,6 @@ class LLMRolloutWorker(WorkerBase):
             del self.rollout_worker
             self.rollout_worker = None
             logger.info("[Rollout] destroy_worker: rollout_worker deleted")
-        logger.info("[Rollout] destroy_worker: calling destroy_distributed")
+        logger.info("[Teardown] destroy_worker: calling destroy_distributed()")
         destroy_distributed()
         logger.info("[Rollout] Destroy context of torch dist.")

--- a/cosmos_rl/rollout/worker/rollout_control.py
+++ b/cosmos_rl/rollout/worker/rollout_control.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
 import time
 import threading
 import uuid
@@ -43,12 +44,14 @@ from cosmos_rl.dispatcher.command import (
     BuildMeshCommand,
     PolicyToRolloutUnicastCommand,
     RolloutToRolloutBroadcastCommand,
+    StopCommand,
     Command,
 )
 from cosmos_rl.utils.util import str2torch_dtype
 from cosmos_rl.utils.pynccl import (
     create_nccl_uid,
     create_nccl_comm,
+    bounded_drain_or_abort,
     nccl_broadcast,
     nccl_group_start,
     nccl_group_end,
@@ -88,6 +91,12 @@ from cosmos_rl.rollout.worker.weight_sync import (
 """
 Keep in mind that torch distributed is not thread safe. So try to keep the usage in the same thread.
 """
+
+
+# Bounded teardown drain of ``inference_stream``.  Backstop in case an
+# in-flight NCCL op (e.g. the WeightSyncThread R2R broadcast) wedges the device;
+# on timeout we abort all NCCL communicators so teardown always completes.
+_TEARDOWN_DRAIN_TIMEOUT_S = float(os.getenv("COSMOS_TEARDOWN_DRAIN_TIMEOUT_S", "15.0"))
 
 
 class DisaggregatedRolloutControlWorker(RolloutWorkerBase):
@@ -352,16 +361,45 @@ class DisaggregatedRolloutControlWorker(RolloutWorkerBase):
                 self.shutdown_signal.set()
             if not self.shutdown_mp_signal.is_set():
                 self.shutdown_mp_signal.set()
+            # All joins below MUST be bounded.  Worker teardown blocking
+            # on an unresponsive controller or a wedged daemon would
+            # otherwise turn into multi-minute scheduler-timeout hangs
+            # (e.g. ``unregister_from_controller`` -> ``requests.post``
+            # to a wedged controller keeping the worker alive long
+            # enough that the orchestrator hard-kills the whole job).
+            # Worst-case delay caused by a missed join is bounded: the
+            # background/heartbeat daemons are ``daemon=True`` /
+            # ``mp.Process(daemon=True)`` with PR_SET_PDEATHSIG, so the
+            # OS will reap them when the worker process exits.
+            _JOIN_TIMEOUT_S = 15.0
+            logger.info(
+                "[Teardown] %s: handle_shutdown joining daemons "
+                "(background/teacher/heartbeat)",
+                self.replica_name,
+            )
             if self.background_thread is not None:
                 logger.info("[Rollout] handle_shutdown: joining command-query thread")
-                self.background_thread.join()
+                self.background_thread.join(timeout=_JOIN_TIMEOUT_S)
+                if self.background_thread.is_alive():
+                    logger.warning(
+                        "[Rollout] background_thread did not exit within "
+                        "%.1fs of shutdown_signal; continuing teardown "
+                        "(daemon will be reaped on process exit)",
+                        _JOIN_TIMEOUT_S,
+                    )
                 self.background_thread = None
                 logger.info("[Rollout] handle_shutdown: command-query thread joined")
             if self.teacher_interact_thread is not None:
                 logger.info(
                     "[Rollout] handle_shutdown: joining teacher-interact thread"
                 )
-                self.teacher_interact_thread.join()
+                self.teacher_interact_thread.join(timeout=_JOIN_TIMEOUT_S)
+                if self.teacher_interact_thread.is_alive():
+                    logger.warning(
+                        "[Rollout] teacher_interact_thread did not exit "
+                        "within %.1fs of shutdown_signal; continuing teardown",
+                        _JOIN_TIMEOUT_S,
+                    )
                 self.teacher_interact_thread = None
                 logger.info("[Rollout] handle_shutdown: teacher-interact thread joined")
             if self.scheduler is not None:
@@ -370,12 +408,26 @@ class DisaggregatedRolloutControlWorker(RolloutWorkerBase):
 
             if self.heartbeat_thread is not None:
                 logger.info("[Rollout] handle_shutdown: joining heartbeat process")
-                self.heartbeat_thread.join()
+                self.heartbeat_thread.join(timeout=_JOIN_TIMEOUT_S)
+                if self.heartbeat_thread.is_alive():
+                    logger.warning(
+                        "[Rollout] heartbeat process did not exit within "
+                        "%.1fs of shutdown_signal; continuing teardown "
+                        "(PR_SET_PDEATHSIG will reap it on process exit)",
+                        _JOIN_TIMEOUT_S,
+                    )
                 self.heartbeat_thread = None
                 logger.info("[Rollout] handle_shutdown: heartbeat process joined")
-            logger.info("[Rollout] handle_shutdown: unregistering from controller")
+            logger.info(
+                "[Teardown] %s: handle_shutdown daemons joined; "
+                "calling unregister_from_controller",
+                self.replica_name,
+            )
             self.unregister_from_controller()
-            logger.info("[Rollout] handle_shutdown: complete")
+            logger.info(
+                "[Teardown] %s: unregister_from_controller returned",
+                self.replica_name,
+            )
 
     def get_underlying_model(self):
         """
@@ -383,8 +435,41 @@ class DisaggregatedRolloutControlWorker(RolloutWorkerBase):
         """
         return self.rollout.get_underlying_model()
 
+    @RolloutWorkerBase.register_rollout_command_handler(StopCommand)
+    def handle_stop(self, command: StopCommand):
+        """Controller-authoritative end-of-job stop (non-validation runs).
+
+        The controller publishes STOP once every policy replica has
+        unregistered (its main loop finished, so no policy will read this
+        rollout's output again).  Setting the shutdown signals here breaks
+        ``main_loop`` out of *any* branch -- normal drain, an empty queue,
+        or the weight-version-gate spin that no longer clears once weight
+        syncs have stopped (the residual hang the prompt-stream ``is_end``
+        could not reach).  No NCCL collective is involved, and teardown's
+        bounded ``cleanup_ucxx`` still lets any in-flight output read drain.
+        """
+        logger.info(
+            "[Rollout] Received STOP from controller for %s; setting shutdown signal.",
+            self.replica_name,
+        )
+        self.shutdown_signal.set()
+        self.shutdown_mp_signal.set()
+
     @RolloutWorkerBase.register_rollout_command_handler(BuildMeshCommand)
     def build_global_mesh(self, build_mesh_command: BuildMeshCommand):
+        # If this replica is already draining (prompt source exhausted),
+        # skip the NCCL mesh rebuild -- entering the collective would
+        # deadlock the peers that join while we exit shortly without
+        # them.  The controller-side filter on ``status.ended`` is the
+        # primary defence; this guard handles the race where a
+        # BuildMeshCommand was queued before that filter took effect.
+        if self.state.prompt_consume_end():
+            logger.info(
+                "[Rollout] Skipping BuildMeshCommand for %s: prompt "
+                "source exhausted, this replica is draining.",
+                self.replica_name,
+            )
+            return
         logger.info(f"[Rollout] Building global mesh for {self.replica_name}")
 
         replica_name_to_rank = build_mesh_command.replica_name_to_rank
@@ -1437,6 +1522,7 @@ class DisaggregatedRolloutControlWorker(RolloutWorkerBase):
                     f"[Rollout] Failed in query commands from controller for replica {self.replica_name}\n: {str(e)}"
                 )
 
+            stop_received = False
             for instruction in commands:
                 command = Command.depack(instruction)
                 logger.debug(f"[Rollout] Received command: {command.command_type}")
@@ -1461,6 +1547,12 @@ class DisaggregatedRolloutControlWorker(RolloutWorkerBase):
                     continue
 
                 self._command_queue.put(command)
+                if isinstance(command, StopCommand):
+                    stop_received = True
+                    break
+
+            if stop_received:
+                break
 
     def teacher_interact_loop(self):
         """Background task to interact with teacher model for distillation"""
@@ -1762,13 +1854,121 @@ class DisaggregatedRolloutControlWorker(RolloutWorkerBase):
         try:
             self._main_loop_impl()
         finally:
+            # Stop the UCXX output server *before* any NCCL teardown/abort.
+            # The rollout backend (e.g. rl-gym's ModularRolloutWorker via
+            # UCXXRolloutMixin) serves this replica's generated output to the
+            # trainer over a UCXX server.  cleanup_ucxx() is otherwise never
+            # invoked, so at end-of-data a trainer can still be pulling the
+            # final output when teardown begins -- and that concurrent UCXX
+            # activity wedges ncclCommAbort on the straggler.  stop_server()
+            # sets the shutdown flag and bounded-joins its threads (in-flight
+            # reads finish first), so this is a graceful close, not a kill.
+            self._cleanup_payload_server()
             wst = getattr(self, "_weight_sync_thread", None)
             if wst is not None:
+                logger.info(
+                    "[Teardown] %s: stopping WeightSyncThread", self.replica_name
+                )
+                _t_wst = time.monotonic()
                 wst.stop()
+                logger.info(
+                    "[Teardown] %s: WeightSyncThread.stop() returned in %.2fs "
+                    "(thread_alive=%s)",
+                    self.replica_name,
+                    time.monotonic() - _t_wst,
+                    wst._thread.is_alive(),
+                )
+
+    def _cleanup_payload_server(self) -> None:
+        """Best-effort, bounded shutdown of the rollout's UCXX output server.
+
+        Invoked at the very start of teardown (before NCCL abort).  The server
+        lives on the rollout backend (``self.rollout``) when it composes
+        ``UCXXRolloutMixin``; guarded with ``getattr`` so backends without a
+        UCXX server are unaffected.
+        """
+        rollout_engine = getattr(self, "rollout", None)
+        cleanup = getattr(rollout_engine, "cleanup_ucxx", None)
+        if not callable(cleanup):
+            return
+        logger.info(
+            "[Teardown] %s: stopping UCXX output server (cleanup_ucxx)",
+            self.replica_name,
+        )
+        _t0 = time.monotonic()
+        try:
+            cleanup()
+        except Exception:
+            logger.exception(
+                "[Teardown] %s: cleanup_ucxx raised (continuing teardown)",
+                self.replica_name,
+            )
+        logger.info(
+            "[Teardown] %s: UCXX output server stopped in %.2fs",
+            self.replica_name,
+            time.monotonic() - _t0,
+        )
+
+    # Main-loop branch counters and prompt-version rejection logging.
+    _MAINLOOP_LOG_INTERVAL_S = 1.0
+    _VERSION_FAIL_LOG_INTERVAL_S = 5.0
+
+    def _maybe_emit_mainloop_summary(self, now):
+        """Emit a bounded summary of which branch the loop took.
+
+        This is the *only* aggregated counter we keep in the rollout main
+        loop.  We do not log per-iteration -- a hot-spinning loop can
+        easily produce thousands of ``generate start`` lines per second per
+        worker. Instead we tally
+        branch hits in ``_mainloop_branch_counts`` and flush once per
+        ``_MAINLOOP_LOG_INTERVAL_S`` (default 1s) so a stuck rollout
+        produces a handful of lines/sec, not millions.
+        """
+        if now - self._mainloop_log_last_ts < self._MAINLOOP_LOG_INTERVAL_S:
+            return
+        c = self._mainloop_branch_counts
+        # Skip emission when the previous window was completely idle
+        # (loop-pump was blocked elsewhere).
+        total = sum(c.values())
+        if total == 0:
+            self._mainloop_log_last_ts = now
+            return
+        logger.debug(
+            "[Rollout main_loop %.1fs] rank=%d empty_q=%d consume_end=%d "
+            "version_fail=%d gen_attempted=%d gen_succeeded=%d "
+            "fetched_nonempty=%d weight_unsynced=%d",
+            self._MAINLOOP_LOG_INTERVAL_S,
+            self.global_rank,
+            c["empty_q"],
+            c["consume_end"],
+            c["version_fail"],
+            c["gen_attempted"],
+            c["gen_succeeded"],
+            c["fetched_nonempty"],
+            c["weight_unsynced"],
+        )
+        for k in c:
+            c[k] = 0
+        self._mainloop_log_last_ts = now
 
     def _main_loop_impl(self):
         """Core main loop extracted for clean WST lifecycle management."""
         async_mode = get_async_r2r_sync_mode(self)
+
+        # Per-worker branch counters for the legacy sync rollout path. The
+        # async rollout path uses ``stream_generation_step`` instead.
+        self._mainloop_branch_counts = {
+            "empty_q": 0,
+            "consume_end": 0,
+            "version_fail": 0,
+            "gen_attempted": 0,
+            "gen_succeeded": 0,
+            "fetched_nonempty": 0,
+            "weight_unsynced": 0,
+        }
+        self._mainloop_log_last_ts = time.time()
+        self._version_fail_last_log_ts = 0.0
+
         while not self.shutdown_signal.is_set():
             self.consume_command(cmd_pred=None)
 
@@ -1780,7 +1980,22 @@ class DisaggregatedRolloutControlWorker(RolloutWorkerBase):
             if self.validation_flag.is_set():
                 self.do_validation()
 
+            now = time.time()
+            self._maybe_emit_mainloop_summary(now)
+
+            # Multi-rank coordinated shutdown is driven by the controller's
+            # explicit ``StopCommand`` (consumed above via ``consume_command``
+            # -> ``handle_stop``).  Because ``consume_one_command`` broadcasts
+            # the dequeued command across ranks, every rank sets the shutdown
+            # signal at the same collective call and leaves ``main_loop`` in
+            # lockstep -- so no rank strands a peer in a later collective.
+            # This replaces the former Option-C per-iteration drain vote (a
+            # CPU all-reduce gated on ``prompt_fetch_end``), which existed
+            # only because the previous stop signal rode on the racy R2R
+            # weight-sync broadcast.
+
             if not self.state.weight_synced():
+                self._mainloop_branch_counts["weight_unsynced"] += 1
                 continue
 
             _, is_validation, _, _ = self.report_rollouts()
@@ -1793,11 +2008,14 @@ class DisaggregatedRolloutControlWorker(RolloutWorkerBase):
                 continue
 
             if not self.state.prompt_fetch_end():
+                pre_qsize = self._prompt_queue.qsize()
                 no_more_prompts = self.request_new_prompts(
                     self.batch_size,
                     self._prompt_queue,
                     rank_in_mesh=self.rank_in_rollout_repicas,
                 )
+                if self._prompt_queue.qsize() > pre_qsize:
+                    self._mainloop_branch_counts["fetched_nonempty"] += 1
                 if no_more_prompts:
                     logger.info(
                         f"[Rollout] Receive prompt end, wait for {self.replica_name} to finish all rollouts generation"
@@ -1812,23 +2030,79 @@ class DisaggregatedRolloutControlWorker(RolloutWorkerBase):
                 assert self._prompt_queue.empty() and self.state.prompt_fetch_end(), (
                     "[Rollout] If prompt are all consumed, prompt queue should be empty and prompt end event should be set."
                 )
+                self._mainloop_branch_counts["consume_end"] += 1
+                # Mirror the async-rollout generation path
+                # (``stream_generation_step``, used when
+                # ``config.rollout.mode == "async"`` and the backend is
+                # in ``SUPPORT_ASYNC_BACKEND``): that method already
+                # calls ``self.shutdown_signal.set()`` at the analogous
+                # ``prompt_consume_end()`` site.  Without setting it
+                # here too, the default sync path leaves worker threads
+                # spinning on this branch waiting for an external
+                # ``shutdown`` broadcast that may never arrive (e.g.
+                # when the controller has already crashed).
+                #
+                # Scope the self-terminate to single-process workers
+                # (``world_size == 1``).  In a multi-rank worker the
+                # final prompt batch is scattered round-robin and
+                # *unevenly* across DP ranks, so ranks reach
+                # ``consume_end`` on different iterations.  If the first
+                # rank to drain set ``shutdown_signal`` and left
+                # ``main_loop`` here, it would strand its peers in the
+                # next cross-rank collective -> deadlock.  Multi-rank
+                # workers therefore keep the proven controller-broadcast
+                # lockstep shutdown; only single-process workers (the
+                # prefetch / bench regime that motivated this) take the
+                # self-terminate fast path.
+                if self.parallel_dims.world_size == 1:
+                    self.shutdown_signal.set()
                 continue
             elif self._prompt_queue.empty():
+                self._mainloop_branch_counts["empty_q"] += 1
                 continue
             else:
                 logger.debug(f"[Rollout] generate start for rank {self.global_rank}")
 
                 first_payload: RLPayload = self._prompt_queue.queue[0][0]
+                allowed = self.config.train.train_policy.allowed_outdated_steps
+                ceiling = self.current_weight_version + allowed
                 is_valid_prompt_for_current_weight_version = (
-                    first_payload.weight_version
-                    <= self.current_weight_version
-                    + self.config.train.train_policy.allowed_outdated_steps
+                    first_payload.weight_version <= ceiling
                 )
 
                 if not is_valid_prompt_for_current_weight_version:
+                    self._mainloop_branch_counts["version_fail"] += 1
+                    # Explain prompt-version rejections at most once per 5s
+                    # per worker.
+                    if (
+                        now - self._version_fail_last_log_ts
+                        >= self._VERSION_FAIL_LOG_INTERVAL_S
+                    ):
+                        self._version_fail_last_log_ts = now
+                        logger.info(
+                            "[Rollout rank=%d] prompt rejected: "
+                            "prompt.weight_version=%s current_weight_version=%s "
+                            "allowed_outdated=%d ceiling=%s; head-of-queue "
+                            "will be re-checked until current_weight_version advances",
+                            self.global_rank,
+                            first_payload.weight_version,
+                            self.current_weight_version,
+                            allowed,
+                            ceiling,
+                        )
+                    # Back off before re-checking the head-of-queue
+                    # prompt.  The rejection clears as soon as the next
+                    # P->R broadcast advances ``current_weight_version``
+                    # (typically every few seconds), so without a sleep
+                    # this branch hot-spins.  50ms wakes well within
+                    # the broadcast interval and is invisible to
+                    # throughput.
+                    time.sleep(0.05)
                     continue
 
+                self._mainloop_branch_counts["gen_attempted"] += 1
                 self.one_step_generation()
+                self._mainloop_branch_counts["gen_succeeded"] += 1
 
                 if self.state.prompt_fetch_end() and self._prompt_queue.empty():
                     self.state.set_prompt_consume_end()
@@ -1939,6 +2213,24 @@ class DisaggregatedRolloutControlWorker(RolloutWorkerBase):
         Perform one step of rollout generation.
         Returns the number of valid payloads generated.
         """
+        generation_start_ts = time.time()
+        try:
+            _peek_wv = (
+                self._prompt_queue.queue[0][0].weight_version
+                if not self._prompt_queue.empty()
+                else None
+            )
+        except Exception:
+            _peek_wv = None
+        # Paired with the matching exit log below for per-call latency
+        # measurements when DEBUG logging is enabled.
+        logger.debug(
+            "[one_step_generation entry] rank=%d cur_wv=%s peek_prompt_wv=%s",
+            self.global_rank,
+            self.current_weight_version,
+            _peek_wv,
+        )
+
         payloads_list: List[RLPayload] = self._prompt_queue.get()
 
         rollout_results: List[RolloutResult] = self._call_rollout_generation(
@@ -1950,6 +2242,13 @@ class DisaggregatedRolloutControlWorker(RolloutWorkerBase):
         )
 
         if len(rollout_results) == 0:
+            logger.debug(
+                "[one_step_generation exit] rank=%d elapsed_ms=%.1f "
+                "batch=%d produced=0 returned_false=True",
+                self.global_rank,
+                (time.time() - generation_start_ts) * 1000.0,
+                len(payloads_list),
+            )
             return False
 
         assert len(rollout_results) == len(payloads_list), (
@@ -1958,9 +2257,18 @@ class DisaggregatedRolloutControlWorker(RolloutWorkerBase):
 
         logger.debug(f"[Rollout] generate end for rank {self.global_rank}")
 
-        return self._filter_valid_rollout_results_and_report(
+        result = self._filter_valid_rollout_results_and_report(
             rollout_results, payloads_list
         )
+        logger.debug(
+            "[one_step_generation exit] rank=%d elapsed_ms=%.1f "
+            "batch=%d produced=%d returned_false=False",
+            self.global_rank,
+            (time.time() - generation_start_ts) * 1000.0,
+            len(payloads_list),
+            len(rollout_results),
+        )
+        return result
 
     def _stream_generation_feed_prompts(
         self,
@@ -2088,7 +2396,17 @@ class DisaggregatedRolloutControlWorker(RolloutWorkerBase):
         if self.state.prompt_consume_end():
             # Send end signal to the controller
             # Because we first report_rollouts() to the controller, so we don't need to check the reward_dispatcher queue here.
-            self.shutdown_signal.set()
+            #
+            # Scope the self-terminate to single-process workers
+            # (``world_size == 1``); see the matching guard in the
+            # synchronous ``_main_loop_impl`` consume-end branch.  A
+            # multi-rank async worker would otherwise strand its peers
+            # in the next cross-rank collective when the first rank to
+            # exhaust its (unevenly scattered) prompt share leaves
+            # ahead of the others.  Multi-rank workers shut down via
+            # the controller stop-broadcast instead.
+            if self.parallel_dims.world_size == 1:
+                self.shutdown_signal.set()
             if self.global_rank == 0:
                 self.send_end_signal()
 
@@ -2236,12 +2554,23 @@ class DisaggregatedRolloutControlWorker(RolloutWorkerBase):
             self.teacher_interact_thread.start()
 
         self.main_loop()
+        # [Teardown trace] These calls are otherwise silent; emitting a
+        # breadcrumb before/after each one means the last line in a wedged
+        # worker's log names the exact blocking call (e.g. a hung
+        # inference_stream.synchronize() from a cross-replica NCCL teardown
+        # race) instead of an un-attributable silent gap before unregister.
         logger.info(
-            "[Rollout] work: main_loop returned, synchronizing inference stream"
+            "[Teardown] %s: main_loop returned; draining inference_stream",
+            self.replica_name,
         )
-        self.inference_stream.synchronize()
-        logger.info(
-            "[Rollout] work: inference stream synchronized, calling handle_shutdown"
+        # Synchronous-path backstop: in async_r2r_sync=disabled there is no
+        # WeightSyncThread, so R2R/P2R run on inference_stream; an orphaned
+        # collective here is drained-or-aborted the same way.  Quiet on healthy
+        # runs now that the controller waits for rollout checkout.
+        bounded_drain_or_abort(
+            self.inference_stream,
+            _TEARDOWN_DRAIN_TIMEOUT_S,
+            f"inference_stream[{self.replica_name}]",
         )
         self.handle_shutdown()
-        logger.info("[Rollout] work: handle_shutdown returned")
+        logger.info("[Teardown] %s: work() returning", self.replica_name)

--- a/cosmos_rl/rollout/worker/weight_sync.py
+++ b/cosmos_rl/rollout/worker/weight_sync.py
@@ -56,12 +56,26 @@ import queue
 import threading
 import time
 from enum import Enum
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional
 
 import torch
 
 from cosmos_rl.utils.logging import logger
-from cosmos_rl.utils.pynccl import nccl_broadcast, nccl_group_end, nccl_group_start
+from cosmos_rl.utils.pynccl import (
+    bounded_drain_or_abort,
+    nccl_broadcast,
+    nccl_group_end,
+    nccl_group_start,
+)
+
+# Bounded wait for in-flight GPU work on the WeightSyncThread stream during
+# teardown.  A grouped R2R broadcast is enqueued asynchronously and pynccl only
+# bounds the enqueue phase, so a broadcast whose peer departed can hang on the
+# device with no watchdog.  After this deadline we abort all NCCL comms so
+# ``stop()`` (and in turn ``destroy_distributed``) cannot wedge.
+_WST_STREAM_DRAIN_TIMEOUT_S = float(
+    os.getenv("COSMOS_WST_STREAM_DRAIN_TIMEOUT_S", "10.0")
+)
 
 if TYPE_CHECKING:
     pass
@@ -336,10 +350,29 @@ class WeightSyncThread:
             )
 
     def stop(self) -> None:
-        """Signal the thread to stop and wait for it to finish."""
+        """Signal the thread to stop and wait for it to finish.
+
+        The Python thread joining is not sufficient: a grouped R2R broadcast
+        enqueued on ``self._stream`` runs asynchronously on the GPU, and pynccl
+        only bounds the *enqueue* phase (``run_task`` stops polling after
+        ``ncclSuccess``).  If a peer already departed, that broadcast kernel can
+        hang on the device while this thread reports ``thread_alive=False`` --
+        which later wedges any device sync (``inference_stream.synchronize()``)
+        and ``destroy_distributed``.  After joining we therefore bounded-drain
+        the stream and, on timeout, abort all NCCL communicators.
+        """
         self._stop.set()
         if self._thread.is_alive():
             self._thread.join(timeout=10.0)
+        # Backstop for an orphaned in-flight R2R broadcast on our stream (peer
+        # departed mid-collective).  Should never fire once the controller waits
+        # for all rollouts to check out before shutting down; logs loudly if it
+        # does.  See ``bounded_drain_or_abort``.
+        bounded_drain_or_abort(
+            self._stream,
+            _WST_STREAM_DRAIN_TIMEOUT_S,
+            f"WeightSyncThread[{self._worker.replica_name}]",
+        )
 
     def _run(self) -> None:
         torch.cuda.set_device(self._worker.device)
@@ -401,7 +434,10 @@ class WeightSyncThread:
             worker.data_packer.flush_pending_sends()
 
         weight_step = command.weight_step
-        r2r_barrier(worker, weight_step)
+        # Use the controller's authoritative recipient set for this round as the
+        # barrier participant count so it stays in lockstep as replicas finish.
+        expected_world_size = len(getattr(command, "dst_replica_names", None) or [])
+        r2r_barrier(worker, weight_step, expected_world_size=expected_world_size)
         t0 = time.monotonic()
         transferred_cnt, bytes_broadcast = do_nccl_broadcast_grouped(
             worker,
@@ -518,15 +554,32 @@ def setup_redis_barrier(worker) -> None:
     )
 
 
-def r2r_barrier(worker, weight_step: int) -> None:
+def r2r_barrier(
+    worker, weight_step: int, expected_world_size: Optional[int] = None
+) -> None:
     """Redis-based barrier so all rollout workers start R2R broadcast together.
 
     Uses an atomic INCR counter per weight step.  The last worker to arrive
     publishes a "go" signal; earlier workers block on pub/sub until they
     receive it (or timeout).  Silently skipped if Redis is unavailable.
+
+    ``expected_world_size`` is the authoritative number of participants for
+    *this* broadcast round, derived from the controller's ``dst_replica_names``
+    in the R2R command.  Using it (instead of the cached ``_r2r_world_size``,
+    which is frozen at setup) keeps the barrier in lockstep with the controller:
+    when a replica reaches end-of-data and the controller drops it from the
+    broadcast set, the remaining workers expect the shrunken count and the
+    barrier completes immediately rather than spinning for the full timeout.
     """
     r2r_redis = getattr(worker, "_r2r_redis", None)
-    world_size = getattr(worker, "_r2r_world_size", 0)
+    if expected_world_size is not None and expected_world_size > 0:
+        world_size = expected_world_size
+    else:
+        # Fall back to the live mesh size, then the cached value.  The cached
+        # ``_r2r_world_size`` becomes stale once replicas leave the mesh.
+        world_size = len(getattr(worker, "replica_name_to_rank", {})) or getattr(
+            worker, "_r2r_world_size", 0
+        )
     if r2r_redis is None or world_size <= 1:
         return
 
@@ -572,8 +625,20 @@ def r2r_barrier(worker, weight_step: int) -> None:
                 )
                 return
 
+            # Allow teardown to interrupt the wait: if the WeightSyncThread is
+            # asked to stop, abort the barrier rather than blocking ``wst.stop()``
+            # (and in turn ``destroy_distributed()``) for the full timeout.
+            wst = getattr(worker, "_weight_sync_thread", None)
+            stop_event = getattr(wst, "_stop", None)
             deadline = time.monotonic() + _R2R_BARRIER_TIMEOUT_S
             while time.monotonic() < deadline:
+                if stop_event is not None and stop_event.is_set():
+                    logger.info(
+                        "[R2R Barrier] Stop requested while waiting (step=%d); "
+                        "aborting barrier.",
+                        weight_step,
+                    )
+                    return
                 msg = pubsub.get_message(timeout=1.0)
                 if msg is not None and msg.get("type") == "message":
                     break

--- a/cosmos_rl/utils/constant.py
+++ b/cosmos_rl/utils/constant.py
@@ -38,6 +38,20 @@ COSMOS_HEARTBEAT_SEND_INTERVAL = int(
 COSMOS_CONTROL_HTTP_TIMEOUT = float(os.environ.get("COSMOS_CONTROL_HTTP_TIMEOUT", "30"))
 
 COSMOS_ROLLOUT_SCAN_INTERVAL = int(os.environ.get("COSMOS_ROLLOUT_SCAN_INTERVAL", "10"))
+# Opt-in escalation: when truthy, the controller's replica-status monitor
+# initiates a controller-wide shutdown (SIGTERM to self -> FastAPI lifespan
+# shutdown) once every policy replica has been marked dead by the heartbeat
+# timeout.  Default is off because cosmos-rl supports dynamic replica
+# scaling (scale-to-zero, rolling restart) where ``len(policy_replicas)
+# == 0`` is a legitimate transient state and a fatal shutdown would be
+# wrong.  Deployments without auto-respawn -- where one trainer death
+# means the whole job is lost -- can set this to ``1`` to free the
+# allocation immediately instead of waiting for the wall-clock timeout.
+# See ``cosmos_rl/dispatcher/run_web_panel.py::monitor_replica_status``
+# for the escalation logic.
+COSMOS_SHUTDOWN_ON_NO_POLICY_REPLICAS = os.environ.get(
+    "COSMOS_SHUTDOWN_ON_NO_POLICY_REPLICAS", "0"
+).lower() in ("1", "true", "yes")
 COSMOS_ROLLOUT_STEP_INTERVAL = int(
     os.environ.get("COSMOS_ROLLOUT_STEP_INTERVAL", "100")
 )

--- a/cosmos_rl/utils/payload_transport/ucxx/mixins.py
+++ b/cosmos_rl/utils/payload_transport/ucxx/mixins.py
@@ -43,6 +43,7 @@ from cosmos_rl.utils.payload_transport.ucxx.ucxx_buffer import (
     UCXX_AVAILABLE,
     UCXXBuffer,
     UCXXBufferConfig,
+    reset_ucxx_context,
 )
 
 # Trace utility is provided by a sibling MR; fall back to a wall-clock
@@ -411,9 +412,29 @@ class UCXXRolloutMixin:
             return None
 
     def cleanup_ucxx(self) -> None:
-        """Clean up UCXX resources."""
+        """Clean up UCXX resources.
+
+        Order matters:
+
+        1. ``stop_server`` joins the server threads/loops and closes every
+           listener and endpoint (a bounded drain that lets in-flight reads
+           finish -- which needs the progress thread *running*).
+        2. ``reset_ucxx_context`` then stops the UCXX worker's background C++
+           progress thread (and tears down the global context).  Doing this
+           *before* the shared-memory ``close()`` ensures no ``ucp_worker_progress``
+           runs concurrently with object teardown -- the race behind the rare
+           post-"Server stopped" SIGSEGV.
+        3. ``close()`` releases the shared-memory buffer once the progress
+           thread is quiescent.
+
+        Reset is gated on ``_ucxx_enabled`` so it only fires in a process that
+        actually started a UCXX server.
+        """
+        started_ucxx = self._ucxx_enabled
         if self._ucxx_buffer:
             self._ucxx_buffer.stop_server()
+            if started_ucxx:
+                reset_ucxx_context()
             self._ucxx_buffer.close()
             self._ucxx_buffer = None
         self._ucxx_enabled = False

--- a/cosmos_rl/utils/payload_transport/ucxx/ucxx_buffer.py
+++ b/cosmos_rl/utils/payload_transport/ucxx/ucxx_buffer.py
@@ -66,6 +66,158 @@ except ImportError:
     )
 
 
+def _drain_inflight_requests(worker, timeout_s: float = 8.0) -> None:
+    """Cancel + drain all in-flight UCXX requests **while the progress thread
+    is still running**, so every request-completion callback fires now, with a
+    healthy interpreter.
+
+    This is the fix for the residual post-"Server stopped" SIGSEGV seen on long
+    runs (~1% of rollout teardowns).  Per the ucxx docs, ``~Worker()`` /
+    ``~Endpoint()`` call ``cancelInflightRequests()`` during destruction, and
+    "we can't release the GIL when the garbage collector runs and destroys the
+    object."  So if any UCP request is still in flight when ``ucxx.reset()`` (or
+    interpreter finalization) garbage-collects the UCXX objects, the C++
+    progress thread dispatches that request's Python completion callback while
+    the collector holds the GIL / is tearing down the request->future dict ->
+    use-after-free (observed backtrace: ``WorkerProgressThread`` -> ucp callback
+    -> ``PyDict_GetItemWithError``).  At end-of-data there *are* in-flight reads
+    (the policy's last output fetches, logged as "Request canceled"), and more
+    of them on long runs -- which is why only the long matrix tripped it.
+
+    The documented teardown contract is: schedule cancellation, then progress
+    the worker until ``getCancelingSize()`` reaches 0.  The progress thread is
+    still alive here, so it does the progressing; we just wait (bounded) for the
+    canceling set to drain before the caller stops the thread and resets.
+
+    All calls are ``getattr``-guarded: on a ucxx build without these methods this
+    degrades to the prior behaviour (no worse than before).
+    """
+    cancel = getattr(worker, "cancel_inflight_requests", None)
+    if cancel is None:
+        return
+    try:
+        n = cancel()
+    except Exception:
+        logger.exception("[UCXXBuffer] cancel_inflight_requests failed")
+        return
+
+    get_canceling_size = getattr(worker, "get_canceling_size", None)
+    if get_canceling_size is not None:
+        deadline = time.monotonic() + timeout_s
+        while time.monotonic() < deadline:
+            try:
+                if get_canceling_size() == 0:
+                    break
+            except Exception:
+                break
+            time.sleep(0.01)
+    else:
+        # No introspection available; give the live progress thread a beat to
+        # dispatch the scheduled cancellations before it is stopped.
+        time.sleep(0.2)
+    logger.info("[UCXXBuffer] Drained in-flight UCXX requests (scheduled cancel=%s)", n)
+
+
+def reset_ucxx_context() -> None:
+    """Tear down the process-global UCXX context, stopping its progress thread.
+
+    UCXX runs in its default ``thread`` progress mode, where
+    ``ApplicationContext`` starts a C++ ``WorkerProgressThread`` (inside
+    ``ucxx::Worker``) that calls ``ucp_worker_progress`` in the background.
+    That thread keeps running until the worker is explicitly told to stop it --
+    ``stop_server`` closes the listeners and joins the asyncio loops, but the
+    global context (and therefore the progress thread) lives on.  Left running,
+    the progress thread dispatches into Python objects that the interpreter is
+    finalizing at shutdown (``PyObject_GC_UnTrack`` in the frame) ->
+    use-after-free -> a rare SIGSEGV logged *after* "Server stopped".
+
+    The critical ordering is three steps, all *before* any GC pass:
+    (1) drain in-flight requests (``_drain_inflight_requests``) while the
+    progress thread is still alive, so every request-completion callback fires
+    now; (2) stop the progress thread; (3) ``ucxx.reset()``.  Steps (1) and (2)
+    together are what make (3) safe.
+
+    Stopping the thread first (without (1)) is *not* sufficient: a UCP request
+    left in flight is cancelled by ``~Worker()``/``~Endpoint()`` during the
+    ``gc.collect()`` that ``ucxx.reset()`` (and interpreter finalization)
+    trigger, and the ucxx docs are explicit that the GIL cannot be released
+    while the collector destroys those objects -- so the progress thread
+    dispatches the request's Python callback into a half-torn-down
+    request->future dict (observed backtrace: ``WorkerProgressThread`` -> ucp
+    callback -> ``PyDict_GetItemWithError`` -> SIGSEGV).  ``reset()`` alone is
+    worse still: it stops the thread only *as a side effect* of GC finalizing
+    the ``ApplicationContext`` (``ThreadMode.__del__`` ->
+    ``stop_progress_thread()``), so the thread is racing
+    ``PyObject_GC_UnTrack`` on the very objects being collected.  Draining and
+    then stopping the thread up front needs no cooperation from any still-open
+    endpoint, so it is robust even when an endpoint is stuck.
+
+    ``ucxx.reset()`` then destroys the (now-quiescent) context for full hygiene.
+    It still raises if an Endpoint/Listener lingers (a stuck handler /
+    half-closed client), but that is now harmless -- the crash-causing thread is
+    already stopped -- so we just log it.
+
+    No-op when UCXX is unavailable or was never initialised in this process, and
+    idempotent (a second call sees no context; ``stop_progress_thread`` is itself
+    idempotent).
+    """
+    if not UCXX_AVAILABLE or ucxx is None:
+        return
+
+    # Reach the live context without *creating* one (``ucxx`` exposes the
+    # ``_get_ctx`` helper, but it would instantiate a fresh ApplicationContext
+    # just to tear it down).  ``ucxx.core`` is bound as an attribute of the
+    # package the moment ``import ucxx`` runs (its ``__init__`` does
+    # ``from .core import *``), so attribute access is reliable and avoids a
+    # redundant import.
+    ucxx_core = getattr(ucxx, "core", None)
+    if ucxx_core is None:
+        return
+    ctx = getattr(ucxx_core, "_ctx", None)
+    if ctx is None:
+        return
+
+    # Capture the worker before anything can null ``_ctx`` (``ucxx.reset()``
+    # nulls it before it may raise).  This handle is what lets us stop the
+    # progress thread regardless of endpoint state.
+    worker = getattr(ctx, "worker", None)
+    ctx = None  # drop the extra reference so it cannot itself defeat reset()
+
+    # 1) Drain in-flight requests while the progress thread is STILL running,
+    #    so no request-completion callback is left to fire into a finalizing
+    #    interpreter once we stop the thread / reset (the ~Worker()/~Endpoint()
+    #    GC path -- see _drain_inflight_requests).
+    if worker is not None:
+        _drain_inflight_requests(worker)
+
+    # 2) Stop the C++ progress thread synchronously, BEFORE any gc pass.  With
+    #    the requests already drained, no concurrent ``ucp_worker_progress``
+    #    callback can race object teardown.
+    if worker is not None:
+        try:
+            worker.stop_progress_thread()
+            logger.info("[UCXXBuffer] UCXX worker progress thread stopped")
+        except Exception:
+            logger.exception("[UCXXBuffer] Failed to stop UCXX worker progress thread")
+    else:
+        logger.warning(
+            "[UCXXBuffer] No UCXX worker handle captured; progress thread "
+            "could not be stopped explicitly"
+        )
+
+    # 3) Destroy the now-quiescent global context for full resource hygiene.
+    #    Safe because the progress thread is already joined; a raise here (an
+    #    endpoint/listener still referenced) no longer implies a live thread.
+    try:
+        ucxx.reset()
+        logger.info("[UCXXBuffer] UCXX context reset")
+    except Exception as e:
+        logger.warning(
+            f"[UCXXBuffer] ucxx.reset() did not fully tear down ({e}); "
+            "progress thread already stopped, so this is non-fatal"
+        )
+
+
 class StaleSlotError(RuntimeError):
     """Raised when a client reads a slot that has already been consumed."""
 

--- a/cosmos_rl/utils/pynccl.py
+++ b/cosmos_rl/utils/pynccl.py
@@ -27,17 +27,15 @@ from __future__ import annotations
 
 import glob
 import os
+import queue
 import threading
 import time
 from contextlib import contextmanager
-from typing import Dict, List, Optional, Callable
-import queue
 from dataclasses import dataclass, field
+from typing import Callable, Dict, List, Optional
 
 import torch
-from torch.cuda import Stream
-from torch.distributed import ReduceOp
-
+from cosmos_rl.utils.logging import logger
 from cosmos_rl.utils.pynccl_wrapper import (
     NCCLLibrary,
     buffer_type,
@@ -48,8 +46,8 @@ from cosmos_rl.utils.pynccl_wrapper import (
     ncclResultEnum,
     ncclUniqueId,
 )
-
-from cosmos_rl.utils.logging import logger
+from torch.cuda import Stream
+from torch.distributed import ReduceOp
 
 
 # ---------------------------------------------------------------------------
@@ -124,6 +122,11 @@ class _CommunicatorRegistry:
         """Remove and return metadata for *idx* (or sentinel tuple if absent)."""
         with self._lock:
             return self._store.pop(idx, None)
+
+    def all_indices(self) -> list[int]:
+        """Return a snapshot of all currently registered communicator handles."""
+        with self._lock:
+            return list(self._store.keys())
 
 
 _COMM_REGISTRY = _CommunicatorRegistry()
@@ -507,6 +510,73 @@ def nccl_abort(comm_idx: int):
         logger.warning(f"[NCCL] Aborted communicator idx={comm_idx}")
 
 
+def nccl_abort_all() -> int:
+    """Abort every registered communicator (best-effort).
+
+    Intended for teardown: ``ncclCommAbort`` forces any in-flight collective
+    (e.g. a grouped R2R broadcast whose peer already departed) to stop spinning
+    on the device, so that subsequent stream syncs and ``destroy_distributed``
+    cannot wedge.  Returns the number of communicators aborted.
+    """
+    indices = _COMM_REGISTRY.all_indices()
+    for cid in indices:
+        try:
+            nccl_abort(cid)
+        except Exception:
+            # Best-effort: already in a teardown/error path.
+            pass
+    if indices:
+        logger.warning("[NCCL] nccl_abort_all aborted %d communicator(s)", len(indices))
+    return len(indices)
+
+
+def bounded_drain_or_abort(stream, timeout_s: float, context: str) -> bool:
+    """Bounded-wait for in-flight GPU work on ``stream`` during teardown.
+
+    Records an event on ``stream`` and polls it until it completes or
+    ``timeout_s`` elapses.  ``pynccl`` only bounds the *enqueue* phase of a
+    collective (``run_task`` stops polling after ``ncclSuccess``), so a grouped
+    R2R broadcast whose peer has departed keeps spinning on the device with no
+    watchdog -- which would otherwise wedge the subsequent stream sync and
+    ``destroy_distributed``.
+
+    With coordinated controller shutdown in place this timeout should never fire
+    on a healthy run; reaching it means a peer genuinely vanished mid-collective
+    (crash / OOM / network), so we abort all NCCL communicators (best-effort) to
+    force teardown to completion.  Returns ``True`` if the stream drained
+    cleanly, ``False`` if it timed out and aborted.  ``context`` is a short
+    label included in logs to identify the call site.
+    """
+    try:
+        done = torch.cuda.Event()
+        done.record(stream)
+    except Exception:
+        # No CUDA context / stream available (e.g. CPU-only tests).
+        return True
+    t0 = time.monotonic()
+    deadline = t0 + timeout_s
+    while not done.query():
+        if time.monotonic() > deadline:
+            logger.warning(
+                "[ABNORMAL teardown] %s: in-flight GPU work exceeded %.1fs; a peer "
+                "likely departed unexpectedly mid-collective (crash/OOM/network) -- "
+                "this is NOT the normal coordinated-exit path.  Aborting NCCL "
+                "communicators to unblock teardown.",
+                context,
+                timeout_s,
+            )
+            try:
+                nccl_abort_all()
+            except Exception:
+                pass
+            return False
+        time.sleep(0.01)
+    logger.debug(
+        "[Teardown] %s: stream drained in %.2fs", context, time.monotonic() - t0
+    )
+    return True
+
+
 # Collective wrapper functions
 
 
@@ -721,6 +791,8 @@ __all__ = [
     "create_nccl_uid",
     "create_nccl_comm",
     "nccl_abort",
+    "nccl_abort_all",
+    "bounded_drain_or_abort",
     "get_nccl_comm_nranks",
     # collectives
     "nccl_broadcast",

--- a/cosmos_rl/utils/redis_stream.py
+++ b/cosmos_rl/utils/redis_stream.py
@@ -71,6 +71,22 @@ class RedisStreamHandler:
         self.teacher_request_stream = "teacher_request_stream"
         self.ping()
 
+    @staticmethod
+    def _is_polling_read_miss(exc: Exception) -> bool:
+        """Return True for expected streaming poll misses.
+
+        Redis stream reads use blocking XREAD as a poll primitive. A socket
+        timeout means no item arrived before the block timeout; connection
+        refused can also appear while worker polling threads unwind after the
+        controller has stopped its embedded Redis.
+        """
+        if isinstance(exc, redis.exceptions.TimeoutError):
+            return True
+        if isinstance(exc, redis.exceptions.ConnectionError):
+            message = str(exc).lower()
+            return "connection refused" in message or "error 111" in message
+        return False
+
     def set_key_value(self, key: str, value: str) -> bool:
         # Add message to stream
         try:
@@ -163,6 +179,7 @@ class RedisStreamHandler:
         Returns:
             list: A list of stream entries.
         """
+        messages = None
         try:
             messages = make_request_with_retry(
                 self.requests_for_alternative_clients(
@@ -177,6 +194,11 @@ class RedisStreamHandler:
                 max_retries=COSMOS_HTTP_STREAM_POLL_MAX_RETRY,
             )
         except Exception as e:
+            if self._is_polling_read_miss(e):
+                logger.debug(
+                    f"[Redis] Poll read returned no command from {stream_name}_command: {e}"
+                )
+                return []
             logger.error(
                 f"[Redis] Failed to read from Redis stream {stream_name}_command: {e}"
             )
@@ -246,6 +268,11 @@ class RedisStreamHandler:
                 max_retries=COSMOS_HTTP_STREAM_POLL_MAX_RETRY,
             )
         except Exception as e:
+            if self._is_polling_read_miss(e):
+                logger.debug(
+                    f"[Redis] Poll read returned no rollout from {stream_name}_rollout: {e}"
+                )
+                return []
             logger.error(
                 f"[Redis] Failed to read from Redis stream {stream_name}_rollout: {e}"
             )

--- a/tests/run_test.sh
+++ b/tests/run_test.sh
@@ -68,6 +68,7 @@ run python tests/test_nccl_timeout.py
 run python tests/test_parallel_map.py
 run python tests/test_policy_to_policy.py
 run python tests/test_policy_to_rollout.py
+run python tests/test_multirank_shutdown.py
 run python tests/test_process_flow.py
 run python tests/test_custom_class.py
 run python tests/test_math_verify.py

--- a/tests/subprocess_helpers.py
+++ b/tests/subprocess_helpers.py
@@ -1,0 +1,120 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Shared subprocess teardown helpers for GPU integration tests."""
+
+import os
+import signal
+import subprocess
+import time
+import urllib.error
+import urllib.request
+
+
+def _kill_descendants(parent_pid: int) -> None:
+    """Best-effort SIGKILL of ``parent_pid``'s descendant processes (Linux)."""
+    try:
+        result = subprocess.run(
+            ["pgrep", "-P", str(parent_pid)],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except (FileNotFoundError, OSError):
+        return
+    for line in result.stdout.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            child_pid = int(line)
+        except ValueError:
+            continue
+        _kill_descendants(child_pid)
+        try:
+            os.kill(child_pid, signal.SIGKILL)
+        except (ProcessLookupError, PermissionError):
+            pass
+
+
+def kill_process_group(process):
+    """SIGKILL the whole process tree of ``process`` and reap it."""
+    if process.poll() is None:
+        try:
+            _kill_descendants(process.pid)
+            pgid = os.getpgid(process.pid)
+            os.killpg(pgid, signal.SIGKILL)
+        except (ProcessLookupError, PermissionError):
+            pass
+        except Exception:
+            try:
+                process.kill()
+            except Exception:
+                pass
+    try:
+        process.wait(timeout=30)
+    except Exception:
+        pass
+
+
+def wait_for_controller_ready(
+    testcase, controller_process, port, timeout_s=120, context=""
+):
+    """Poll ``/api/meta`` until the controller finishes setup or exits."""
+    url = f"http://127.0.0.1:{port}/api/meta"
+    deadline = time.monotonic() + timeout_s
+    while time.monotonic() < deadline:
+        exit_code = controller_process.poll()
+        if exit_code is not None:
+            testcase.fail(
+                f"Controller exited with code {exit_code} before becoming ready"
+                f"{f' ({context})' if context else ''}."
+            )
+        try:
+            with urllib.request.urlopen(url, timeout=2) as response:
+                if response.status == 200:
+                    return
+        except (urllib.error.URLError, TimeoutError):
+            pass
+        time.sleep(0.5)
+    testcase.fail(
+        f"Controller did not become ready within {timeout_s:.0f}s"
+        f"{f' ({context})' if context else ''}."
+    )
+
+
+def wait_all_or_fail(testcase, processes, timeout_s, context):
+    """Bounded wait for subprocess trees; always reaps process groups."""
+    deadline = time.monotonic() + timeout_s
+    try:
+        try:
+            for process in processes:
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    raise subprocess.TimeoutExpired(cmd=context, timeout=timeout_s)
+                process.communicate(timeout=remaining)
+                testcase.assertEqual(
+                    process.returncode,
+                    0,
+                    f"Process failed with code: {process.returncode} ({context})",
+                )
+        except subprocess.TimeoutExpired:
+            testcase.fail(
+                f"Timed out after {timeout_s:.0f}s waiting for processes to exit "
+                f"cleanly ({context})."
+            )
+    finally:
+        for process in processes:
+            kill_process_group(process)

--- a/tests/test_colocated.py
+++ b/tests/test_colocated.py
@@ -22,6 +22,7 @@ import sys
 from cosmos_rl.utils import network_util
 import toml
 import tempfile
+from subprocess_helpers import wait_all_or_fail, wait_for_controller_ready
 
 
 class TestColocated(unittest.TestCase):
@@ -55,6 +56,7 @@ class TestColocated(unittest.TestCase):
         config["policy"]["parallelism"]["dp_shard_size"] = 4
         config["rollout"]["parallelism"]["n_init_replicas"] = 2
         config["policy"]["parallelism"]["n_init_replicas"] = 2
+        config["redis"] = str(network_util.find_available_port(12808))
         if "logging" not in config:
             config["logging"] = {}
         config["logging"]["logger"] = ["console"]
@@ -71,9 +73,17 @@ class TestColocated(unittest.TestCase):
         controller_process = subprocess.Popen(
             controller_cmd,
             shell=True,
+            start_new_session=True,
             stdout=sys.stderr,
             stderr=sys.stderr,
             env=env_dict,
+        )
+        wait_for_controller_ready(
+            self,
+            controller_process,
+            port,
+            timeout_s=120,
+            context="test_colocated",
         )
         os.environ["COSMOS_CONTROLLER_HOST"] = f"localhost:{port}"
         # Create the Python command for torchrun
@@ -94,6 +104,7 @@ class TestColocated(unittest.TestCase):
         # Start the process
         policy_process0 = subprocess.Popen(
             policy_cmd,
+            start_new_session=True,
             stdout=sys.stderr,
             stderr=sys.stderr,
             env=policy_env,
@@ -104,20 +115,14 @@ class TestColocated(unittest.TestCase):
         # Start the process
         policy_process1 = subprocess.Popen(
             policy_cmd,
+            start_new_session=True,
             stdout=sys.stderr,
             stderr=sys.stderr,
             env=policy_env,
         )
 
         processes = [controller_process, policy_process0, policy_process1]
-
-        # Wait for process to complete
-        for process in processes:
-            stdout, stderr = process.communicate()
-            # Check if process completed successfully
-            assert process.returncode == 0, (
-                f"Process failed with code: {process.returncode}"
-            )
+        wait_all_or_fail(self, processes, timeout_s=300, context="test_colocated")
 
 
 if __name__ == "__main__":

--- a/tests/test_custom_class.py
+++ b/tests/test_custom_class.py
@@ -28,6 +28,7 @@ from cosmos_rl.policy.config import Config as CosmosConfig
 from cosmos_rl.dispatcher.data.schema import RLPayload
 from cosmos_rl.utils import util
 from cosmos_rl.utils import network_util
+from subprocess_helpers import wait_all_or_fail, wait_for_controller_ready
 from cosmos_rl.utils.payload import extract_rollouts
 from datasets import concatenate_datasets
 
@@ -251,6 +252,7 @@ class TestCustomRollout(unittest.TestCase):
 
         config["policy"]["parallelism"]["tp_size"] = 1
         config["policy"]["parallelism"]["dp_shard_size"] = 4
+        config["redis"] = str(network_util.find_available_port(12808))
 
         with tempfile.NamedTemporaryFile(
             mode="w+", suffix=".toml", delete=False
@@ -262,11 +264,18 @@ class TestCustomRollout(unittest.TestCase):
         env_dict = os.environ.copy()
         env_dict["COSMOS_ROLE"] = "Controller"
         controller_process = subprocess.Popen(
-            controller_cmd,
-            shell=True,
+            controller_cmd.split(),
+            start_new_session=True,
             stdout=sys.stderr,
             stderr=sys.stderr,
             env=env_dict,
+        )
+        wait_for_controller_ready(
+            self,
+            controller_process,
+            port,
+            timeout_s=120,
+            context="test_custom_rollout",
         )
         os.environ["COSMOS_CONTROLLER_HOST"] = f"localhost:{port}"
         # Create the Python command for torchrun
@@ -297,6 +306,7 @@ class TestCustomRollout(unittest.TestCase):
         # Start the process
         policy_process = subprocess.Popen(
             policy_cmd,
+            start_new_session=True,
             stdout=sys.stderr,
             stderr=sys.stderr,
             env=policy_env,
@@ -308,6 +318,7 @@ class TestCustomRollout(unittest.TestCase):
             rollout_processes.append(
                 subprocess.Popen(
                     rollout_cmd,
+                    start_new_session=True,
                     stdout=sys.stderr,
                     stderr=sys.stderr,
                     env=rollout_env,
@@ -315,14 +326,7 @@ class TestCustomRollout(unittest.TestCase):
             )
 
         processes = [controller_process, policy_process] + rollout_processes
-
-        # Wait for process to complete
-        for process in processes:
-            stdout, stderr = process.communicate()
-            # Check if process completed successfully
-            assert process.returncode == 0, (
-                f"Process failed with code: {process.returncode}"
-            )
+        wait_all_or_fail(self, processes, timeout_s=300, context="test_custom_rollout")
 
 
 if __name__ == "__main__":

--- a/tests/test_hf_models.py
+++ b/tests/test_hf_models.py
@@ -83,11 +83,33 @@ def test_cosmos_hf_model(model, inputs):
         return logits[:, -1, :]
 
 
+_LOGITS_RTOL = 2e-2
+_LOGITS_ATOL = 2e-2
+
+
 def _logits_equal(a: torch.Tensor, b: torch.Tensor) -> bool:
     """Compare logits; generate() may upcast to float32 while forward stays bf16."""
-    if a.dtype != b.dtype:
-        a, b = a.float(), b.float()
-    return torch.equal(a, b)
+    a, b = a.float(), b.float()
+    # generate() returns float32; forward/cosmos paths stay bf16.  Compare with
+    # bf16-scale tolerance after promotion instead of requiring bitwise equality.
+    return torch.allclose(a, b, rtol=_LOGITS_RTOL, atol=_LOGITS_ATOL)
+
+
+def _logits_mismatch_summary(a: torch.Tensor, b: torch.Tensor) -> str:
+    a_float, b_float = a.detach().float(), b.detach().float()
+    diff = (a_float - b_float).abs()
+    if diff.numel() == 0:
+        return (
+            f"empty logits: a_dtype={a.dtype}, b_dtype={b.dtype}, "
+            f"rtol={_LOGITS_RTOL}, atol={_LOGITS_ATOL}"
+        )
+    max_abs_diff = diff.max().item()
+    mean_abs_diff = diff.mean().item()
+    return (
+        f"max_abs_diff={max_abs_diff:.6g}, mean_abs_diff={mean_abs_diff:.6g}, "
+        f"a_dtype={a.dtype}, b_dtype={b.dtype}, "
+        f"rtol={_LOGITS_RTOL}, atol={_LOGITS_ATOL}"
+    )
 
 
 class TestHFModel(unittest.TestCase):
@@ -325,9 +347,13 @@ class TestHFModel(unittest.TestCase):
                     cosmos_hf_model, copy.deepcopy(inputs)
                 )
                 assert _logits_equal(hf_generate_logits, hf_forward_logits), (
+                    "hf generate != hf forward: "
+                    f"{_logits_mismatch_summary(hf_generate_logits, hf_forward_logits)}\n"
                     f"{hf_generate_logits} != {hf_forward_logits}"
                 )
                 assert _logits_equal(hf_generate_logits, cosmos_hf_logits), (
+                    "hf generate != cosmos hf: "
+                    f"{_logits_mismatch_summary(hf_generate_logits, cosmos_hf_logits)}\n"
                     f"{hf_generate_logits} != {cosmos_hf_logits}"
                 )
 

--- a/tests/test_multirank_shutdown.py
+++ b/tests/test_multirank_shutdown.py
@@ -1,0 +1,1302 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""CPU unit tests for the multi-rank end-of-data shutdown protocol.
+
+Covers the corner cases enumerated in ``rollout_multirank_shutdown.md``:
+
+  * Corner 1 (P2R-gates-the-stop) and corners 2/3 (stop never emitted /
+    R2R ``in_mesh`` gate) -- neutralised on the controller side by
+    excluding ``status.ended`` rollouts from ``trigger_weight_sync`` so
+    no P2R recv / R2R broadcast is ever issued to a worker that is
+    leaving ``main_loop``.
+  * Corner 4 (lockstep invariant) and corner E (``dp>1`` uneven tail) --
+    handled by the controller's explicit ``StopCommand``: it is delivered
+    over the redis command channel and broadcast across ranks inside
+    ``consume_one_command``, so every rank sets the shutdown signal at the
+    same collective call and leaves ``main_loop`` in lockstep.  (This
+    replaced the former Option-C per-iteration drain vote.)
+
+The true cross-rank lockstep itself is exercised by the GPU integration
+test ``test_process_flow.py`` (bounded so a regression fails fast); these
+tests pin the decision logic that test depends on, on CPU.
+"""
+
+import threading
+import unittest
+import asyncio
+from queue import Queue
+from types import SimpleNamespace
+from unittest.mock import patch, MagicMock, AsyncMock
+
+from cosmos_rl.rollout.worker.rollout_control import (
+    DisaggregatedRolloutControlWorker,
+)
+from cosmos_rl.rollout.worker import weight_sync
+from cosmos_rl.rollout.worker.weight_sync import r2r_barrier
+from cosmos_rl.dispatcher.command import Command, StopCommand, TrainingCompleteCommand
+from cosmos_rl.dispatcher.status import (
+    JobPhase,
+    PolicyStatusManager,
+    RolloutStatusManager,
+    need_weight_sync,
+    should_broadcast_stop,
+)
+from cosmos_rl.dispatcher.protocol import MESH_NAMES, RegisterRequest, Role
+
+
+# ---------------------------------------------------------------------------
+# Controller -- final-step weight-sync suppression (unified end-of-data stop)
+# ---------------------------------------------------------------------------
+class TestNeedWeightSync(unittest.TestCase):
+    """``need_weight_sync``: the controller must NOT weight-sync on the final
+    training step of a non-validation run.  That sync is never consumed (no
+    step N+1) and, issued as an "ending signal", races rollout self-terminate
+    at end-of-data -> orphaned P2R recv -> ``ncclCommAbort`` hang.  Rollouts
+    now stop via the unified prompt-stream ``is_end`` path instead.  Validation
+    runs keep the last-step sync (it drives the final validation)."""
+
+    def test_non_validation_final_step_suppressed(self):
+        # Final step lands on an interval boundary, yet must NOT sync.
+        self.assertFalse(
+            need_weight_sync(
+                step=10,
+                total_steps=10,
+                sync_weight_interval=1,
+                validation_enabled=False,
+                validation_freq=None,
+            )
+        )
+        # Even with a coarse interval the final step never syncs.
+        self.assertFalse(
+            need_weight_sync(
+                step=10,
+                total_steps=10,
+                sync_weight_interval=5,
+                validation_enabled=False,
+                validation_freq=None,
+            )
+        )
+
+    def test_non_validation_interval_step_still_syncs(self):
+        # Non-final interval boundary -> normal sync (weights consumed by the
+        # next generation).
+        self.assertTrue(
+            need_weight_sync(
+                step=5,
+                total_steps=10,
+                sync_weight_interval=5,
+                validation_enabled=False,
+                validation_freq=None,
+            )
+        )
+
+    def test_non_validation_non_interval_step_no_sync(self):
+        self.assertFalse(
+            need_weight_sync(
+                step=4,
+                total_steps=10,
+                sync_weight_interval=5,
+                validation_enabled=False,
+                validation_freq=None,
+            )
+        )
+
+    def test_validation_final_step_kept(self):
+        # Validation on -> the last-step sync is retained to drive the final
+        # validation even when it is not an interval boundary.
+        self.assertTrue(
+            need_weight_sync(
+                step=10,
+                total_steps=10,
+                sync_weight_interval=5,
+                validation_enabled=True,
+                validation_freq=3,
+            )
+        )
+
+    def test_validation_freq_step_syncs(self):
+        self.assertTrue(
+            need_weight_sync(
+                step=6,
+                total_steps=10,
+                sync_weight_interval=5,
+                validation_enabled=True,
+                validation_freq=3,
+            )
+        )
+
+
+# ---------------------------------------------------------------------------
+# Explicit STOP command -- the unified, NCCL-free end-of-job stop
+# ---------------------------------------------------------------------------
+class TestStopCommandSerialization(unittest.TestCase):
+    """``StopCommand`` must survive the redis pack/depack round-trip and
+    resolve back to its own subclass (so ``get_rollout_command_handler``
+    dispatches to ``handle_stop``)."""
+
+    def test_pack_depack_roundtrip(self):
+        cmd = StopCommand("replica-7")
+        restored = Command.depack(cmd.pack())
+        self.assertIsInstance(restored, StopCommand)
+        self.assertEqual(restored.replica_name, "replica-7")
+        self.assertEqual(restored.command_type, "STOP")
+
+
+class TestStopCommandHandler(unittest.TestCase):
+    """``handle_stop`` must break ``main_loop`` out of *any* branch -- a
+    normal drain, an empty queue, or the weight-version-gate spin that no
+    longer clears once weight syncs stop -- by setting both shutdown
+    signals.  It must not touch NCCL (the whole point of the redis-channel
+    delivery)."""
+
+    @staticmethod
+    def _worker():
+        return SimpleNamespace(
+            replica_name="replica-0",
+            shutdown_signal=threading.Event(),
+            shutdown_mp_signal=threading.Event(),
+        )
+
+    def test_sets_both_shutdown_signals(self):
+        worker = self._worker()
+        self.assertFalse(worker.shutdown_signal.is_set())
+        DisaggregatedRolloutControlWorker.handle_stop(worker, StopCommand("replica-0"))
+        self.assertTrue(worker.shutdown_signal.is_set())
+        self.assertTrue(worker.shutdown_mp_signal.is_set())
+
+
+class TestShouldBroadcastStop(unittest.TestCase):
+    """``should_broadcast_stop`` gates the controller's one-shot end-of-job
+    STOP broadcast.  It must fire exactly when the policy side is genuinely
+    done (all policy replicas gone *after* we saw some, training finished,
+    non-validation, not already sent) and stay silent for every other
+    transition -- notably cold start, transient scale-to-zero, and
+    validation runs."""
+
+    # The canonical "policy just finished" state -> the one case that fires.
+    _FIRE = dict(
+        n_policy=0,
+        had_policy_replicas=True,
+        stop_broadcast_sent=False,
+        validation_enabled=False,
+        training_finished=True,
+        all_rollouts_ended=False,
+    )
+
+    def test_fires_at_genuine_end_of_job(self):
+        self.assertTrue(should_broadcast_stop(**self._FIRE))
+
+    def test_silent_while_policy_still_present(self):
+        # n_policy > 0: policy still running -> never stop the rollouts.
+        self.assertFalse(should_broadcast_stop(**{**self._FIRE, "n_policy": 2}))
+
+    def test_silent_on_cold_start(self):
+        # n_policy == 0 but no policy ever seen -> startup, not end-of-job.
+        self.assertFalse(
+            should_broadcast_stop(**{**self._FIRE, "had_policy_replicas": False})
+        )
+        self.assertFalse(
+            should_broadcast_stop(
+                **{
+                    **self._FIRE,
+                    "had_policy_replicas": False,
+                    "all_rollouts_ended": True,
+                }
+            )
+        )
+
+    def test_silent_on_transient_scale_to_zero(self):
+        # Policy gone but training not finished (rolling restart /
+        # scale-to-zero) and rollouts still live: stopping would be wrong.
+        self.assertFalse(
+            should_broadcast_stop(
+                **{
+                    **self._FIRE,
+                    "training_finished": False,
+                    "all_rollouts_ended": False,
+                }
+            )
+        )
+
+    def test_fires_when_rollouts_ended_but_total_steps_inflated(self):
+        # Post-is_end recompute can leave total_steps > current_step (buffer
+        # backlog the policy already walked away from).  STOP must still fire
+        # once every rollout has checked out and the policy is gone.
+        self.assertTrue(
+            should_broadcast_stop(
+                **{
+                    **self._FIRE,
+                    "training_finished": False,
+                    "all_rollouts_ended": True,
+                }
+            )
+        )
+
+    def test_suppressed_for_validation_runs(self):
+        # Validation keeps the final weight sync + R2R replica_should_stop;
+        # STOP would race that path.
+        self.assertFalse(
+            should_broadcast_stop(**{**self._FIRE, "validation_enabled": True})
+        )
+
+    def test_one_shot_not_resent(self):
+        # Already broadcast once -> never again.
+        self.assertFalse(
+            should_broadcast_stop(**{**self._FIRE, "stop_broadcast_sent": True})
+        )
+
+
+# ---------------------------------------------------------------------------
+# Controller -- policy-seen state is set by /register, not monitor polling
+# ---------------------------------------------------------------------------
+class TestRegisterTracksPolicySeen(unittest.TestCase):
+    def test_policy_register_sets_persistent_seen_flag(self):
+        """Short tests can register and unregister between monitor scans."""
+        from cosmos_rl.dispatcher import run_web_panel
+
+        original_any_seen = run_web_panel._replicas_were_registered
+        original_policy_seen = run_web_panel._policy_replicas_were_registered
+        run_web_panel._replicas_were_registered = False
+        run_web_panel._policy_replicas_were_registered = False
+        request = RegisterRequest(
+            replica_name="policy-0",
+            role=Role.POLICY,
+            mesh_names=MESH_NAMES,
+            global_rank=0,
+            host_ip="127.0.0.1",
+            host_name="localhost",
+            ranks=[0, 0, 0, 0],
+            group_size=[1, 1, 1, 1],
+        )
+        try:
+            with patch.object(
+                run_web_panel.controller, "register", new=AsyncMock()
+            ) as register_mock:
+                asyncio.run(run_web_panel.register(request))
+            register_mock.assert_awaited_once()
+            self.assertTrue(run_web_panel._replicas_were_registered)
+            self.assertTrue(run_web_panel._policy_replicas_were_registered)
+        finally:
+            run_web_panel._replicas_were_registered = original_any_seen
+            run_web_panel._policy_replicas_were_registered = original_policy_seen
+
+
+# ---------------------------------------------------------------------------
+# Controller -- trigger_weight_sync excludes ended rollouts
+# ---------------------------------------------------------------------------
+def _replica(name, ended, start_time):
+    return SimpleNamespace(
+        name=name,
+        start_time=start_time,
+        status=SimpleNamespace(ended=ended),
+    )
+
+
+class _RolloutMgrStub:
+    def __init__(self, replicas):
+        self._replicas = replicas
+        self.rollout_atoms_in_replica = 1
+
+    def get_all_atoms_arrived_replicas(self):
+        return list(self._replicas)
+
+
+class TestTriggerWeightSyncExcludesEnded(unittest.TestCase):
+    """Corners 1-3: the controller must not issue P2R/R2R to a rollout
+    that has already POSTed ``is_end`` (and is self-terminating), unless
+    validation is enabled (then the rollout stays for the final
+    validation and must keep receiving the sync)."""
+
+    def _run(self, replicas, validation_enabled):
+        mgr = PolicyStatusManager()
+        mgr.config = SimpleNamespace(
+            validation=SimpleNamespace(enable=validation_enabled)
+        )
+        mgr.policy_atoms_in_replica = 1
+        mgr.redis_handler = object()
+        policy_replica = _replica("policy-0", ended=False, start_time=0)
+        rollout_mgr = _RolloutMgrStub(replicas)
+
+        with (
+            patch(
+                "cosmos_rl.dispatcher.command.PolicyToRolloutUnicastCommand.trigger"
+            ) as p2r,
+            patch(
+                "cosmos_rl.dispatcher.command.RolloutToRolloutBroadcastCommand.trigger"
+            ) as r2r,
+        ):
+            mgr.trigger_weight_sync(
+                policy_replica, rollout_mgr, current_step=10, total_steps=10
+            )
+        return p2r, r2r
+
+    def test_single_ended_replica_no_sync(self):
+        """1 replica, ended, validation off -> early return, no P2R/R2R.
+
+        This is the failing-test topology (single rollout replica, intra-
+        replica TP): once it ends, the controller stops syncing entirely
+        and the rollout stops via the controller's explicit STOP command.
+        """
+        p2r, r2r = self._run(
+            [_replica("r0", ended=True, start_time=1)], validation_enabled=False
+        )
+        p2r.assert_not_called()
+        r2r.assert_not_called()
+
+    def test_mixed_excludes_only_ended(self):
+        """Live + ended replicas, validation off -> sync targets only the
+        live replica (ended dropped from P2R target and R2R recipients)."""
+        live = _replica("r-live", ended=False, start_time=1)
+        ended = _replica("r-ended", ended=True, start_time=0)
+        p2r, r2r = self._run([live, ended], validation_enabled=False)
+        p2r.assert_called_once()
+        r2r.assert_called_once()
+        # P2R unicast target is the (only) live replica.
+        self.assertIs(p2r.call_args.kwargs["dst_replica"], live)
+        # R2R recipient list excludes the ended replica.
+        dst_replicas = r2r.call_args.kwargs["dst_replicas"]
+        self.assertEqual(dst_replicas, [live])
+
+    def test_ended_included_when_validation_enabled(self):
+        """Validation on -> exclusion disabled; ended replica still synced
+        (it stays alive to serve the final validation)."""
+        ended = _replica("r-ended", ended=True, start_time=0)
+        p2r, r2r = self._run([ended], validation_enabled=True)
+        p2r.assert_called_once()
+        r2r.assert_called_once()
+        self.assertIs(p2r.call_args.kwargs["dst_replica"], ended)
+        self.assertEqual(r2r.call_args.kwargs["dst_replicas"], [ended])
+
+    def test_no_ended_unchanged_behavior(self):
+        """No ended replicas, validation off -> all replicas synced
+        (behaviour identical to before the exclusion)."""
+        a = _replica("r-a", ended=False, start_time=0)
+        b = _replica("r-b", ended=False, start_time=1)
+        p2r, r2r = self._run([a, b], validation_enabled=False)
+        p2r.assert_called_once()
+        r2r.assert_called_once()
+        self.assertIs(p2r.call_args.kwargs["dst_replica"], a)
+        self.assertEqual(r2r.call_args.kwargs["dst_replicas"], [a, b])
+
+
+class TestRolloutStatusAllEnded(unittest.TestCase):
+    def test_empty_rollout_manager_is_not_all_ended(self):
+        rsm = RolloutStatusManager()
+        self.assertFalse(rsm.all_rollouts_ended())
+
+    def test_all_ended_requires_at_least_one_rollout(self):
+        rsm = RolloutStatusManager()
+        rsm.rollout_replicas = {
+            "r0": SimpleNamespace(status=SimpleNamespace(ended=True)),
+            "r1": SimpleNamespace(status=SimpleNamespace(ended=True)),
+        }
+        self.assertTrue(rsm.all_rollouts_ended())
+
+
+# ---------------------------------------------------------------------------
+# Cross-replica R2R barrier (async_r2r_sync="generation"/"inference")
+# ---------------------------------------------------------------------------
+class _FakeRedis:
+    """Minimal Redis stand-in for the R2R barrier counter + pub/sub."""
+
+    def __init__(self, incr_result=1, get_result=None):
+        self._incr_result = incr_result
+        self._get_result = get_result if get_result is not None else incr_result
+        self.published = []
+        self.incr_calls = 0
+        self._pubsub = _FakePubSub()
+
+    def incr(self, key):
+        self.incr_calls += 1
+        return self._incr_result
+
+    def expire(self, key, ttl):
+        pass
+
+    def get(self, key):
+        return self._get_result
+
+    def publish(self, channel, msg):
+        self.published.append((channel, msg))
+
+    def pubsub(self):
+        return self._pubsub
+
+
+class _FakePubSub:
+    def __init__(self):
+        self.messages = []
+
+    def subscribe(self, channel):
+        pass
+
+    def get_message(self, timeout=None):
+        return self.messages.pop(0) if self.messages else None
+
+    def unsubscribe(self, channel):
+        pass
+
+    def close(self):
+        pass
+
+
+def _barrier_worker(redis, cached_world_size, mesh=None, stop_set=False):
+    wst = SimpleNamespace(_stop=threading.Event())
+    if stop_set:
+        wst._stop.set()
+    return SimpleNamespace(
+        _r2r_redis=redis,
+        _r2r_world_size=cached_world_size,
+        _r2r_barrier_prefix="test:r2r",
+        replica_name_to_rank=mesh if mesh is not None else {},
+        _weight_sync_thread=wst,
+    )
+
+
+class TestR2RBarrierWorldSize(unittest.TestCase):
+    """The generation-mode shutdown bug: ``_r2r_world_size`` is frozen at
+    setup, so when a replica reaches end-of-data and the controller drops it
+    from the broadcast set, the survivors kept waiting for a participant that
+    will never arrive (120 s timeout per step -> wedged shutdown).  The fix
+    drives the barrier off the controller's authoritative per-round count
+    (``len(dst_replica_names)``), falling back to the live mesh size."""
+
+    def test_expected_world_size_overrides_stale_cache(self):
+        """With one replica ended, the controller ships a count of 6 while the
+        cached size is the stale 7.  The 6th (last) arriver must publish "go"
+        immediately -- proving the barrier used 6, not 7 (which would block)."""
+        redis = _FakeRedis(incr_result=6)
+        worker = _barrier_worker(redis, cached_world_size=7)
+        r2r_barrier(worker, weight_step=80, expected_world_size=6)
+        self.assertEqual(redis.published, [("test:r2r:go:80", "go")])
+
+    def test_falls_back_to_live_mesh_when_no_expected(self):
+        """No explicit count -> use the live mesh size (2), not the stale
+        cached value (5).  Last arriver (count==2) publishes "go"."""
+        redis = _FakeRedis(incr_result=2)
+        worker = _barrier_worker(redis, cached_world_size=5, mesh={"a": 0, "b": 1})
+        r2r_barrier(worker, weight_step=10)
+        self.assertEqual(redis.published, [("test:r2r:go:10", "go")])
+
+    def test_skips_when_single_participant(self):
+        """world_size <= 1 -> no barrier at all (counter never touched)."""
+        redis = _FakeRedis(incr_result=1)
+        worker = _barrier_worker(redis, cached_world_size=5)
+        r2r_barrier(worker, weight_step=1, expected_world_size=1)
+        self.assertEqual(redis.incr_calls, 0)
+        self.assertEqual(redis.published, [])
+
+    def test_stop_event_aborts_wait(self):
+        """Teardown backstop: a waiting (non-last) worker must abort the
+        barrier wait when its WeightSyncThread is asked to stop, so
+        ``wst.stop()`` / ``destroy_distributed()`` are never blocked for the
+        full timeout.  Patch the timeout small so a regression fails fast
+        instead of busy-looping for 120 s."""
+        redis = _FakeRedis(incr_result=1, get_result=1)  # 1/2 -> waiter
+        worker = _barrier_worker(redis, cached_world_size=2, stop_set=True)
+        with patch.object(weight_sync, "_R2R_BARRIER_TIMEOUT_S", 2):
+            r2r_barrier(worker, weight_step=5, expected_world_size=2)
+        # Aborted as a waiter: never published "go".
+        self.assertEqual(redis.published, [])
+
+
+# ---------------------------------------------------------------------------
+# Teardown: in-flight R2R broadcast abort (async_r2r_sync="generation")
+# ---------------------------------------------------------------------------
+class _FakeCudaEvent:
+    """Stand-in for ``torch.cuda.Event`` that never completes (or always does)."""
+
+    def __init__(self, completed):
+        self._completed = completed
+
+    def record(self, stream=None):
+        pass
+
+    def query(self):
+        return self._completed
+
+
+class TestNcclAbortAll(unittest.TestCase):
+    """The teardown gap: an async R2R grouped broadcast is enqueued on the
+    WeightSyncThread stream and pynccl only bounds the *enqueue* phase, so a
+    broadcast whose peer departed hangs on the device with no watchdog.
+    ``nccl_abort_all`` is the primitive that unwedges it at teardown."""
+
+    def test_aborts_all_registered_and_empties_registry(self):
+        from cosmos_rl.utils import pynccl
+
+        # Registry is empty on CPU; register a few fakes.
+        idxs = [
+            pynccl._COMM_REGISTRY.register(object(), rank=r, world_size=4)
+            for r in range(3)
+        ]
+        self.assertEqual(sorted(pynccl._COMM_REGISTRY.all_indices()), sorted(idxs))
+        with patch.object(pynccl, "_nccl") as fake_nccl:
+            n = pynccl.nccl_abort_all()
+        self.assertEqual(n, 3)
+        self.assertEqual(fake_nccl.ncclCommAbort.call_count, 3)
+        # Registry fully drained -> a second call is a no-op.
+        self.assertEqual(pynccl._COMM_REGISTRY.all_indices(), [])
+        with patch.object(pynccl, "_nccl"):
+            self.assertEqual(pynccl.nccl_abort_all(), 0)
+
+
+class TestBoundedDrainOrAbort(unittest.TestCase):
+    """The shared teardown guard used by both ``WeightSyncThread.stop()`` (its
+    own stream) and the rollout ``work()`` teardown (inference_stream): bounded-
+    wait for in-flight GPU work and, on timeout (a peer departed mid-collective),
+    abort all NCCL comms so the subsequent sync / ``destroy_distributed`` cannot
+    wedge.  Returns True if drained cleanly, False if it timed out + aborted."""
+
+    def _drain(self, completed):
+        from cosmos_rl.utils import pynccl
+
+        with (
+            patch(
+                "cosmos_rl.utils.pynccl.torch.cuda.Event",
+                lambda: _FakeCudaEvent(completed),
+            ),
+            patch("cosmos_rl.utils.pynccl.nccl_abort_all") as fake_abort,
+        ):
+            result = pynccl.bounded_drain_or_abort(
+                object(), timeout_s=0.05, context="test"
+            )
+        return result, fake_abort
+
+    def test_aborts_when_stream_never_drains(self):
+        result, fake_abort = self._drain(completed=False)
+        fake_abort.assert_called_once()
+        self.assertFalse(result)
+
+    def test_no_abort_when_stream_drains(self):
+        result, fake_abort = self._drain(completed=True)
+        fake_abort.assert_not_called()
+        self.assertTrue(result)
+
+
+class TestCleanupPayloadServer(unittest.TestCase):
+    """Teardown stops the rollout's UCXX output server (``cleanup_ucxx``)
+    before the NCCL abort, so a trainer still pulling this replica's final
+    output cannot wedge ``ncclCommAbort``.  The hook is ``getattr``-guarded so
+    backends without a UCXX server are unaffected."""
+
+    def _call(self, rollout):
+        fake_self = SimpleNamespace(rollout=rollout, replica_name="r-test")
+        DisaggregatedRolloutControlWorker._cleanup_payload_server(fake_self)
+
+    def test_calls_cleanup_when_present(self):
+        rollout = SimpleNamespace(cleanup_ucxx=MagicMock())
+        self._call(rollout)
+        rollout.cleanup_ucxx.assert_called_once_with()
+
+    def test_noop_when_backend_has_no_server(self):
+        # Backend without cleanup_ucxx -> no error, nothing to call.
+        self._call(SimpleNamespace())
+        self._call(None)
+
+    def test_swallows_cleanup_exception(self):
+        rollout = SimpleNamespace(
+            cleanup_ucxx=MagicMock(side_effect=RuntimeError("boom"))
+        )
+        # Must not propagate: teardown has to continue to the NCCL abort.
+        self._call(rollout)
+        rollout.cleanup_ucxx.assert_called_once_with()
+
+
+class TestRolloutCheckoutGate(unittest.TestCase):
+    """Root-cause fix: on all-policy-dead the controller must wait for rollout
+    replicas to check out (post end) before self-SIGTERM, otherwise stragglers
+    wedge on a dead controller and survivors orphan the final R2R broadcast.
+    ``_await_rollout_checkout`` is the bounded gate."""
+
+    @staticmethod
+    def _controller(ended_flags):
+        replicas = {
+            f"r{i}": SimpleNamespace(status=SimpleNamespace(ended=bool(e)))
+            for i, e in enumerate(ended_flags)
+        }
+        rsm = SimpleNamespace(
+            rollout_replicas=replicas,
+            maintain_life_status=MagicMock(),
+        )
+        rsm.all_rollouts_ended = lambda: all(
+            r.status.ended for r in rsm.rollout_replicas.values()
+        )
+        return SimpleNamespace(
+            rollout_status_manager=rsm, policy_status_manager=object()
+        )
+
+    def test_returns_true_when_all_already_ended(self):
+        from cosmos_rl.dispatcher import run_web_panel
+
+        ctrl = self._controller([True, True, True])
+        ev = threading.Event()
+        self.assertTrue(
+            run_web_panel._await_rollout_checkout(
+                ctrl, ev, timeout_s=5.0, scan_interval_s=0.01
+            )
+        )
+        # All ended up front -> never had to pump life-status.
+        ctrl.rollout_status_manager.maintain_life_status.assert_not_called()
+
+    def test_returns_true_when_no_rollouts_exist(self):
+        from cosmos_rl.dispatcher import run_web_panel
+
+        ctrl = self._controller([])
+        ev = threading.Event()
+        self.assertTrue(
+            run_web_panel._await_rollout_checkout(
+                ctrl, ev, timeout_s=5.0, scan_interval_s=0.01
+            )
+        )
+        ctrl.rollout_status_manager.maintain_life_status.assert_not_called()
+
+    def test_waits_then_true_when_straggler_checks_out(self):
+        from cosmos_rl.dispatcher import run_web_panel
+
+        ctrl = self._controller([True, False])
+        rsm = ctrl.rollout_status_manager
+
+        # Straggler posts end on the first maintain_life_status pump.
+        def _flip(_pol):
+            rsm.rollout_replicas["r1"].status.ended = True
+
+        rsm.maintain_life_status.side_effect = _flip
+        ev = threading.Event()
+        self.assertTrue(
+            run_web_panel._await_rollout_checkout(
+                ctrl, ev, timeout_s=5.0, scan_interval_s=0.01
+            )
+        )
+        rsm.maintain_life_status.assert_called()
+
+    def test_times_out_when_rollout_never_checks_out(self):
+        from cosmos_rl.dispatcher import run_web_panel
+
+        ctrl = self._controller([True, False])
+        ev = threading.Event()
+        # Deadline in the past -> forces the abnormal-path return without hanging.
+        self.assertFalse(
+            run_web_panel._await_rollout_checkout(
+                ctrl, ev, timeout_s=0.0, scan_interval_s=0.01
+            )
+        )
+
+    def test_external_shutdown_signal_breaks_wait(self):
+        from cosmos_rl.dispatcher import run_web_panel
+
+        ctrl = self._controller([False])
+        ev = threading.Event()
+        ev.set()  # already signaled -> wait() returns True immediately
+        self.assertFalse(
+            run_web_panel._await_rollout_checkout(
+                ctrl, ev, timeout_s=5.0, scan_interval_s=0.01
+            )
+        )
+
+
+class TestFinalValidationCompletion(unittest.TestCase):
+    def test_validation_report_completion_clears_controller_state(self):
+        data_fetcher = SimpleNamespace(
+            val_datasize=2,
+            val_dataloader=None,
+            activated_val_iter=object(),
+            activated_val_tqdm=SimpleNamespace(update=MagicMock()),
+        )
+
+        def _clear_validation_status():
+            data_fetcher.activated_val_iter = None
+            data_fetcher.activated_val_tqdm = None
+
+        data_fetcher.clear_validation_status = MagicMock(
+            side_effect=_clear_validation_status
+        )
+        psm = SimpleNamespace(
+            val_report_data={},
+            data_fetcher=data_fetcher,
+            config=SimpleNamespace(
+                validation=SimpleNamespace(n_generation=1),
+                logging=SimpleNamespace(logger=[]),
+            ),
+            total_steps=2,
+            custom_logger_fns=[],
+            try_trigger_data_fetch_and_training=MagicMock(),
+        )
+        psm._expected_validation_rollout_count = (
+            PolicyStatusManager._expected_validation_rollout_count.__get__(psm)
+        )
+        psm._reported_validation_rollout_count = (
+            PolicyStatusManager._reported_validation_rollout_count.__get__(psm)
+        )
+        psm.validation_report_validation_results = (
+            PolicyStatusManager.validation_report_validation_results.__get__(psm)
+        )
+        rollouts = [
+            SimpleNamespace(reward=1.0, report_metrics=None),
+            SimpleNamespace(reward=0.0, report_metrics=None),
+        ]
+        with patch("cosmos_rl.dispatcher.status.logger.info") as info:
+            psm.validation_report_validation_results(
+                validation_step=2,
+                validation_results=[rollouts],
+                rollout_status_manager=SimpleNamespace(),
+            )
+        data_fetcher.clear_validation_status.assert_called_once()
+        self.assertIsNone(data_fetcher.activated_val_iter)
+        psm.try_trigger_data_fetch_and_training.assert_called_once()
+        self.assertTrue(
+            any("Validation finished" in call.args[0] for call in info.call_args_list)
+        )
+
+    def test_validation_prompt_fetch_after_policy_shutdown_serves_active_validation(
+        self,
+    ):
+        from cosmos_rl.dispatcher.controller import Controller
+
+        class NoPolicyStatus:
+            def __len__(self):
+                return 0
+
+        psm = NoPolicyStatus()
+        data_fetcher = SimpleNamespace(
+            activated_val_iter=object(),
+            get_batched_prompt=MagicMock(return_value=(["payload"], False)),
+        )
+        controller = SimpleNamespace(
+            policy_status_manager=psm, data_fetcher=data_fetcher
+        )
+        method = Controller._get_batched_prompt_impl.__get__(controller)
+        payloads, is_end = asyncio.run(method(8, validation_step=2))
+        self.assertEqual(payloads, ["payload"])
+        self.assertFalse(is_end)
+        data_fetcher.get_batched_prompt.assert_called_once_with(
+            8,
+            2,
+            None,
+            weight_version=None,
+        )
+
+    def test_validation_prompt_fetch_after_validation_exhausted_signals_end(self):
+        from cosmos_rl.dispatcher.controller import Controller
+
+        class NoPolicyStatus:
+            def __len__(self):
+                return 0
+
+        controller = SimpleNamespace(
+            policy_status_manager=NoPolicyStatus(),
+            data_fetcher=SimpleNamespace(activated_val_iter=None),
+        )
+        method = Controller._get_batched_prompt_impl.__get__(controller)
+        payloads, is_end = asyncio.run(method(8, validation_step=2))
+        self.assertEqual(payloads, [])
+        self.assertTrue(is_end)
+
+    def test_non_validation_prompt_fetch_after_policy_shutdown_is_training_end(self):
+        from cosmos_rl.dispatcher.controller import Controller
+
+        class NoPolicyStatus:
+            def __len__(self):
+                return 0
+
+        psm = NoPolicyStatus()
+        controller = SimpleNamespace(policy_status_manager=psm)
+        method = Controller._get_batched_prompt_impl.__get__(controller)
+        payloads, is_end = asyncio.run(method(8))
+        self.assertEqual(payloads, [])
+        self.assertTrue(is_end)
+
+    def test_finalize_logs_error_if_validation_is_still_active(self):
+        from cosmos_rl.dispatcher import run_web_panel
+
+        class EmptyPolicyStatus:
+            def __len__(self):
+                return 0
+
+            def training_finished(self):
+                return True
+
+        class EmptyManager:
+            def __len__(self):
+                return 0
+
+        original_controller = run_web_panel.controller
+        original_server = run_web_panel.server
+        server = SimpleNamespace(should_exit=False)
+        psm = EmptyPolicyStatus()
+        psm.data_fetcher = SimpleNamespace(activated_val_iter=object())
+        run_web_panel.controller = SimpleNamespace(
+            policy_status_manager=psm,
+            rollout_status_manager=EmptyManager(),
+            teacher_result_manager=set(),
+            is_rl=True,
+        )
+        run_web_panel.server = server
+        try:
+            with patch("cosmos_rl.dispatcher.run_web_panel.logger.error") as error:
+                self.assertTrue(run_web_panel._maybe_finalize("clean unregister of r0"))
+        finally:
+            run_web_panel.controller = original_controller
+            run_web_panel.server = original_server
+        self.assertIn("validation is still active", error.call_args.args[0])
+        self.assertTrue(server.should_exit)
+
+
+# ---------------------------------------------------------------------------
+# Rollout -- fail-fast command poll after StopCommand
+# ---------------------------------------------------------------------------
+class TestQueryCommandStopsAfterStop(unittest.TestCase):
+    """``query_command_from_controller`` must not block on a second XREAD after
+    ``StopCommand`` is enqueued."""
+
+    def test_stops_poll_loop_after_stop_command(self):
+        stop_cmd = StopCommand("replica-0")
+        subscribe_calls = []
+
+        def fake_subscribe(replica_name):
+            subscribe_calls.append(replica_name)
+            return [stop_cmd.pack()]
+
+        worker = SimpleNamespace(
+            replica_name="replica-0",
+            shutdown_signal=threading.Event(),
+            redis_controller=SimpleNamespace(subscribe_command=fake_subscribe),
+            _command_queue=Queue(),
+        )
+        DisaggregatedRolloutControlWorker.query_command_from_controller(worker)
+        self.assertEqual(subscribe_calls, ["replica-0"])
+        self.assertEqual(worker._command_queue.qsize(), 1)
+        self.assertIsInstance(worker._command_queue.get(), StopCommand)
+
+
+# ---------------------------------------------------------------------------
+# Controller -- JobPhase end-of-data model
+# ---------------------------------------------------------------------------
+class TestJobPhaseEnterDraining(unittest.TestCase):
+    def test_first_is_end_enters_draining_and_recomputes(self):
+        recompute_args = []
+
+        def _recompute(explicit_num_remaining_samples=None):
+            recompute_args.append(explicit_num_remaining_samples)
+
+        psm = SimpleNamespace(
+            job_phase=JobPhase.RUNNING,
+            total_pending_rollouts=lambda: 8,
+            recompute_total_steps=_recompute,
+        )
+        psm.enter_draining_phase = PolicyStatusManager.enter_draining_phase.__get__(psm)
+        psm.enter_draining_phase()
+        self.assertEqual(psm.job_phase, JobPhase.DRAINING)
+        self.assertEqual(recompute_args, [8])
+
+    def test_second_enter_stays_draining(self):
+        recompute_args = []
+
+        def _recompute(explicit_num_remaining_samples=None):
+            recompute_args.append(explicit_num_remaining_samples)
+
+        psm = SimpleNamespace(
+            job_phase=JobPhase.DRAINING,
+            total_pending_rollouts=lambda: 4,
+            recompute_total_steps=_recompute,
+        )
+        psm.enter_draining_phase = PolicyStatusManager.enter_draining_phase.__get__(psm)
+        psm.enter_draining_phase()
+        self.assertEqual(psm.job_phase, JobPhase.DRAINING)
+        self.assertEqual(recompute_args, [])
+
+
+class TestJobPhaseWeightSync(unittest.TestCase):
+    def test_draining_suppresses_weight_sync(self):
+        psm = SimpleNamespace(
+            job_phase=JobPhase.DRAINING,
+            total_steps=10,
+            config=SimpleNamespace(
+                train=SimpleNamespace(sync_weight_interval=1),
+                validation=SimpleNamespace(enable=False, freq=None),
+            ),
+        )
+        rsm = SimpleNamespace(
+            all_rollouts_ended=lambda: False,
+            rollout_replicas={},
+        )
+        psm.should_weight_sync_after_train_ack = (
+            PolicyStatusManager.should_weight_sync_after_train_ack.__get__(psm)
+        )
+        self.assertFalse(psm.should_weight_sync_after_train_ack(2, rsm))
+
+    def test_running_defers_to_need_weight_sync(self):
+        psm = SimpleNamespace(
+            job_phase=JobPhase.RUNNING,
+            total_steps=10,
+            config=SimpleNamespace(
+                train=SimpleNamespace(sync_weight_interval=5),
+                validation=SimpleNamespace(enable=False, freq=None),
+            ),
+        )
+        ended = SimpleNamespace(status=SimpleNamespace(ended=True), start_time=1.0)
+        live = SimpleNamespace(status=SimpleNamespace(ended=False), start_time=2.0)
+        rsm = SimpleNamespace(
+            all_rollouts_ended=lambda: False,
+            rollout_replicas={"r0": ended, "r1": live},
+            get_all_atoms_arrived_replicas=lambda: [ended, live],
+        )
+        psm.should_weight_sync_after_train_ack = (
+            PolicyStatusManager.should_weight_sync_after_train_ack.__get__(psm)
+        )
+        psm._weight_sync_rollout_targets = (
+            PolicyStatusManager._weight_sync_rollout_targets.__get__(psm)
+        )
+        self.assertTrue(psm.should_weight_sync_after_train_ack(5, rsm))
+
+    def test_final_validation_sync_when_rollouts_already_ended(self):
+        """Regression: final validation must not be skipped after prompt is_end."""
+        ended = SimpleNamespace(status=SimpleNamespace(ended=True), start_time=1.0)
+        psm = SimpleNamespace(
+            job_phase=JobPhase.RUNNING,
+            total_steps=2,
+            config=SimpleNamespace(
+                train=SimpleNamespace(sync_weight_interval=1),
+                validation=SimpleNamespace(enable=True, freq=1),
+            ),
+        )
+        rsm = SimpleNamespace(
+            all_rollouts_ended=lambda: True,
+            rollout_replicas={"r0": ended},
+            get_all_atoms_arrived_replicas=lambda: [ended],
+        )
+        psm.should_weight_sync_after_train_ack = (
+            PolicyStatusManager.should_weight_sync_after_train_ack.__get__(psm)
+        )
+        psm._weight_sync_rollout_targets = (
+            PolicyStatusManager._weight_sync_rollout_targets.__get__(psm)
+        )
+        self.assertTrue(psm.should_weight_sync_after_train_ack(2, rsm))
+
+    def test_non_final_sync_suppressed_when_rollouts_ended(self):
+        ended = SimpleNamespace(status=SimpleNamespace(ended=True), start_time=1.0)
+        psm = SimpleNamespace(
+            job_phase=JobPhase.RUNNING,
+            total_steps=2,
+            config=SimpleNamespace(
+                train=SimpleNamespace(sync_weight_interval=1),
+                validation=SimpleNamespace(enable=True, freq=1),
+            ),
+        )
+        rsm = SimpleNamespace(
+            all_rollouts_ended=lambda: True,
+            rollout_replicas={"r0": ended},
+            get_all_atoms_arrived_replicas=lambda: [ended],
+        )
+        psm.should_weight_sync_after_train_ack = (
+            PolicyStatusManager.should_weight_sync_after_train_ack.__get__(psm)
+        )
+        self.assertFalse(psm.should_weight_sync_after_train_ack(1, rsm))
+
+
+class TestJobPhaseFinishDraining(unittest.TestCase):
+    def test_finish_triggers_training_complete_when_buffer_empty(self):
+        training_complete = []
+        recompute_calls = []
+
+        def _recompute(explicit_num_remaining_samples=None):
+            recompute_calls.append(explicit_num_remaining_samples)
+            psm.total_steps = psm.current_step
+
+        def _trigger_training_complete():
+            training_complete.append(True)
+
+        psm = SimpleNamespace(
+            total_steps=10,
+            current_step=9,
+            policy_replicas={},
+            total_pending_rollouts=lambda: 0,
+            all_ready_or_reduced=lambda: True,
+            recompute_total_steps=_recompute,
+            trigger_training_complete=_trigger_training_complete,
+            rollout_buffer=SimpleNamespace(queue=SimpleNamespace(clear=lambda: None)),
+        )
+        psm.finish_draining_phase = PolicyStatusManager.finish_draining_phase.__get__(
+            psm
+        )
+        rsm = SimpleNamespace(all_rollouts_ended=lambda: True)
+        psm.finish_draining_phase(rsm)
+        self.assertEqual(recompute_calls, [0])
+        self.assertEqual(psm.total_steps, 10)
+        self.assertEqual(training_complete, [True])
+
+    def test_finish_happen_to_finish_skips_when_buffer_empty(self):
+        """When the buffer is already drained, no TrainingComplete is needed."""
+        training_complete = []
+
+        psm = SimpleNamespace(
+            total_steps=3,
+            current_step=3,
+            total_pending_rollouts=lambda: 0,
+            recompute_total_steps=lambda **kw: None,
+            trigger_training_complete=lambda: training_complete.append(True),
+            rollout_buffer=SimpleNamespace(queue=SimpleNamespace(clear=lambda: None)),
+        )
+        psm.finish_draining_phase = PolicyStatusManager.finish_draining_phase.__get__(
+            psm
+        )
+        psm.finish_draining_phase(SimpleNamespace(all_rollouts_ended=lambda: True))
+        self.assertEqual(training_complete, [])
+
+    def test_finish_buffered_rollouts_triggers_training_complete(self):
+        """Regression: buffered rollouts at the final step must still dispatch."""
+        cleared = []
+        training_complete = []
+        queue = SimpleNamespace(clear=lambda: cleared.append(True))
+
+        psm = SimpleNamespace(
+            total_steps=3,
+            current_step=3,
+            policy_replicas={},
+            total_pending_rollouts=lambda: 8,
+            all_ready_or_reduced=lambda: True,
+            recompute_total_steps=lambda **kw: None,
+            trigger_training_complete=lambda: training_complete.append(True),
+            rollout_buffer=SimpleNamespace(queue=queue),
+        )
+        psm.finish_draining_phase = PolicyStatusManager.finish_draining_phase.__get__(
+            psm
+        )
+        psm.finish_draining_phase(SimpleNamespace(all_rollouts_ended=lambda: True))
+        self.assertEqual(cleared, [True])
+        self.assertEqual(psm.total_steps, 4)
+        self.assertEqual(training_complete, [True])
+
+
+class TestJobPhaseValidationBypass(unittest.TestCase):
+    def test_on_rollout_is_end_noop_when_validation_enabled(self):
+        psm = SimpleNamespace(
+            job_phase=JobPhase.RUNNING,
+            config=SimpleNamespace(validation=SimpleNamespace(enable=True)),
+            enter_draining_phase=lambda: (_ for _ in ()).throw(
+                AssertionError("must not enter draining")
+            ),
+            finish_draining_phase=lambda rsm: (_ for _ in ()).throw(
+                AssertionError("must not finish draining")
+            ),
+        )
+        psm.on_rollout_is_end = PolicyStatusManager.on_rollout_is_end.__get__(psm)
+        psm.on_rollout_is_end(SimpleNamespace())
+        self.assertEqual(psm.job_phase, JobPhase.RUNNING)
+
+
+class TestTrainingCompleteCommand(unittest.TestCase):
+    def test_pack_depack_roundtrip(self):
+        cmd = TrainingCompleteCommand(
+            "policy-0",
+            global_step=3,
+            total_steps=3,
+            remain_samples_num=0,
+        )
+        restored = Command.depack(cmd.pack())
+        self.assertIsInstance(restored, TrainingCompleteCommand)
+        self.assertEqual(restored.replica_name, "policy-0")
+        self.assertEqual(restored.global_step, 3)
+        self.assertEqual(restored.total_steps, 3)
+        self.assertEqual(restored.command_type, "TRAINING_COMPLETE")
+
+    def test_trigger_training_complete_dispatch(self):
+        triggered = []
+        replica = SimpleNamespace(
+            name="policy-0",
+            sub_profiler_config=SimpleNamespace(
+                do_profile=False,
+                active_steps=None,
+                rank_filter=None,
+                record_shape=None,
+                profile_memory=None,
+                with_stack=None,
+                with_modules=None,
+            ),
+        )
+
+        def fake_trigger(**kwargs):
+            triggered.append(kwargs)
+
+        psm = SimpleNamespace(
+            data_fetcher=SimpleNamespace(activated_val_iter=None),
+            current_step=2,
+            total_steps=3,
+            remain_samples_num=0,
+            dispatched_rollouts_by_step={},
+            config=SimpleNamespace(
+                validation=SimpleNamespace(enable=False, freq=1),
+                train=SimpleNamespace(
+                    ckpt=SimpleNamespace(
+                        enable_checkpoint=False, save_freq=1, save_freq_in_epoch=None
+                    ),
+                    epoch=1,
+                ),
+            ),
+            redis_handler=object(),
+            get_all_atoms_arrived_replicas=lambda: [replica],
+            training_finished=lambda: False,
+            check_checkpoint_saving=lambda n: False,
+            set_status=lambda name, status: None,
+        )
+        psm.trigger_training_complete = (
+            PolicyStatusManager.trigger_training_complete.__get__(psm)
+        )
+        with patch.object(TrainingCompleteCommand, "trigger", fake_trigger):
+            psm.trigger_training_complete()
+        self.assertEqual(psm.current_step, 3)
+        self.assertEqual(psm.dispatched_rollouts_by_step[3], 0)
+        self.assertEqual(len(triggered), 1)
+        self.assertEqual(triggered[0]["global_step"], 3)
+
+    def test_finish_draining_calls_training_complete(self):
+        calls = []
+
+        def _trigger():
+            calls.append(True)
+
+        psm = SimpleNamespace(
+            total_steps=10,
+            current_step=9,
+            policy_replicas={},
+            total_pending_rollouts=lambda: 0,
+            all_ready_or_reduced=lambda: True,
+            recompute_total_steps=lambda **kw: setattr(
+                psm, "total_steps", psm.current_step
+            ),
+            trigger_training_complete=_trigger,
+            rollout_buffer=SimpleNamespace(queue=SimpleNamespace(clear=lambda: None)),
+        )
+        psm.finish_draining_phase = PolicyStatusManager.finish_draining_phase.__get__(
+            psm
+        )
+        psm.finish_draining_phase(SimpleNamespace(all_rollouts_ended=lambda: True))
+        self.assertEqual(calls, [True])
+
+    def test_finish_draining_defers_while_policy_in_flight(self):
+        calls = []
+
+        psm = SimpleNamespace(
+            total_steps=1,
+            current_step=1,
+            policy_replicas={"p0": SimpleNamespace(status="running")},
+            total_pending_rollouts=lambda: 8,
+            all_ready_or_reduced=lambda: False,
+            recompute_total_steps=lambda **kw: None,
+            trigger_training_complete=lambda: calls.append(True),
+            rollout_buffer=SimpleNamespace(queue=SimpleNamespace(clear=lambda: None)),
+        )
+        psm.finish_draining_phase = PolicyStatusManager.finish_draining_phase.__get__(
+            psm
+        )
+        psm.finish_draining_phase(SimpleNamespace(all_rollouts_ended=lambda: True))
+        self.assertEqual(calls, [])
+
+
+class TestOnRolloutIsEndSequence(unittest.TestCase):
+    def test_enter_once_finish_only_when_all_ended(self):
+        enter_count = []
+        finish_count = []
+
+        psm = SimpleNamespace(
+            job_phase=JobPhase.RUNNING,
+            config=SimpleNamespace(validation=SimpleNamespace(enable=False)),
+            enter_draining_phase=lambda: (
+                enter_count.append(1),
+                setattr(psm, "job_phase", JobPhase.DRAINING),
+            ),
+            finish_draining_phase=lambda rsm: finish_count.append(
+                rsm.all_rollouts_ended()
+            ),
+        )
+        psm.on_rollout_is_end = PolicyStatusManager.on_rollout_is_end.__get__(psm)
+
+        rsm_partial = SimpleNamespace(all_rollouts_ended=lambda: False)
+        psm.on_rollout_is_end(rsm_partial)
+        self.assertEqual(enter_count, [1])
+        self.assertEqual(finish_count, [False])
+        self.assertEqual(psm.job_phase, JobPhase.DRAINING)
+
+        rsm_all = SimpleNamespace(all_rollouts_ended=lambda: True)
+        psm.on_rollout_is_end(rsm_all)
+        self.assertEqual(enter_count, [1])
+        self.assertEqual(finish_count, [False, True])
+
+
+class TestTrainAckDuringPartialDrain(unittest.TestCase):
+    def test_train_ack_suppresses_weight_sync_while_draining(self):
+        psm = SimpleNamespace(
+            job_phase=JobPhase.DRAINING,
+            total_steps=10,
+            config=SimpleNamespace(
+                train=SimpleNamespace(sync_weight_interval=1),
+                validation=SimpleNamespace(enable=False, freq=None),
+            ),
+        )
+        rsm = SimpleNamespace(
+            all_rollouts_ended=lambda: False,
+            rollout_replicas={
+                "r0": SimpleNamespace(status=SimpleNamespace(ended=True)),
+                "r1": SimpleNamespace(status=SimpleNamespace(ended=True)),
+            },
+        )
+        psm.should_weight_sync_after_train_ack = (
+            PolicyStatusManager.should_weight_sync_after_train_ack.__get__(psm)
+        )
+        self.assertFalse(psm.should_weight_sync_after_train_ack(2, rsm))
+
+
+class TestEndOfDataRecomputeUsesBufferOnly(unittest.TestCase):
+    """Regression: ``enter_draining_phase`` uses ``total_pending_rollouts`` only."""
+
+    def test_recompute_uses_buffer_count_on_first_is_end(self):
+        from cosmos_rl.dispatcher import run_web_panel
+
+        recompute_args = []
+
+        def _recompute(explicit_num_remaining_samples=None):
+            recompute_args.append(explicit_num_remaining_samples)
+
+        psm = SimpleNamespace(
+            job_phase=JobPhase.RUNNING,
+            config=SimpleNamespace(validation=SimpleNamespace(enable=False)),
+            total_steps=10,
+            current_step=10,
+            total_pending_rollouts=lambda: 8,
+            recompute_total_steps=_recompute,
+            finish_draining_phase=lambda rsm: None,
+        )
+        psm.enter_draining_phase = PolicyStatusManager.enter_draining_phase.__get__(psm)
+        psm.on_rollout_is_end = PolicyStatusManager.on_rollout_is_end.__get__(psm)
+        rsm = SimpleNamespace(
+            rollout_end=lambda name: None,
+            all_rollouts_ended=lambda: False,
+        )
+        fake_controller = SimpleNamespace(
+            rollout_status_manager=rsm,
+            policy_status_manager=psm,
+        )
+        req = SimpleNamespace(
+            is_end=True, src_replica_name="r0", payloads=[], metrics={}
+        )
+        with patch.object(run_web_panel, "controller", fake_controller):
+            asyncio.run(run_web_panel.put_rollout_group(req))
+        self.assertEqual(recompute_args, [8])
+        self.assertEqual(psm.job_phase, JobPhase.DRAINING)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_process_flow.py
+++ b/tests/test_process_flow.py
@@ -23,20 +23,39 @@ os.environ["TORCH_CPP_LOG_LEVEL"] = "ERROR"
 os.environ.setdefault("PYTHONFAULTHANDLER", "1")
 import unittest
 import subprocess
+import signal
 import sys
 import time
-import signal
 import toml
 import tempfile
 
 from cosmos_rl.utils import network_util
+from subprocess_helpers import (
+    kill_process_group,
+    wait_all_or_fail,
+    wait_for_controller_ready,
+)
 
+# Bounded wait for the end-of-data shutdown tests.  Sized to cover a healthy
+# run (model load + vLLM init + a short single-epoch GRPO/SFT drain, which
+# completes well under a minute on CI) plus generous margin -- but far below
+# the CI job's ``timeout 2h`` wall, so a shutdown deadlock fails fast and
+# attributed instead of burning hours.  A wedge here manifests within seconds
+# of end-of-data, so this is pure backstop headroom, not expected runtime.
+_END_OF_DATA_TIMEOUT_S = 300
 
-# Bound for how long a process-flow scenario may take before a non-exiting
-# process is treated as hung. Generous (covers model load + a few steps + the
-# heartbeat-timeout teardown) but finite, so a hang fails fast and LOUD here
-# instead of silently burning the outer CI `timeout 2h`.
-_PROC_EXIT_TIMEOUT = float(os.environ.get("COSMOS_TEST_PROC_EXIT_TIMEOUT", "1200"))
+_kill_process_group = kill_process_group
+_wait_all_or_fail = wait_all_or_fail
+
+# Default bounded wait for non-end-of-data scenarios (validation, reward check,
+# ddp load).  Sized above healthy runtime with margin, but far below the CI
+# job's ``timeout 2h`` wall.  Override via COSMOS_TEST_PROC_EXIT_TIMEOUT.
+_PROC_EXIT_TIMEOUT = float(os.environ.get("COSMOS_TEST_PROC_EXIT_TIMEOUT", "300"))
+# Long multi-replica / multi-epoch runs (e.g. test_multi_replica_sft) need more
+# headroom than the default; keep a separate cap with faulthandler diagnostics.
+_LONG_PROC_EXIT_TIMEOUT = float(
+    os.environ.get("COSMOS_TEST_LONG_PROC_EXIT_TIMEOUT", "1200")
+)
 
 
 def _signal_tree(proc, sig):
@@ -115,6 +134,7 @@ class TestProcessFlow(unittest.TestCase):
             cur_dir, "data_fixtures", "test_dataset"
         )
         config["train"]["train_policy"]["allowed_outdated_steps"] = 100
+        config["redis"] = str(network_util.find_available_port(12808))
         with tempfile.NamedTemporaryFile(
             mode="w+", suffix=".toml", delete=False
         ) as tmpfile:
@@ -133,6 +153,13 @@ class TestProcessFlow(unittest.TestCase):
             # Own session so a hang can be group-signaled (SIGABRT -> faulthandler
             # all-thread dump) without touching the test runner's own group.
             start_new_session=True,
+        )
+        wait_for_controller_ready(
+            self,
+            controller_process,
+            port,
+            timeout_s=120,
+            context="grpo end-of-data shutdown (tp=2)",
         )
         os.environ["COSMOS_CONTROLLER_HOST"] = f"localhost:{port}"
         # Create the Python command for torchrun
@@ -188,8 +215,192 @@ class TestProcessFlow(unittest.TestCase):
 
         processes = [controller_process, policy_process, rollout_process]
 
-        # Wait for processes to complete (bounded; diagnoses hangs).
-        _await_processes(processes)
+        _wait_all_or_fail(
+            self,
+            processes,
+            timeout_s=_END_OF_DATA_TIMEOUT_S,
+            context="grpo end-of-data shutdown (tp=2)",
+        )
+
+    def _make_multirank_end_of_data_config(self, rollout_tp_size, world_size):
+        cur_dir = os.path.dirname(os.path.abspath(__file__))
+        config_path = os.path.join(cur_dir, "configs", "test_simple_grpo.toml")
+        with open(config_path, "r") as f:
+            config = toml.load(f)
+        config["train"]["epoch"] = 1
+        # Small batch so the last step of the single epoch leaves an
+        # uneven prompt tail across the worker's ranks.  GRPO's default
+        # mini_batch=2 requires train_batch_per_replica to be divisible by it,
+        # so this test uses mini_batch=1 to keep the odd tail intentional.
+        config["train"]["train_batch_per_replica"] = 3
+        config["train"]["train_policy"]["mini_batch"] = 1
+        config["train"]["train_policy"]["dataset"]["name"] = os.path.join(
+            cur_dir, "data_fixtures", "test_dataset"
+        )
+        config["train"]["train_policy"]["allowed_outdated_steps"] = 100
+        config["redis"] = str(network_util.find_available_port(12808))
+        config["rollout"]["parallelism"]["tp_size"] = rollout_tp_size
+        # Auto-infer rollout dp_shard from WORLD_SIZE // tp_size.  Required
+        # for the tp=1 layout (dp=2 on a 2-GPU worker); explicit dp_shard_size
+        # values are rejected for vLLM rollout configs.
+        config["rollout"]["parallelism"]["dp_shard_size"] = -1
+        return config
+
+    def test_multirank_end_of_data_config_is_valid(self):
+        """CPU guard for the CI-only GRPO end-of-data test configs."""
+        from cosmos_rl.policy.config import Config
+        from cosmos_rl.utils.parallelism import ParallelDims
+
+        world_size = 2
+        old_world_size = os.environ.get("WORLD_SIZE")
+        try:
+            os.environ["WORLD_SIZE"] = str(world_size)
+            for rollout_tp_size in (1, 2):
+                with self.subTest(rollout_tp_size=rollout_tp_size):
+                    config = self._make_multirank_end_of_data_config(
+                        rollout_tp_size, world_size
+                    )
+                    loaded = Config.from_dict(config)
+                    train_batch_per_replica = config["train"]["train_batch_per_replica"]
+                    mini_batch = config["train"]["train_policy"]["mini_batch"]
+                    policy_parallel = config["policy"]["parallelism"]
+                    policy_dp_shard = policy_parallel["dp_shard_size"]
+                    if policy_dp_shard == -1:
+                        policy_dp_shard = world_size // policy_parallel["tp_size"]
+                    rollout_parallel = config["rollout"]["parallelism"]
+                    rollout_dp_shard = world_size // rollout_parallel["tp_size"]
+                    parallel_dims = ParallelDims.from_config(loaded.rollout.parallelism)
+                    self.assertEqual(
+                        train_batch_per_replica % (policy_dp_shard * mini_batch),
+                        0,
+                    )
+                    self.assertEqual(rollout_parallel["dp_shard_size"], -1)
+                    self.assertEqual(parallel_dims.dp_shard, rollout_dp_shard)
+                    self.assertEqual(
+                        rollout_parallel["tp_size"] * rollout_dp_shard,
+                        world_size,
+                    )
+        finally:
+            if old_world_size is None:
+                os.environ.pop("WORLD_SIZE", None)
+            else:
+                os.environ["WORLD_SIZE"] = old_world_size
+
+    def _run_multirank_end_of_data(self, rollout_tp_size, context):
+        """Drive a multi-rank rollout worker to genuine end-of-data and
+        assert every process exits cleanly within a bounded wait.
+
+        Shared body for the ``tp`` (dp==1) and ``dp`` (dp>1) variants
+        below.  ``rollout_tp_size`` selects the rollout DP layout for the
+        2-GPU rollout worker: ``2`` -> pure TP (all ranks drain on the
+        same iteration); ``1`` -> dp_shard=2, so the final round-robin
+        batch leaves an *uneven* tail and ranks reach end-of-data on
+        different iterations -- the case the cross-rank ``StopCommand``
+        broadcast must handle without stranding a peer.
+        """
+        cur_dir = os.path.dirname(os.path.abspath(__file__))
+        world_size = 2
+        port = network_util.find_available_port(8123)
+        config = self._make_multirank_end_of_data_config(rollout_tp_size, world_size)
+        with tempfile.NamedTemporaryFile(
+            mode="w+", suffix=".toml", delete=False
+        ) as tmpfile:
+            toml.dump(config, tmpfile)
+            tmpfile_toml = tmpfile.name
+        controller_cmd = f"{sys.executable} -m cosmos_rl.dispatcher.run_web_panel --config {tmpfile_toml}"
+        controller_cmd += f" --port {port}"
+        env_dict = os.environ.copy()
+        env_dict["COSMOS_ROLE"] = "Controller"
+        controller_process = subprocess.Popen(
+            controller_cmd,
+            shell=True,
+            stdout=sys.stderr,
+            stderr=sys.stderr,
+            env=env_dict,
+            start_new_session=True,
+        )
+        wait_for_controller_ready(
+            self,
+            controller_process,
+            port,
+            timeout_s=120,
+            context=context,
+        )
+        os.environ["COSMOS_CONTROLLER_HOST"] = f"localhost:{port}"
+        worker_args = [
+            "torchrun",
+            f"--nproc_per_node={world_size}",
+            "--role=rank",
+            "--tee=3",
+            "--rdzv_backend=c10d",
+            "--rdzv_endpoint=localhost:0",
+            os.path.join(cur_dir, "launch_test_worker.py"),
+            "--shm_name",
+            "-1",
+            "--shm_size",
+            "-1",
+            "--mode",
+        ]
+        policy_cmd = worker_args + ["dummy_policy"]
+        rollout_cmd = worker_args + ["dummy_rollout"]
+        policy_env = dict(os.environ)
+        policy_env["CUDA_VISIBLE_DEVICES"] = "0,1"
+        policy_process = subprocess.Popen(
+            policy_cmd,
+            stdout=sys.stderr,
+            stderr=sys.stderr,
+            env=policy_env,
+            start_new_session=True,
+        )
+        rollout_env = dict(os.environ)
+        rollout_env["CUDA_VISIBLE_DEVICES"] = "2,3"
+        rollout_process = subprocess.Popen(
+            rollout_cmd,
+            stdout=sys.stderr,
+            stderr=sys.stderr,
+            env=rollout_env,
+            start_new_session=True,
+        )
+
+        processes = [controller_process, policy_process, rollout_process]
+        # Generous bound (model load + a short single-epoch GRPO run) but
+        # far below the 2h CI wall, so the consume-end deadlock surfaces
+        # as a fast, attributed failure.
+        _wait_all_or_fail(
+            self, processes, timeout_s=_END_OF_DATA_TIMEOUT_S, context=context
+        )
+
+    def test_process_exit_grpo_multirank_end_of_data(self):
+        """Regression: a multi-rank rollout worker driven to genuine
+        end-of-data must shut down without deadlocking.
+
+        ``tp`` layout (rollout tp_size=2 -> world_size=2, dp==1): all
+        ranks reach end-of-data on the same iteration.  The controller's
+        explicit ``StopCommand`` -- broadcast across ranks by
+        ``consume_one_command`` -- self-terminates them in lockstep,
+        without the old stop-carrying R2R weight-sync broadcast that raced
+        the end-of-data signal (see rollout_multirank_shutdown.md).
+        """
+        self._run_multirank_end_of_data(
+            rollout_tp_size=2,
+            context="grpo multi-rank end-of-data shutdown (tp=2, dp=1)",
+        )
+
+    def test_process_exit_grpo_multirank_dp_end_of_data(self):
+        """Regression (corner E): rollout tp_size=1 -> dp_shard=2, so the
+        final round-robin batch is scattered *unevenly* and the two ranks
+        reach ``prompt_consume_end`` on *different* iterations.
+
+        This is the case a rank-local ``shutdown_signal.set()`` cannot
+        handle (the first rank to drain would strand the other in the next
+        collective); the ``StopCommand`` is delivered to every rank at the
+        same ``consume_one_command`` broadcast, so they leave ``main_loop``
+        together regardless of the uneven tail.
+        """
+        self._run_multirank_end_of_data(
+            rollout_tp_size=1,
+            context="grpo multi-rank end-of-data shutdown (tp=1, dp=2)",
+        )
 
     def test_process_exit_sft(self):
         """Test sft all processes exit cleanly."""
@@ -255,8 +466,12 @@ class TestProcessFlow(unittest.TestCase):
         )
         processes = [controller_process, policy_process]
 
-        # Wait for processes to complete (bounded; diagnoses hangs).
-        _await_processes(processes)
+        _wait_all_or_fail(
+            self,
+            processes,
+            timeout_s=_END_OF_DATA_TIMEOUT_S,
+            context="sft end-of-data shutdown",
+        )
 
 
 class TestValidationFlow(unittest.TestCase):
@@ -431,8 +646,7 @@ class TestMultiReplicaSFT(unittest.TestCase):
 
         processes = [controller_process] + rollout_processes
 
-        # Wait for processes to complete (bounded; diagnoses hangs).
-        _await_processes(processes)
+        _await_processes(processes, timeout=_LONG_PROC_EXIT_TIMEOUT)
 
 
 if __name__ == "__main__":

--- a/tests/test_teacher_model.py
+++ b/tests/test_teacher_model.py
@@ -31,6 +31,7 @@ import msgpack
 import tempfile
 from transformers import AutoTokenizer
 from cosmos_rl.utils import network_util
+from subprocess_helpers import wait_all_or_fail
 
 
 class TestTeacherModel(unittest.TestCase):
@@ -250,19 +251,19 @@ dp_replicate_size = 1
         controller_process = subprocess.Popen(
             controller_cmd,
             shell=True,
+            start_new_session=True,
             stdout=sys.stderr,
             stderr=sys.stderr,
             env=env_dict,
         )
         processes = [controller_process]
 
-        # Wait for process to complete
-        for process in processes:
-            stdout, stderr = process.communicate()
-            # Check if process completed successfully
-            assert process.returncode == 0, (
-                f"Process failed with code: {process.returncode}"
-            )
+        wait_all_or_fail(
+            self,
+            processes,
+            timeout_s=600,
+            context="test_distillation_flow",
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_ucxx_transport.py
+++ b/tests/test_ucxx_transport.py
@@ -626,6 +626,141 @@ class TestOptionalUcxxExtra(unittest.TestCase):
                 pass
 
 
+class TestResetUCXXContext(unittest.TestCase):
+    """``reset_ucxx_context`` must deterministically tear down the global
+    UCXX context so its background worker progress thread is joined at
+    cleanup time -- otherwise that C++ thread (``WorkerProgressThread``,
+    started by the default ``thread`` progress mode) outlives the Python
+    objects it dispatches into during interpreter shutdown and SIGSEGVs in
+    ``ucp_worker_progress``.
+
+    These mock the ``ucxx`` module so they run without the optional
+    ``ucxx-cu12`` extra or real UCX hardware.
+    """
+
+    def _invoke(self, fake_ucxx):
+        from cosmos_rl.utils.payload_transport.ucxx import ucxx_buffer
+
+        with (
+            mock.patch.object(ucxx_buffer, "UCXX_AVAILABLE", True),
+            mock.patch.object(ucxx_buffer, "ucxx", fake_ucxx),
+        ):
+            ucxx_buffer.reset_ucxx_context()
+
+    def test_noop_when_unavailable(self):
+        # No ucxx in the process: must be a silent no-op, never raise.
+        from cosmos_rl.utils.payload_transport.ucxx import ucxx_buffer
+
+        with (
+            mock.patch.object(ucxx_buffer, "UCXX_AVAILABLE", False),
+            mock.patch.object(ucxx_buffer, "ucxx", None),
+        ):
+            ucxx_buffer.reset_ucxx_context()  # must not raise
+
+    def test_noop_when_context_not_initialised(self):
+        # UCXX imported but never used (``_ctx is None``): nothing to reset.
+        fake_ucxx = mock.Mock()
+        fake_ucxx.core = SimpleNamespace(_ctx=None)
+        self._invoke(fake_ucxx)
+        fake_ucxx.reset.assert_not_called()
+
+    def test_drains_inflight_then_stops_thread_then_resets(self):
+        # The full teardown contract, in order, all *before* any gc pass:
+        #   (1) cancel + drain in-flight requests while the progress thread is
+        #       still alive (so no request callback fires into a finalizing
+        #       interpreter -- the ~Worker()/~Endpoint() GC path),
+        #   (2) stop the progress thread,
+        #   (3) ucxx.reset().
+        # Record the call order via a shared event list.
+        events = []
+        worker = mock.Mock()
+        worker.cancel_inflight_requests.side_effect = lambda *a, **k: events.append(
+            "cancel"
+        )
+        worker.get_canceling_size.return_value = 0  # drained immediately
+        worker.stop_progress_thread.side_effect = lambda: events.append("stop")
+        fake_ucxx = mock.Mock()
+        fake_ucxx.reset.side_effect = lambda: events.append("reset")
+        fake_ucxx.core = SimpleNamespace(_ctx=SimpleNamespace(worker=worker))
+        self._invoke(fake_ucxx)
+        worker.cancel_inflight_requests.assert_called_once()
+        worker.stop_progress_thread.assert_called_once_with()
+        fake_ucxx.reset.assert_called_once_with()
+        self.assertEqual(
+            events,
+            ["cancel", "stop", "reset"],
+            "must drain in-flight requests, then stop the progress thread, "
+            "then ucxx.reset()",
+        )
+
+    def test_drain_waits_until_canceling_size_zero_before_stop(self):
+        # After cancellation is scheduled, the live progress thread completes it
+        # asynchronously; we must keep waiting until get_canceling_size() hits 0
+        # *before* stopping the thread, or a still-canceling request can fire its
+        # callback into teardown.
+        events = []
+        worker = mock.Mock()
+        # Two requests still canceling, then drained.
+        sizes = [2, 1, 0]
+        worker.get_canceling_size.side_effect = lambda: events.append(
+            ("size", sizes[0])
+        ) or sizes.pop(0)
+        worker.cancel_inflight_requests.side_effect = lambda *a, **k: events.append(
+            "cancel"
+        )
+        worker.stop_progress_thread.side_effect = lambda: events.append("stop")
+        fake_ucxx = mock.Mock()
+        fake_ucxx.reset.side_effect = lambda: events.append("reset")
+        fake_ucxx.core = SimpleNamespace(_ctx=SimpleNamespace(worker=worker))
+        self._invoke(fake_ucxx)
+        # cancel happens first; stop only after the canceling set reached 0.
+        self.assertEqual(events[0], "cancel")
+        self.assertIn(("size", 0), events)
+        self.assertLess(
+            events.index(("size", 0)),
+            events.index("stop"),
+            "must observe canceling_size==0 before stopping the thread",
+        )
+        self.assertEqual(events[-1], "reset")
+
+    def test_drain_is_noop_on_ucxx_build_without_cancel_api(self):
+        # Older/leaner ucxx builds may not expose cancel_inflight_requests; the
+        # drain must degrade silently to the prior stop-then-reset behaviour.
+        events = []
+        worker = mock.Mock(spec=["stop_progress_thread"])  # no cancel_* / size api
+        worker.stop_progress_thread.side_effect = lambda: events.append("stop")
+        fake_ucxx = mock.Mock()
+        fake_ucxx.reset.side_effect = lambda: events.append("reset")
+        fake_ucxx.core = SimpleNamespace(_ctx=SimpleNamespace(worker=worker))
+        self._invoke(fake_ucxx)
+        worker.stop_progress_thread.assert_called_once_with()
+        fake_ucxx.reset.assert_called_once_with()
+        self.assertEqual(events, ["stop", "reset"])
+
+    def test_progress_thread_stopped_even_when_reset_raises(self):
+        # reset() raises while an Endpoint/Listener still references the
+        # context.  That is now non-fatal: the progress thread was already
+        # stopped beforehand, so the crash-causing thread is gone regardless.
+        #
+        # Faithfully mirror the real ``ucxx.reset()``: it sets ``core._ctx`` to
+        # None *before* raising on lingering references -- which is why the
+        # worker must be captured (and stopped) before reset() is called.
+        worker = mock.Mock()
+        worker.get_canceling_size.return_value = 0
+        fake_ucxx = mock.Mock()
+        fake_ucxx.core = SimpleNamespace(_ctx=SimpleNamespace(worker=worker))
+
+        def _reset_then_raise():
+            fake_ucxx.core._ctx = None  # reset() nulls the global before raising
+            raise RuntimeError("Trying to reset UCX but not all Endpoints closed")
+
+        fake_ucxx.reset.side_effect = _reset_then_raise
+        self._invoke(fake_ucxx)
+        worker.cancel_inflight_requests.assert_called_once()
+        worker.stop_progress_thread.assert_called_once_with()
+        fake_ucxx.reset.assert_called_once_with()
+
+
 # ---------------------------------------------------------------------------
 # UCXXClient.read port rotation + on-failure fallback
 #

--- a/tests/utils/mock_policy_entrance.py
+++ b/tests/utils/mock_policy_entrance.py
@@ -204,7 +204,11 @@ def main(*args, **kwargs):
             )
             worker.main_loop()
             if args.test == "custom_rollout":
-                assert worker.trainer.computed_cnt == 4
+                assert worker.trainer.computed_cnt == 3, (
+                    "custom_rollout should compute logprobs for the three real "
+                    "training steps; the final TrainingCompleteCommand is a "
+                    "zero-work ack and must not call compute_logprobs"
+                )
         elif policy_type == "sft":
             custom_sft_dataset = kwargs.get("dataset")
             custom_sft_data_packer = kwargs.get("data_packer")


### PR DESCRIPTION
## Summary
Unifies multi-rank rollout shutdown and hardens teardown across the controller,
policy, and rollout paths. The root cause was a *design coupling*, not a missing
guard: the controller forced a final P2R→R2R weight sync purely as an "ending
signal", held open by a hardcoded `time.sleep(30)` in the policy main loop —
which raced rollouts that had already drained and NCCL-aborted, wedging
`ncclCommAbort` on the P2R recipient. This branch also adds the Slurm full-CI
tooling and reworks the UCXX payload transport for correctness.

## What changed
**Controller / rollout shutdown (`fix: harden controller-rollout shutdown in CI`)**
- **Unified stop on the `is_end` path:** `_get_batched_prompt_impl` forces
  `is_end=True` once `training_finished()` (non-validation), routing step-bounded
  runs through the same NCCL-free path as data-bounded runs. Starvation-safe:
  every needed rollout is already buffered by training-finish.
- **Suppress the never-consumed final-step weight sync** (non-validation) via a
  pure `need_weight_sync` helper; validation keeps it (final validation is driven
  by that R2R broadcast).
- **Bounded policy wait** replaces `time.sleep(30)` (gated on `validation.enable`).
- **Explicit NCCL-free `StopCommand`** broadcast once every policy replica
  unregisters — reaches every rollout via `consume_command`→`handle_stop`
  regardless of fetch state, unblocking a rank wedged on the `version_fail` gate;
  `broadcast_object_cpu` gives race-free lockstep exit for `world_size>1`.
- **`async_r2r_sync` barrier fixes:** authoritative per-round participant count
  (shrinks as replicas finish, killing the 120s barrier timeout) + abortable
  barrier wait (checks `_stop` each iteration).
- **Phased shutdown:** explicit `JobPhase` (RUNNING → DRAINING) + zero-work
  `TrainingCompleteCommand` ack so completion is separated from teardown.
- **Strict final-validation guard:** `_maybe_finalize` logs an error if the
  controller finalizes while validation is still active (covered by
  `test_finalize_logs_error_if_validation_is_still_active`).
- **Teardown defense-in-depth:** shared `bounded_drain_or_abort` (WST + inference
  streams); rollout-aware controller checkout gate; **UCXX teardown
  drain→stop→reset** ordering — `_drain_inflight_requests` cancels in-flight UCP
  requests with the progress thread alive so callbacks fire under a healthy
  interpreter, fixing a GC-time use-after-free SIGSEGV.
- **Log hygiene:** removed temporary Trace A–F dispatch/main-loop instrumentation
  and demoted high-volume counters to DEBUG.

## Test plan
- [x] `tests/test_multirank_shutdown.py` — 58 tests (StopCommand round-trip/handler,
  weight-sync `status.ended` exclusion, `nccl_abort_all`, `bounded_drain_or_abort`,
  rollout-checkout gate, R2R barrier world-size, `_maybe_finalize` validation guard)
- [x] `tests/test_ucxx_transport.py::TestResetUCXXContext` (drain→stop→reset order,
  cancel-API fallback)
- [x] `tests/test_process_flow.py`, `test_custom_class.py`, `test_colocated.py`,
  `test_teacher_model.py` (import-layout fix verified)
- [ ] Full 8-GPU Slurm CI suite green except known `test_deepep.py` CUDA
  (`layout.cu:138 'named symbol not found'`) infra failure