### PR TITLE
feat: weight-sync backlog observability + opt-in drop-to-latest coalescing

### DIFF
--- a/cosmos_rl/dispatcher/status.py
+++ b/cosmos_rl/dispatcher/status.py
@@ -153,6 +153,45 @@ def should_broadcast_stop(
     )
 
 
+def should_coalesce_skip(
+    *,
+    coalesce_enabled: bool,
+    forced: bool,
+    last_staged_step: int,
+    max_adopted_version: int,
+) -> bool:
+    """Pure decision: should the controller *skip* (coalesce) this weight-sync
+    round instead of issuing a fresh P2R+R2R?
+
+    Depth-1 drop-to-latest.  A round the controller issued at
+    ``last_staged_step`` is still *in flight* exactly while the rollouts have
+    not yet adopted it -- i.e. ``last_staged_step > max_adopted_version``
+    (``max_adopted_version`` is the freshest weight version any rollout has
+    generated with, tracked from the stamped ``rollout.weight_version``).
+    Issuing another round while one is in flight would only pile redundant
+    ~1.6 GB transfers onto the rollout's ``WeightSyncThread`` queue -- every
+    intermediate version is superseded before it is ever adopted (the rollout's
+    ``sync_buffer_to_live`` always jumps to the latest ``buf_ver``).  So we skip;
+    once the rollouts catch up the next tick issues at ``current_step`` (the
+    latest) -> drop-to-latest.
+
+    Note "in flight" is *derived*, not tracked: there is exactly one source of
+    truth (the adopted-version comparison), so no counter can drift.
+
+    ``forced`` overrides the skip for the one round that must never be coalesced
+    away: a validation-trigger step, where the rollout needs that exact version
+    to validate.  (The first sync issues naturally -- ``last_staged_step`` starts
+    at -1, so the comparison is false -- and the staleness ceiling is enforced
+    independently by ``filter_outdated_rollouts``.)
+
+    When ``coalesce_enabled`` is False this is always False -> behaviour is
+    identical to the unconditional every-interval sync.
+    """
+    if not coalesce_enabled or forced:
+        return False
+    return last_staged_step > max_adopted_version
+
+
 class ReplicaScalingEnum(StrEnum):
     """
     Enum for replica scaling event.
@@ -283,6 +322,22 @@ class PolicyStatusManager:
 
         # For rank specific data dispatch
         self.rollout_buffer_per_rank: List[Queue] = []
+
+        # --- Weight-sync coalescing (depth-1 drop-to-latest) state ---
+        # ``_weight_last_staged_step``: weight_step of the most recent issued
+        #   round (-1 = none issued yet, so the first sync issues naturally).
+        # ``_weight_max_adopted_version``: highest rollout-reported weight
+        #   version seen (updated from put_rollouts).  A round is "in flight"
+        #   iff _weight_last_staged_step > _weight_max_adopted_version -- the
+        #   single derived source of truth the coalescing gate keys on.
+        # ``_weight_coalesced_skips``: count of coalesced (skipped) rounds, for
+        #   the bench report (observability only).
+        self._weight_last_staged_step: int = -1
+        self._weight_max_adopted_version: int = -1
+        self._weight_coalesced_skips: int = 0
+        # Latest accepted-rollout staleness percentiles, merged into the
+        # train_ack report_data (operator-facing tuning signal).
+        self._weight_staleness_recent: Dict[str, int] = {}
 
     def setup(
         self,
@@ -462,6 +517,27 @@ class PolicyStatusManager:
         new_total_steps = self.total_steps
         if new_total_steps > self.current_step:
             logger.info("[Controller] There are still remaining steps, no op required")
+            return
+        rollouts_per_step = self.config.train.train_batch_per_replica * len(
+            self.get_all_atoms_arrived_replicas()
+        )
+        if (
+            rollouts_per_step > 0
+            and total_pending_rollouts >= rollouts_per_step
+            and self.current_step < original_total_steps
+        ):
+            # Buffer still holds at least one full training step and the
+            # policy has not reached the pre-recompute ``total_steps`` yet.
+            # ``train_ack`` will dispatch that step via ``try_trigger``; do
+            # not cut training short (custom_rollout CI: computed_cnt check).
+            logger.info(
+                "[Controller] DRAINING: %d buffered rollouts (>= %d/step) "
+                "but policy at step %d/%d; deferring TrainingComplete",
+                total_pending_rollouts,
+                rollouts_per_step,
+                self.current_step,
+                original_total_steps,
+            )
             return
         if self.current_step == original_total_steps and total_pending_rollouts == 0:
             logger.info(
@@ -1149,11 +1225,19 @@ class PolicyStatusManager:
         cleanup messages so the rollout worker releases them immediately
         instead of waiting for age-based cleanup.
         """
+        allowed_outdated_steps = self.config.train.train_policy.allowed_outdated_steps
         filtered_rollouts = []
+        accepted_staleness: List[int] = []
+        discarded_staleness: List[int] = []
         for idx, rollout in enumerate(rollouts):
             assert rollout.weight_version <= self.current_step, (
                 f"Rollout weight version {rollout.weight_version} is greater than current step {self.current_step}"
             )
+            # Adoption signal for weight-sync coalescing: the freshest weight
+            # version any rollout has actually generated with confirms that
+            # round was delivered + adopted (deadlock-free re-arm signal).
+            if rollout.weight_version > self._weight_max_adopted_version:
+                self._weight_max_adopted_version = rollout.weight_version
             # Estimate the step when this rollout will be used for training
             # This is estimated based on the current step, the number of pending rollouts,
             # and the number of rollouts before this rollout in the current batch.
@@ -1163,15 +1247,41 @@ class PolicyStatusManager:
                 self.config.train.train_batch_per_replica
                 * max(len(self.get_all_atoms_arrived_replicas()), 1)
             )
-            if (
-                estimated_step - rollout.weight_version
-                <= self.config.train.train_policy.allowed_outdated_steps
-            ):
+            staleness = estimated_step - rollout.weight_version
+            if staleness <= allowed_outdated_steps:
                 filtered_rollouts.append(rollout)
+                accepted_staleness.append(staleness)
             else:
+                discarded_staleness.append(staleness)
                 logger.debug(
-                    f"[Controller] Filtered out outdated rollout with version {rollout.weight_version}, current step {self.current_step}, estimated step {estimated_step}, pending rollouts {self.total_pending_rollouts()}, preceeding rollouts in this batch {idx}, allowed_outdated_steps {self.config.train.train_policy.allowed_outdated_steps}"
+                    f"[Controller] Filtered out outdated rollout with version {rollout.weight_version}, current step {self.current_step}, estimated step {estimated_step}, pending rollouts {self.total_pending_rollouts()}, preceeding rollouts in this batch {idx}, allowed_outdated_steps {allowed_outdated_steps}"
                 )
+
+        # Operator-facing weight-version staleness (see weight-sync coalescing
+        # plan, Phase 1b): how outdated the *accepted* rollouts are vs the live
+        # weight version, so the sync frequency can be tuned.  Stashed for the
+        # train_ack report (`rollout/weight_staleness_*`) and logged inline with
+        # the config knobs so the headroom vs allowed_outdated_steps is obvious.
+        if accepted_staleness:
+            p50 = int(np.percentile(accepted_staleness, 50))
+            p99 = int(np.percentile(accepted_staleness, 99))
+            smax = int(np.max(accepted_staleness))
+            self._weight_staleness_recent = {
+                "rollout/weight_staleness_p50": p50,
+                "rollout/weight_staleness_p99": p99,
+                "rollout/weight_staleness_max": smax,
+            }
+            logger.info(
+                "[Controller] weight staleness: accepted p50=%d p99=%d max=%d, "
+                "discarded=%d/%d (allowed_outdated_steps=%d, sync_weight_interval=%d)",
+                p50,
+                p99,
+                smax,
+                len(discarded_staleness),
+                len(rollouts),
+                allowed_outdated_steps,
+                self.config.train.sync_weight_interval,
+            )
 
         discarded_count = len(rollouts) - len(filtered_rollouts)
 
@@ -1490,6 +1600,13 @@ class PolicyStatusManager:
                                         / total_samples_for_filtering
                                     }
                                 )
+                    # Operator-facing weight-version staleness + coalescing
+                    # activity (see weight-sync coalescing plan, Phase 1b/2).
+                    if self._weight_staleness_recent:
+                        policy_report_data.update(self._weight_staleness_recent)
+                    policy_report_data["rollout/weight_coalesced_skips"] = (
+                        self._weight_coalesced_skips
+                    )
                     self.train_report_data.setdefault(train_step, {}).update(
                         policy_report_data
                     )
@@ -1588,12 +1705,42 @@ class PolicyStatusManager:
 
             # P->R & R->R
             if need_sync_weight:
-                self.trigger_weight_sync(
-                    any_loaded_replica,
-                    rollout_status_manager,
-                    step,
-                    self.total_steps,
+                # Weight-sync coalescing (depth-1 drop-to-latest): while a
+                # previously issued round is still in flight to the rollouts
+                # (last_staged > max_adopted), skip issuing redundant P2R+R2R
+                # rounds -- every intermediate version is superseded on the
+                # rollout before it is adopted.  Once the rollouts catch up, the
+                # next tick issues at the latest step.
+                tp = self.config.train.train_policy
+                coalesce_enabled = (
+                    self.config.train.coalesce_weight_sync
+                    and getattr(tp, "allowed_outdated_steps", 0) > 0
+                    and not getattr(tp, "on_policy", False)
                 )
+                forced = self._weight_sync_forced(step, self.total_steps)
+                if should_coalesce_skip(
+                    coalesce_enabled=coalesce_enabled,
+                    forced=forced,
+                    last_staged_step=self._weight_last_staged_step,
+                    max_adopted_version=self._weight_max_adopted_version,
+                ):
+                    self._weight_coalesced_skips += 1
+                    logger.info(
+                        "[Controller] Coalesced weight-sync skip "
+                        "(last_staged=%d, current=%d, max_adopted=%d, "
+                        "total_skips=%d)",
+                        self._weight_last_staged_step,
+                        step,
+                        self._weight_max_adopted_version,
+                        self._weight_coalesced_skips,
+                    )
+                else:
+                    self.trigger_weight_sync(
+                        any_loaded_replica,
+                        rollout_status_manager,
+                        step,
+                        self.total_steps,
+                    )
             # Trigger next step training if data is available
             self.try_trigger_data_fetch_and_training()
             if self.config.train.train_policy.on_policy:
@@ -1632,6 +1779,28 @@ class PolicyStatusManager:
             total_steps=total_steps,
             redis_handler=self.redis_handler,
         )
+
+        # Weight-sync coalescing: record this as the latest staged round.  It
+        # counts as "in flight" until the rollouts adopt it
+        # (_weight_max_adopted_version catches up), gating the next round.
+        self._weight_last_staged_step = current_step
+
+    def _weight_sync_forced(self, step: int, total_steps: int) -> bool:
+        """The one round that must never be coalesced away: a validation-trigger
+        step, where the rollout needs that exact weight version to validate.
+
+        Nothing else needs forcing -- the first sync issues naturally (the gate
+        comparison is false while ``last_staged_step`` is -1), and the staleness
+        ceiling is enforced independently by ``filter_outdated_rollouts``.
+        """
+        val = self.config.validation
+        if getattr(val, "enable", False):
+            freq = getattr(val, "freq", 0)
+            if freq and step % freq == 0:
+                return True
+            if step == total_steps:
+                return True
+        return False
 
     def rollouts_enough_for_one_step(self) -> bool:
         """

--- a/cosmos_rl/policy/config/__init__.py
+++ b/cosmos_rl/policy/config/__init__.py
@@ -906,6 +906,16 @@ class TrainingConfig(BaseModel):
         default=1,
         description="The interval of train step for synchronizing weights between replicas.",
     )
+    coalesce_weight_sync: bool = Field(
+        default=False,
+        description="If True, the controller coalesces (drops) redundant P2R+R2R "
+        "weight-sync rounds while a round is still in flight to the rollouts "
+        "(depth-1 drop-to-latest): it re-issues at the latest step only once the "
+        "rollouts have adopted the previously staged version. Reduces wasted "
+        "weight transfers when the trainer outruns rollout drain. Only active for "
+        "off-policy runs (allowed_outdated_steps > 0); ignored for on-policy, "
+        "which requires step-exact weight sync.",
+    )
     deterministic: bool = Field(
         default=False,
         description="Whether to use deterministic training. If set to True, will use deterministic training, which is expected to be slower.",
@@ -990,6 +1000,23 @@ class TrainingConfig(BaseModel):
                 logger.warning(
                     "on_policy is enabled, so allowed_outdated_steps is set to 0."
                 )
+
+        # Weight-sync coalescing is an off-policy-only optimization: it
+        # intentionally lets rollouts run slightly stale, which on-policy (and
+        # allowed_outdated_steps == 0) cannot tolerate.  Disable it rather than
+        # silently mis-sync.
+        if self.coalesce_weight_sync:
+            outdated_ok = getattr(self.train_policy, "allowed_outdated_steps", 0) > 0
+            on_policy = getattr(self.train_policy, "on_policy", False)
+            if on_policy or not outdated_ok:
+                logger.warning(
+                    "coalesce_weight_sync requires off-policy training with "
+                    "allowed_outdated_steps > 0 (on_policy=%s, "
+                    "allowed_outdated_steps=%s); disabling it.",
+                    on_policy,
+                    getattr(self.train_policy, "allowed_outdated_steps", 0),
+                )
+                self.coalesce_weight_sync = False
 
         if self.deterministic and self.seed is None:
             self.seed = 42

--- a/cosmos_rl/rollout/worker/llm_worker.py
+++ b/cosmos_rl/rollout/worker/llm_worker.py
@@ -106,14 +106,8 @@ class LLMRolloutWorker(WorkerBase):
             raise ValueError(f"Invalid rollout backend: {rollout_backend}")
 
     def destroy_worker(self):
-        logger.info("[Teardown] destroy_worker: deleting rollout_worker")
         if self.rollout_worker is not None:
-            logger.info(
-                "[Rollout] destroy_worker: deleting rollout_worker (vLLM shutdown)"
-            )
+            logger.info("[Teardown] destroy_worker: shutting down rollout_worker")
             del self.rollout_worker
             self.rollout_worker = None
-            logger.info("[Rollout] destroy_worker: rollout_worker deleted")
-        logger.info("[Teardown] destroy_worker: calling destroy_distributed()")
         destroy_distributed()
-        logger.info("[Rollout] Destroy context of torch dist.")

--- a/cosmos_rl/rollout/worker/weight_sync.py
+++ b/cosmos_rl/rollout/worker/weight_sync.py
@@ -237,12 +237,17 @@ def sync_buffer_to_live(worker) -> None:
                 live_sd[name].copy_(buffer_sd[name])
     worker._buffer_synced_version = buf_ver
     elapsed_ms = (time.monotonic() - t0) * 1000
+    # ``superseded`` = buffer versions transferred since the last adopt but
+    # jumped over here (never adopted into the live model) -> wasted NCCL
+    # transfers.  Coalescing (Phase 2) should drive this to ~0.
+    superseded = max(0, buf_ver - synced_ver - 1)
     logger.info(
         "[WeightSync] Synced buffer -> live (%d params, ver %d->%d, "
-        "wait_event=%s, %.1f ms CPU enqueue)",
+        "superseded=%d, wait_event=%s, %.1f ms CPU enqueue)",
         len(live_sd),
         synced_ver,
         buf_ver,
+        superseded,
         has_event,
         elapsed_ms,
     )
@@ -296,6 +301,12 @@ class WeightSyncThread:
         self._idle = threading.Event()
         self._idle.set()
         self._last_event: torch.cuda.Event | None = None
+        # Backlog observability (see weight-sync coalescing plan): high-water
+        # queue depth and total executed transfers.  A healthy (coalesced) run
+        # keeps ``_max_qdepth`` ~1; a piled-up run shows it climbing while most
+        # transfers are superseded before they are ever adopted.
+        self._max_qdepth = 0
+        self._executed = 0
         self._thread = threading.Thread(
             target=self._run,
             daemon=True,
@@ -312,11 +323,17 @@ class WeightSyncThread:
         self._seq += 1
         self._idle.clear()
         self._queue.put((0, self._seq, ("p2r", command)))
+        qdepth = self._queue.qsize()
+        if qdepth > self._max_qdepth:
+            self._max_qdepth = qdepth
         logger.info(
-            "[WeightSyncThread] Enqueued P2R (step=%s, seq=%d, buf_ver=%d)",
+            "[WeightSyncThread] Enqueued P2R (step=%s, seq=%d, buf_ver=%d, "
+            "qdepth=%d, max_qdepth=%d)",
             getattr(command, "weight_step", "?"),
             self._seq,
             getattr(self._worker, "_buffer_version", -1),
+            qdepth,
+            self._max_qdepth,
         )
 
     def enqueue_r2r(self, command) -> None:
@@ -324,11 +341,17 @@ class WeightSyncThread:
         self._seq += 1
         self._idle.clear()
         self._queue.put((1, self._seq, ("r2r", command)))
+        qdepth = self._queue.qsize()
+        if qdepth > self._max_qdepth:
+            self._max_qdepth = qdepth
         logger.info(
-            "[WeightSyncThread] Enqueued R2R (step=%s, seq=%d, buf_ver=%d)",
+            "[WeightSyncThread] Enqueued R2R (step=%s, seq=%d, buf_ver=%d, "
+            "qdepth=%d, max_qdepth=%d)",
             getattr(command, "weight_step", "?"),
             self._seq,
             getattr(self._worker, "_buffer_version", -1),
+            qdepth,
+            self._max_qdepth,
         )
 
     def drain(self, timeout: float = 120.0) -> None:
@@ -409,12 +432,16 @@ class WeightSyncThread:
         self._last_event = torch.cuda.Event()
         self._last_event.record(self._stream)
         self._worker._buffer_version += 1
+        self._executed += 1
         elapsed_ms = (time.monotonic() - t0) * 1000
         logger.info(
-            "[WeightSyncThread] P2R done (step=%s, ver=%s, %.1f ms)",
+            "[WeightSyncThread] P2R done (step=%s, ver=%s, %.1f ms, "
+            "qdepth_after=%d, executed=%d)",
             command.weight_step,
             self._worker.current_weight_version,
             elapsed_ms,
+            self._queue.qsize(),
+            self._executed,
         )
 
     def _execute_r2r(self, command) -> None:
@@ -447,6 +474,7 @@ class WeightSyncThread:
         self._last_event = torch.cuda.Event()
         self._last_event.record(self._stream)
         worker._buffer_version += 1
+        self._executed += 1
 
         if weight_step is not None:
             worker.current_weight_version = weight_step
@@ -480,12 +508,15 @@ class WeightSyncThread:
 
         elapsed_ms = (time.monotonic() - t0) * 1000
         logger.info(
-            "[WeightSyncThread] R2R done: %d params, %.1f MB, %.0f ms, step=%s, ver=%s",
+            "[WeightSyncThread] R2R done: %d params, %.1f MB, %.0f ms, step=%s, "
+            "ver=%s, qdepth_after=%d, executed=%d",
             transferred_cnt,
             bytes_broadcast / (1024 * 1024),
             elapsed_ms,
             weight_step,
             worker.current_weight_version,
+            self._queue.qsize(),
+            self._executed,
         )
 
 

--- a/cosmos_rl/utils/payload_transport/ucxx/data_packer_mixin.py
+++ b/cosmos_rl/utils/payload_transport/ucxx/data_packer_mixin.py
@@ -126,7 +126,7 @@ class UCXXDataPackerMixin(PrefetchDataPackerMixin):
     _ucxx_dp_client: Optional[UCXXClient] = None
     _ucxx_dp_device: Optional[torch.device] = None
     _ucxx_dp_max_attempts: int = 2
-    _ucxx_dp_read_timeout: float = 5.0
+    _ucxx_dp_read_timeout: float = 30.0
 
     # Cumulative stats for periodic INFO summaries (UCXX-specific so the
     # base mixin's _on_prefetch_complete hook is the right place).
@@ -179,7 +179,7 @@ class UCXXDataPackerMixin(PrefetchDataPackerMixin):
         device: torch.device,
         prefetch_timeout: float = 300.0,
         max_attempts: int = 2,
-        read_timeout: float = 5.0,
+        read_timeout: float = 30.0,
     ) -> None:
         """Initialise UCXX client + start the (inherited) prefetch thread.
 
@@ -233,7 +233,7 @@ class UCXXDataPackerMixin(PrefetchDataPackerMixin):
         device: torch.device,
         prefetch_timeout: float = 300.0,
         max_attempts: int = 2,
-        read_timeout: float = 5.0,
+        read_timeout: float = 30.0,
     ) -> None:
         """DEPRECATED: use :meth:`_setup_ucxx_data_packer` (kwargs-only).
 

--- a/cosmos_rl/utils/payload_transport/ucxx/transport.py
+++ b/cosmos_rl/utils/payload_transport/ucxx/transport.py
@@ -82,14 +82,13 @@ class UCXXPayloadTransport(PayloadTransport):
           remote slot read (initial + retries).  Retries fire only on
           transient UCX errors classified in ``_TRANSIENT_UCXX_ERRORS``;
           non-transient errors short-circuit immediately.
-        * ``ucxx_read_timeout`` (float, default 5.0): per-await wall
+        * ``ucxx_read_timeout`` (float, default 30.0): per-await wall
           clock budget for each ``endpoint.send`` / ``endpoint.recv``
           inside one ``UCXXClient.read`` call (distinct from
           ``ucxx_prefetch_timeout`` above -- this bounds a single
-          network operation, not a whole batch).  p99 healthy-path read
-          of a ~500 MB slot is ~1 s, so 5 s gives 5x headroom.  Larger
-          values just delay rotation onto a healthy port when one
-          server thread wedges -- they don't help the happy path.
+          network operation, not a whole batch).  Retries on transient
+          UCX errors use ``ucxx_read_max_attempts``, so this default
+          targets slow large-payload reads without wedging rotation.
 
         No-op for packers that do not subclass the mixin -- matches the
         defensive default of the base class.
@@ -109,9 +108,9 @@ class UCXXPayloadTransport(PayloadTransport):
         if max_attempts < 1:
             max_attempts = 1
         try:
-            read_timeout = float(custom.get("ucxx_read_timeout", 5.0))
+            read_timeout = float(custom.get("ucxx_read_timeout", 30.0))
         except (TypeError, ValueError):
-            read_timeout = 5.0
+            read_timeout = 30.0
         logger.debug(
             f"[UCXXPayloadTransport] Attaching UCXX data packer "
             f"(device={device}, prefetch_timeout={prefetch_timeout}, "

--- a/tests/test_multirank_shutdown.py
+++ b/tests/test_multirank_shutdown.py
@@ -53,6 +53,7 @@ from cosmos_rl.dispatcher.status import (
     RolloutStatusManager,
     need_weight_sync,
     should_broadcast_stop,
+    should_coalesce_skip,
 )
 from cosmos_rl.dispatcher.protocol import MESH_NAMES, RegisterRequest, Role
 
@@ -257,6 +258,80 @@ class TestShouldBroadcastStop(unittest.TestCase):
         self.assertFalse(
             should_broadcast_stop(**{**self._FIRE, "stop_broadcast_sent": True})
         )
+
+
+class TestShouldCoalesceSkip(unittest.TestCase):
+    """``should_coalesce_skip`` implements depth-1 drop-to-latest.  It skips
+    (coalesces) a weight-sync round only when coalescing is enabled, the round
+    is not forced, and a previously issued round is still in flight
+    (``last_staged_step > max_adopted_version``); otherwise it issues."""
+
+    # Canonical "a round is still in flight" state -> the one case that skips.
+    _SKIP = dict(
+        coalesce_enabled=True,
+        forced=False,
+        last_staged_step=10,
+        max_adopted_version=7,
+    )
+
+    def test_skips_while_round_in_flight(self):
+        # Issued step 10, rollouts only adopted 7 -> in flight -> skip.
+        self.assertTrue(should_coalesce_skip(**self._SKIP))
+
+    def test_issues_when_rollouts_caught_up(self):
+        # Rollouts adopted the last staged version -> issue (drop-to-latest).
+        self.assertFalse(
+            should_coalesce_skip(**{**self._SKIP, "max_adopted_version": 10})
+        )
+        # Adopted even beyond -> still issue.
+        self.assertFalse(
+            should_coalesce_skip(**{**self._SKIP, "max_adopted_version": 12})
+        )
+
+    def test_first_sync_issues_naturally(self):
+        # Nothing staged yet (last_staged = -1) -> never skip, no special-case.
+        self.assertFalse(
+            should_coalesce_skip(
+                coalesce_enabled=True,
+                forced=False,
+                last_staged_step=-1,
+                max_adopted_version=-1,
+            )
+        )
+
+    def test_never_coalesces_when_disabled(self):
+        # Feature off -> behave like the unconditional every-interval sync.
+        self.assertFalse(
+            should_coalesce_skip(**{**self._SKIP, "coalesce_enabled": False})
+        )
+
+    def test_forced_round_always_issues(self):
+        # Validation-trigger steps override the skip even with a round in flight.
+        self.assertFalse(should_coalesce_skip(**{**self._SKIP, "forced": True}))
+
+
+class TestWeightSyncForced(unittest.TestCase):
+    """``_weight_sync_forced`` forces a sync only on validation-trigger steps."""
+
+    def _mgr(self, validation_enable=False, freq=0):
+        mgr = PolicyStatusManager()
+        mgr.config = SimpleNamespace(
+            validation=SimpleNamespace(enable=validation_enable, freq=freq),
+        )
+        return mgr
+
+    def test_not_forced_without_validation(self):
+        mgr = self._mgr(validation_enable=False)
+        self.assertFalse(mgr._weight_sync_forced(step=10, total_steps=100))
+
+    def test_forced_on_validation_freq_step(self):
+        mgr = self._mgr(validation_enable=True, freq=10)
+        self.assertTrue(mgr._weight_sync_forced(step=10, total_steps=100))
+        self.assertFalse(mgr._weight_sync_forced(step=11, total_steps=100))
+
+    def test_forced_on_final_step_with_validation(self):
+        mgr = self._mgr(validation_enable=True, freq=10)
+        self.assertTrue(mgr._weight_sync_forced(step=100, total_steps=100))
 
 
 # ---------------------------------------------------------------------------
@@ -1028,6 +1103,8 @@ class TestJobPhaseFinishDraining(unittest.TestCase):
             recompute_total_steps=_recompute,
             trigger_training_complete=_trigger_training_complete,
             rollout_buffer=SimpleNamespace(queue=SimpleNamespace(clear=lambda: None)),
+            config=SimpleNamespace(train=SimpleNamespace(train_batch_per_replica=8)),
+            get_all_atoms_arrived_replicas=lambda: [object()],
         )
         psm.finish_draining_phase = PolicyStatusManager.finish_draining_phase.__get__(
             psm
@@ -1049,6 +1126,8 @@ class TestJobPhaseFinishDraining(unittest.TestCase):
             recompute_total_steps=lambda **kw: None,
             trigger_training_complete=lambda: training_complete.append(True),
             rollout_buffer=SimpleNamespace(queue=SimpleNamespace(clear=lambda: None)),
+            config=SimpleNamespace(train=SimpleNamespace(train_batch_per_replica=8)),
+            get_all_atoms_arrived_replicas=lambda: [object()],
         )
         psm.finish_draining_phase = PolicyStatusManager.finish_draining_phase.__get__(
             psm
@@ -1071,6 +1150,8 @@ class TestJobPhaseFinishDraining(unittest.TestCase):
             recompute_total_steps=lambda **kw: None,
             trigger_training_complete=lambda: training_complete.append(True),
             rollout_buffer=SimpleNamespace(queue=queue),
+            config=SimpleNamespace(train=SimpleNamespace(train_batch_per_replica=8)),
+            get_all_atoms_arrived_replicas=lambda: [object()],
         )
         psm.finish_draining_phase = PolicyStatusManager.finish_draining_phase.__get__(
             psm
@@ -1079,6 +1160,38 @@ class TestJobPhaseFinishDraining(unittest.TestCase):
         self.assertEqual(cleared, [True])
         self.assertEqual(psm.total_steps, 4)
         self.assertEqual(training_complete, [True])
+
+    def test_finish_defers_when_buffer_can_fill_remaining_steps(self):
+        """Do not fire TrainingComplete while a full step of rollouts waits."""
+        training_complete = []
+
+        psm = SimpleNamespace(
+            total_steps=3,
+            current_step=2,
+            policy_replicas={},
+            total_pending_rollouts=lambda: 16,
+            all_ready_or_reduced=lambda: True,
+            trigger_training_complete=lambda: training_complete.append(True),
+            rollout_buffer=SimpleNamespace(
+                queue=SimpleNamespace(
+                    clear=lambda: (_ for _ in ()).throw(
+                        AssertionError("buffer should not be cleared")
+                    )
+                )
+            ),
+            config=SimpleNamespace(train=SimpleNamespace(train_batch_per_replica=8)),
+            get_all_atoms_arrived_replicas=lambda: [object()],
+        )
+
+        def _recompute(**_kw):
+            psm.total_steps = 2
+
+        psm.recompute_total_steps = _recompute
+        psm.finish_draining_phase = PolicyStatusManager.finish_draining_phase.__get__(
+            psm
+        )
+        psm.finish_draining_phase(SimpleNamespace(all_rollouts_ended=lambda: True))
+        self.assertEqual(training_complete, [])
 
 
 class TestJobPhaseValidationBypass(unittest.TestCase):
@@ -1179,6 +1292,8 @@ class TestTrainingCompleteCommand(unittest.TestCase):
             ),
             trigger_training_complete=_trigger,
             rollout_buffer=SimpleNamespace(queue=SimpleNamespace(clear=lambda: None)),
+            config=SimpleNamespace(train=SimpleNamespace(train_batch_per_replica=8)),
+            get_all_atoms_arrived_replicas=lambda: [object()],
         )
         psm.finish_draining_phase = PolicyStatusManager.finish_draining_phase.__get__(
             psm
@@ -1198,6 +1313,8 @@ class TestTrainingCompleteCommand(unittest.TestCase):
             recompute_total_steps=lambda **kw: None,
             trigger_training_complete=lambda: calls.append(True),
             rollout_buffer=SimpleNamespace(queue=SimpleNamespace(clear=lambda: None)),
+            config=SimpleNamespace(train=SimpleNamespace(train_batch_per_replica=8)),
+            get_all_atoms_arrived_replicas=lambda: [object()],
         )
         psm.finish_draining_phase = PolicyStatusManager.finish_draining_phase.__get__(
             psm

--- a/tests/test_ucxx_data_packer_mixin.py
+++ b/tests/test_ucxx_data_packer_mixin.py
@@ -322,7 +322,7 @@ class TestSetupViaTransportAttach(unittest.TestCase):
                 "device": "cuda:0",
                 "prefetch_timeout": 5.0,
                 "max_attempts": 2,
-                "read_timeout": 5.0,
+                "read_timeout": 30.0,
             },
         )
 

--- a/tests/test_ucxx_transport.py
+++ b/tests/test_ucxx_transport.py
@@ -520,7 +520,7 @@ class TestUCXXAttachDataPacker(unittest.TestCase):
         UCXXPayloadTransport().attach_data_packer(_Packer(), config=SimpleNamespace())
         self.assertEqual(captured["prefetch_timeout"], 30.0)
         self.assertEqual(captured["max_attempts"], 2)
-        self.assertEqual(captured["read_timeout"], 5.0)
+        self.assertEqual(captured["read_timeout"], 30.0)
         self.assertNotIn("n_chunks", captured)
 
     def test_attach_noop_when_setup_method_missing(self):
@@ -566,7 +566,7 @@ class TestUCXXAttachDataPacker(unittest.TestCase):
         UCXXPayloadTransport().attach_data_packer(_Packer(), config=config)
         self.assertEqual(captured["prefetch_timeout"], 30.0)
         self.assertEqual(captured["max_attempts"], 2)
-        self.assertEqual(captured["read_timeout"], 5.0)
+        self.assertEqual(captured["read_timeout"], 30.0)
         self.assertNotIn("n_chunks", captured)
 
     def test_attach_clamps_max_attempts_to_at_least_one(self):

--- a/tests/utils/mock_policy_entrance.py
+++ b/tests/utils/mock_policy_entrance.py
@@ -207,7 +207,8 @@ def main(*args, **kwargs):
                 assert worker.trainer.computed_cnt == 3, (
                     "custom_rollout should compute logprobs for the three real "
                     "training steps; the final TrainingCompleteCommand is a "
-                    "zero-work ack and must not call compute_logprobs"
+                    "zero-work ack and must not call compute_logprobs "
+                    f"(got computed_cnt={getattr(worker.trainer, 'computed_cnt', None)})"
                 )
         elif policy_type == "sft":
             custom_sft_dataset = kwargs.get("dataset")


### PR DESCRIPTION
## Summary
Adds weight-sync diagnostics and an opt-in controller-side coalescing knob for the off-policy / async-weight-sync path.

- **Observability (the primary value):** rollout `WeightSyncThread` queue depth (`qdepth`/`max_qdepth`) and per-adopt `superseded=` (versions transferred but skipped before adoption) in `weight_sync.py`; accepted-rollout weight-version staleness `p50/p99/max` + a coalesced-skip counter from the controller (`status.py`), surfaced in a new **"Weight-Sync Backlog & Coalescing"** analyzer report section.
- **Opt-in coalescing** `train.coalesce_weight_sync` (default **off**, validator-gated to off-policy + `allowed_outdated_steps>0`): controller keeps a single weight-sync round in flight per rollout group and re-arms with the latest weights once rollouts adopt the staged version (depth-1 drop-to-latest, adoption-based). Pure `should_coalesce_skip` helper; validation steps always force a sync.

## Empirical note
On the 2026-06-01 `slow_prep` unthrottled matrix this is a **no-op for cheap transfers** (500 MB model, <1s transfers, staleness-ceiling bound): `max_qdepth ~1–2` either way, `superseded ~150/run`, episodes/sec unchanged within noise. It targets the **large-model / expensive-transfer** regime; kept default-off. The diagnostics are what made this measurable (and disproved a WST-pileup hypothesis).

## Test plan
- [x] `tests/test_multirank_shutdown.py` — `should_coalesce_skip` (in-flight / caught-up / forced / disabled / first-sync) + `_weight_sync_forced`