### PR TITLE
feat(slurm): run full CI suite on an 8-GPU Slurm node

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,16 @@ ARG FLASH_ATTN_VERSION=2.8.3
 ARG PYTHON_VERSION=3.12
 ARG COSMOS_RL_TORCH_VARIANT
 
+# Bound parallelism of the from-source CUDA extension builds (flash-attn/FA3,
+# apex, transformer_engine, grouped_gemm, DeepEP). Empty = use all cores
+# (previous behavior). Set MAX_JOBS to avoid OOM on hosts where one nvcc job per
+# core exceeds RAM. These ENVs are honored by torch's cpp_extension build and by
+# the flash-attn/TE setup scripts, and propagate to the inheriting build stages.
+ARG MAX_JOBS=""
+ARG NVCC_THREADS=""
+ENV MAX_JOBS=${MAX_JOBS}
+ENV NVCC_THREADS=${NVCC_THREADS}
+
 ENV TZ=Etc/UTC
 
 RUN apt-get update -y && apt-get upgrade -y
@@ -223,9 +233,12 @@ FROM pre-package AS package
 
 ARG COSMOS_RL_EXTRAS
 
+# cmake doesn't depend on the source, so install it above the COPY to keep it
+# cached across source-only changes.
+RUN apt-get update && apt-get install -y cmake
+
 COPY . /workspace/cosmos_rl
-RUN apt-get update && apt-get install -y cmake && \
-    pip install /workspace/cosmos_rl${COSMOS_RL_EXTRAS:+[$COSMOS_RL_EXTRAS]} && \
+RUN pip install /workspace/cosmos_rl${COSMOS_RL_EXTRAS:+[$COSMOS_RL_EXTRAS]} && \
     if [[ ",$COSMOS_RL_EXTRAS," == *,vla,* ]]; then \
         bash /workspace/cosmos_rl/tools/scripts/setup_vla.sh; \
     fi && \

--- a/cosmos_rl/comm/base.py
+++ b/cosmos_rl/comm/base.py
@@ -435,7 +435,11 @@ class CommMixin:
         self._is_registered = False
         # let only rank == 0 send the unregister request
         if self.global_rank == 0:
+            logger.info(
+                f"[{self.role}] Sending unregister for {self.replica_name} to controller"
+            )
             self.api_client.unregister(self.replica_name)
+            logger.info(f"[{self.role}] Unregister for {self.replica_name} completed")
 
     def get_group_unique_key(self, replica_name_to_rank: Dict[str, int]):
         return (

--- a/cosmos_rl/dispatcher/api/client.py
+++ b/cosmos_rl/dispatcher/api/client.py
@@ -178,6 +178,9 @@ class APIClient(object):
                 partial(
                     requests.post,
                     json={"replica_name": replica_name},
+                    # Bounded so a hung socket during teardown cannot block the
+                    # clean unregister forever (which would strand the controller).
+                    timeout=constant.COSMOS_CONTROL_HTTP_TIMEOUT,
                 ),
                 self.get_alternative_urls(COSMOS_API_UNREGISTER_SUFFIX),
                 max_retries=self.max_retries,
@@ -191,6 +194,9 @@ class APIClient(object):
                 partial(
                     requests.post,
                     json={"replica_name": replica_name},
+                    # Bounded so a stuck heartbeat post cannot block the heartbeat
+                    # process indefinitely (which would also wedge its join()).
+                    timeout=constant.COSMOS_CONTROL_HTTP_TIMEOUT,
                 ),
                 self.get_alternative_urls(COSMOS_API_HEARTBEAT_SUFFIX),
                 max_retries=self.max_retries,

--- a/cosmos_rl/dispatcher/run_web_panel.py
+++ b/cosmos_rl/dispatcher/run_web_panel.py
@@ -99,6 +99,58 @@ def create_error_response(
 
 controller = Controller()
 server = None
+# Set True on the first successful /register.  Guards heartbeat-reap finalize
+# against the startup window where replica managers are empty but workers have
+# not connected yet (notably SFT controllers where ``not is_rl`` is always true).
+_replicas_were_registered = False
+
+
+def _all_replicas_gone() -> bool:
+    return (
+        len(controller.policy_status_manager) == 0
+        and len(controller.rollout_status_manager) == 0
+        and len(controller.teacher_result_manager) == 0
+    )
+
+
+def _maybe_finalize(reason: str) -> bool:
+    """Shut the controller down once every replica is gone.
+
+    This must trigger regardless of *how* a replica left -- a clean HTTP
+    /unregister OR a heartbeat-timeout reap. Historically the finalize check
+    lived only in the /unregister handler, so a replica that died ungracefully
+    (no clean unregister) left the controller running forever, hanging the
+    process-flow test until the outer job timeout. Centralizing it here and
+    calling it from both paths makes liveness robust to any ungraceful exit.
+
+    The heartbeat-reap path must *not* finalize at startup (empty managers,
+    no replica has registered yet).  The /unregister path is safe without that
+    guard because it only runs after a replica actually departs.
+    """
+    if not _all_replicas_gone():
+        return False
+
+    if reason == "heartbeat-death reap":
+        # All replicas gone after having been live at least once (reaped or
+        # unregistered).  Do not require training_finished / is_rl here --
+        # that would re-introduce the stranded-controller hang when the last
+        # replica dies without a clean HTTP unregister.
+        ready = _replicas_were_registered
+    else:
+        ready = (
+            controller.policy_status_manager.training_finished() or not controller.is_rl
+        )
+
+    if ready:
+        global server
+        if server is not None and not server.should_exit:
+            logger.info(
+                f"[Controller] All replicas are finished ({reason}); finalizing -- "
+                "shutting down controller."
+            )
+            server.should_exit = True
+        return True
+    return False
 
 
 @asynccontextmanager
@@ -114,6 +166,10 @@ async def lifespan(app: FastAPI):
             controller.rollout_status_manager.maintain_life_status(
                 controller.policy_status_manager
             )
+            # A replica reaped via heartbeat timeout is just as "gone" as one
+            # that unregistered cleanly -- finalize the controller here too so a
+            # dead/ungracefully-exiting replica can never strand it.
+            _maybe_finalize("heartbeat-death reap")
             if shutdown_event.wait(timeout=COSMOS_ROLLOUT_SCAN_INTERVAL):
                 break  # Exit early if shutdown signaled during sleep
 
@@ -169,11 +225,13 @@ async def meta():
 
 @app.post(COSMOS_API_REGISTER_SUFFIX)
 async def register(request: RegisterRequest):
+    global _replicas_were_registered
     try:
         await controller.register(
             Atom.from_register_request(request),
             role=request.role,
         )
+        _replicas_were_registered = True
         return {"message": "Registered"}
     except Exception as e:
         import traceback
@@ -189,18 +247,7 @@ async def unregister(request: UnregisterRequest):
     except Exception as e:
         logger.error(f"[Controller] Unregister failed: {e}")
     finally:
-        if (
-            (
-                controller.policy_status_manager.training_finished()
-                or not controller.is_rl
-            )
-            and len(controller.policy_status_manager) == 0
-            and len(controller.rollout_status_manager) == 0
-            and len(controller.teacher_result_manager) == 0
-        ):
-            logger.info("[Controller] All replicas are finished, finalizing...")
-            global server
-            server.should_exit = True
+        _maybe_finalize(f"clean unregister of {request.replica_name}")
         return {"message": "Unregistered"}
 
 

--- a/cosmos_rl/rollout/worker/llm_worker.py
+++ b/cosmos_rl/rollout/worker/llm_worker.py
@@ -65,12 +65,14 @@ class LLMRolloutWorker(WorkerBase):
     def execute(self):
         try:
             self.rollout_worker.work()
+            logger.info("[Rollout] execute: work() returned")
         except Exception as e:
             import traceback
 
             traceback.print_exc()
             raise e
         finally:
+            logger.info("[Rollout] execute: entering destroy_worker()")
             self.destroy_worker()
 
     def build_runner(self, **kwargs):
@@ -105,7 +107,12 @@ class LLMRolloutWorker(WorkerBase):
 
     def destroy_worker(self):
         if self.rollout_worker is not None:
+            logger.info(
+                "[Rollout] destroy_worker: deleting rollout_worker (vLLM shutdown)"
+            )
             del self.rollout_worker
             self.rollout_worker = None
+            logger.info("[Rollout] destroy_worker: rollout_worker deleted")
+        logger.info("[Rollout] destroy_worker: calling destroy_distributed")
         destroy_distributed()
         logger.info("[Rollout] Destroy context of torch dist.")

--- a/cosmos_rl/rollout/worker/rollout_control.py
+++ b/cosmos_rl/rollout/worker/rollout_control.py
@@ -353,19 +353,29 @@ class DisaggregatedRolloutControlWorker(RolloutWorkerBase):
             if not self.shutdown_mp_signal.is_set():
                 self.shutdown_mp_signal.set()
             if self.background_thread is not None:
+                logger.info("[Rollout] handle_shutdown: joining command-query thread")
                 self.background_thread.join()
                 self.background_thread = None
+                logger.info("[Rollout] handle_shutdown: command-query thread joined")
             if self.teacher_interact_thread is not None:
+                logger.info(
+                    "[Rollout] handle_shutdown: joining teacher-interact thread"
+                )
                 self.teacher_interact_thread.join()
                 self.teacher_interact_thread = None
+                logger.info("[Rollout] handle_shutdown: teacher-interact thread joined")
             if self.scheduler is not None:
                 self.scheduler.stop(wait=False)
                 self.scheduler = None
 
             if self.heartbeat_thread is not None:
+                logger.info("[Rollout] handle_shutdown: joining heartbeat process")
                 self.heartbeat_thread.join()
                 self.heartbeat_thread = None
+                logger.info("[Rollout] handle_shutdown: heartbeat process joined")
+            logger.info("[Rollout] handle_shutdown: unregistering from controller")
             self.unregister_from_controller()
+            logger.info("[Rollout] handle_shutdown: complete")
 
     def get_underlying_model(self):
         """
@@ -2226,5 +2236,12 @@ class DisaggregatedRolloutControlWorker(RolloutWorkerBase):
             self.teacher_interact_thread.start()
 
         self.main_loop()
+        logger.info(
+            "[Rollout] work: main_loop returned, synchronizing inference stream"
+        )
         self.inference_stream.synchronize()
+        logger.info(
+            "[Rollout] work: inference stream synchronized, calling handle_shutdown"
+        )
         self.handle_shutdown()
+        logger.info("[Rollout] work: handle_shutdown returned")

--- a/cosmos_rl/tools/slurm/README.md
+++ b/cosmos_rl/tools/slurm/README.md
@@ -150,3 +150,143 @@ python tools/slurm/dispatch_job.py \
 ```
 
 The launcher should be a Python module that registers custom datasets and reward functions with cosmos-rl.
+
+## Running full CI on Slurm
+
+To run the full CI test suite (`tests/run_test.sh`, including the multi-GPU
+`torchrun` tests) on a single 8-GPU Slurm node, use the helpers below. This
+mirrors what GitHub Actions runs in `.github/workflows/build-and-test.yaml`, but
+on a pyxis/enroot cluster.
+
+Slurm compute/login nodes usually don't have a Docker daemon, so the typical
+flow is: **build the `.sqsh` locally** (on a workstation that has `docker` +
+`enroot`), **upload it to the login node**, then **submit the job** from the
+login node.
+
+### 1. Build the CI container image (locally)
+
+`build_ci_image.sh` runs `docker build` (the same base image as GitHub CI), then
+bakes `tests/` + `configs/` into a thin layer at `/workspace/cosmos-rl` (the base
+Dockerfile removes the source tree, so this is what lets the job run without a
+repo mount), and finally `enroot import`s the result into a `.sqsh`. Run it on a
+host that has **both** `docker` and `enroot`:
+
+```bash
+# from the cosmos-rl repo root, on your local machine
+bash tools/slurm/build_ci_image.sh --sqsh-out cosmos_rl_ci.sqsh
+```
+
+Useful flags: `--image-tag` (docker tag, default `cosmos_rl_ci:latest`),
+`--no-clobber` (refuse to overwrite an existing `.sqsh`; by default it is
+overwritten), `--no-build` (import an already-built local image),
+`--no-bake-tests` (skip baking tests, then `--repo-root-path` is required at
+launch), `--build-mode efa|no-efa` (default `no-efa`),
+`--torch-variant 2.8|2.10`.
+
+> Write the `.sqsh` **outside** the repo (e.g. `--sqsh-out ~/cosmos_rl_ci.sqsh`).
+> The repo root is the Docker build context, so a multi-GB `.sqsh` left there gets
+> pulled in by `COPY . /workspace/cosmos_rl` — busting the layer cache and making
+> "exporting layers" crawl even with no source change.
+
+A few CUDA extensions (flash-attn/FA3, apex, transformer_engine, grouped_gemm,
+DeepEP) have no prebuilt wheels for this torch/CUDA/arch combo and are compiled
+from source. These `nvcc` jobs are memory-hungry, so the build caps parallelism
+via `--max-jobs N` (default: auto from RAM/cores). If the build OOMs, lower it
+(e.g. `--max-jobs 4`); raise it to build faster on a big-RAM host. This maps to
+the `MAX_JOBS` build-arg added to the root `Dockerfile`.
+
+#### Reuse an existing container (skip the source build)
+
+The from-source build is only needed to *produce* an image. If you already have
+a cosmos-rl container, skip it entirely:
+
+- **You already have a `.sqsh`** (e.g. the one your training jobs use): don't run
+  the build at all. Launch directly and provide tests via `--repo-root-path`:
+
+  ```bash
+  ./cosmos_rl_ci_job.sh \
+      --container /lustre/.../cosmos_rl.sqsh \
+      --repo-root-path /lustre/.../cosmos-rl \
+      --output-root-path /lustre/.../ci-runs
+  ```
+
+- **You have a published/registry image but not a `.sqsh`**: convert it with
+  `--from-uri` (needs only `enroot`, no `docker`, no source build):
+
+  ```bash
+  bash tools/slurm/build_ci_image.sh \
+      --from-uri docker://nvcr.io#nvidia/cosmos-rl:<tag> \
+      --sqsh-out cosmos_rl_ci.sqsh
+  ```
+
+  Images built this way don't have `tests/` baked in, so `--repo-root-path` is
+  required when launching.
+
+### 2. Upload the launcher + `.sqsh` to the Slurm login node
+
+`cosmos_rl_ci_job.sh` is a **standalone, self-submitting** launcher: copy just
+this one file plus the `.sqsh` to the login node. No python, no template, and the
+launcher itself does not need to live on shared storage (`sbatch` captures the
+script into its spool). Put the `.sqsh` (and a repo checkout, see below) on
+shared storage reachable by the compute nodes:
+
+```bash
+scp tools/slurm/cosmos_rl_ci_job.sh <login-node>:~/
+scp cosmos_rl_ci.sqsh               <login-node>:/lustre/.../cosmos_rl_ci.sqsh
+```
+
+### 3. Submit the CI job (on the login node)
+
+Run the launcher directly. With no `SLURM_JOB_ID` in the environment it parses
+its args and `sbatch`es itself; Slurm then re-invokes the same file on the
+compute node, where it runs `bash tests/run_test.sh` inside the container on a
+single-node, 8-GPU, `--exclusive` allocation. The job's exit code reflects the CI
+result (any failed test fails the job).
+
+```bash
+./cosmos_rl_ci_job.sh \
+    --container /lustre/.../cosmos_rl_ci.sqsh \
+    --output-root-path /lustre/.../ci-runs \
+    --slurm-partition <partition> \
+    --slurm-account <account>
+```
+
+`--repo-root-path` is **optional**. By default the job runs the `tests/` baked
+into the image. Pass `--repo-root-path /lustre/.../cosmos-rl` to **override** the
+baked-in code/tests with a working-tree checkout (mounted at `/opt/cosmos-rl`
+and put on `PYTHONPATH`), so you can iterate on code/tests and re-run CI without
+rebuilding the image. Logs land under `<output-root>/cosmos_ci_<timestamp>/slurm/`
+(`slurm_<jobid>.log` plus a `run_<jobid>/run_test.log` with the per-test
+PASS/FAIL summary).
+
+Use `--dry-run` to print the exact `sbatch` command without submitting.
+
+| Argument               | Req   | Default                 | Description                                  |
+| ---------------------- | ----- | ----------------------- | -------------------------------------------- |
+| `--container`          | **Y** | -                       | CI container `.sqsh` (from step 1) or URI    |
+| `--output-root-path`   | **Y** | -                       | Output root directory for logs               |
+| `--slurm-partition`    | **Y** | -                       | SLURM partition                              |
+| `--slurm-account`      | **Y** | -                       | SLURM account                                |
+| `--scratch-path`       |       | node-local `$SLURM_TMPDIR`/`$TMPDIR` | Writable scratch backing the container `/tmp` + caches; avoids `$HOME`/Lustre per-user quota (EDQUOT) on HF downloads |
+| `--hf-cache`           |       | fresh dir under scratch | Pre-populated HuggingFace cache to reuse (mounted at `/root/.cache/huggingface`) |
+| `--repo-root-path`     |       | None                    | Repo to mount and test, overriding baked-in  |
+| `--job-name`           |       | `cosmos_ci`             | Base name for the SLURM job                  |
+| `--ngpu-per-node`      |       | 8                       | GPUs to request                              |
+| `--test-timeout`       |       | `2h`                    | `timeout` applied to `run_test.sh`           |
+| `--duration`           |       | test-timeout + 30m      | Override SLURM `--time` (hours)              |
+| `--slurm-job-time`     |       | None                    | Override SLURM `--time` in H:M:S             |
+| `--extra-sbatch-arg`   |       | -                       | Extra `sbatch` arg (repeatable)              |
+| `--dry-run`            |       | False                   | Print the sbatch command without submitting  |
+
+**Troubleshooting**
+
+- `OSError: ... Disk quota exceeded (os error 122)` (EDQUOT) during HF model
+  downloads or `/tmp` writes: the container's scratch is landing on a
+  quota-limited filesystem (often `$HOME`). By default scratch is node-local
+  (`$SLURM_TMPDIR`/`$TMPDIR`); if your node lacks roomy local storage, point
+  `--scratch-path` at a project space with quota headroom, and optionally
+  `--hf-cache` at a pre-populated cache to avoid re-downloading models.
+- `RuntimeError: FP8 is only supported for device that has compute capability
+  8.9 or higher` (`test_fp8.py`): the FP8 path needs Ada/Hopper GPUs (L40S/H100,
+  cc ≥ 8.9). It will fail on A100 (cc 8.0) regardless of this tooling — run the
+  job on a cc ≥ 8.9 partition to exercise it.

--- a/cosmos_rl/tools/slurm/build_ci_image.sh
+++ b/cosmos_rl/tools/slurm/build_ci_image.sh
@@ -1,0 +1,229 @@
+#!/usr/bin/env bash
+# =============================================================================
+# Build the cosmos-rl CI image and import it to an enroot .sqsh for Slurm.
+# =============================================================================
+# This mirrors the base image built by the GitHub Actions CI
+# (.github/workflows/build-and-test.yaml) and produces a pyxis/enroot .sqsh
+# that the standalone `cosmos_rl_ci_job.sh` launcher consumes via
+# `srun --container-image`.
+#
+# Two steps:
+#   1. docker build  -> a local docker image (skip with --no-build)
+#   2. enroot import -> a .sqsh file on a shared filesystem
+#
+# NOTE: building (steps above) needs a host with BOTH `docker` and `enroot`
+#       (typically a login/build node). `enroot import dockerd://...` reads the
+#       image from the local docker daemon, so build and import share a daemon.
+#
+# Usage:
+#   # build the CI image from source and import to .sqsh:
+#   bash tools/slurm/build_ci_image.sh --sqsh-out /lustre/.../cosmos_rl_ci.sqsh
+#
+#   # reuse an already-built local docker image, only import to .sqsh:
+#   bash tools/slurm/build_ci_image.sh --no-build --image-tag cosmos_rl_ci:latest \
+#       --sqsh-out /lustre/.../cosmos_rl_ci.sqsh
+#
+#   # reuse an EXISTING published/registry image (no docker build needed; only
+#   # enroot is required). Provide tests at launch via --repo-root-path:
+#   bash tools/slurm/build_ci_image.sh \
+#       --from-uri docker://nvcr.io#nvidia/cosmos-rl:<tag> \
+#       --sqsh-out /lustre/.../cosmos_rl_ci.sqsh
+#
+# If you ALREADY have a .sqsh (e.g. the one your training jobs use), you don't
+# need this script at all -- just launch with:
+#   ./cosmos_rl_ci_job.sh --container <that.sqsh> --repo-root-path <repo> ...
+# =============================================================================
+
+set -euo pipefail
+
+# --- Defaults ---------------------------------------------------------------
+# Repo root is three levels up from this script (cosmos_rl/tools/slurm -> repo).
+# Use `pwd -P` so the `tools -> cosmos_rl/tools` symlink is resolved to the real
+# path; otherwise the logical path is too short and we overshoot the repo root.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd -P)"
+
+IMAGE_TAG="cosmos_rl_ci:latest"
+SQSH_OUT=""
+# Overwrite an existing .sqsh by default; set --no-clobber to refuse instead.
+NO_CLOBBER=0
+DO_BUILD=1
+BAKE_TESTS=1
+# When set, import this enroot source URI directly instead of building locally
+# (e.g. docker://nvcr.io#nvidia/cosmos-rl:<tag> or dockerd://local-image:tag).
+FROM_URI=""
+# Where tests/ + configs/ get baked inside the image. The launcher falls back to
+# this path when --repo-root-path is not given.
+BAKED_REPO_DIR="/workspace/cosmos-rl"
+
+# Dockerfile build args (see Dockerfile header for accepted values).
+# Default to no-efa: CI runs on a single node, so the AWS-EFA stack is not
+# needed and the no-efa base builds faster.
+COSMOS_RL_BUILD_MODE="no-efa"
+COSMOS_RL_TORCH_VARIANT="2.8"
+
+# Parallelism cap for the from-source CUDA extension builds (flash-attn/FA3,
+# apex, transformer_engine, grouped_gemm, DeepEP). Each nvcc job can use many GB,
+# so building with one job per core can OOM. Empty here => auto (computed from
+# RAM/cores below).
+MAX_JOBS=""
+NVCC_THREADS=""
+
+usage() {
+    cat <<'EOF'
+Build the cosmos-rl CI image and import it to an enroot .sqsh.
+
+Options:
+  --repo-root PATH        Repo root to build from (default: inferred from script path)
+  --image-tag TAG         Docker image tag to build/import (default: cosmos_rl_ci:latest)
+  --sqsh-out PATH         Output .sqsh path (default: <repo-root>/cosmos_rl_ci.sqsh)
+  --build-mode MODE       COSMOS_RL_BUILD_MODE build-arg: efa|no-efa (default: no-efa)
+  --torch-variant VER     COSMOS_RL_TORCH_VARIANT build-arg: 2.8|2.10 (default: 2.8)
+  --max-jobs N            Cap parallel compile jobs (default: auto from RAM/cores).
+                          Lower this if the build OOMs; raise to build faster.
+  --nvcc-threads N        Threads per nvcc invocation (default: unset)
+  --no-build              Skip `docker build`; import the existing local image
+  --from-uri URI          Import an existing container source URI directly (no
+                          docker build / no docker needed), e.g.
+                          docker://nvcr.io#nvidia/cosmos-rl:<tag>. Tests are not
+                          baked in this mode -- pass --repo-root-path at launch.
+  --no-bake-tests         Do not bake tests/ + configs/ into the image
+                          (then --repo-root-path is required at launch time)
+  --no-clobber            Refuse to overwrite an existing .sqsh
+                          (default: overwrite and re-import)
+  -h, --help              Show this help
+EOF
+}
+
+# --- Parse args -------------------------------------------------------------
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --repo-root)      REPO_ROOT="$2"; shift 2 ;;
+        --image-tag)      IMAGE_TAG="$2"; shift 2 ;;
+        --sqsh-out)       SQSH_OUT="$2"; shift 2 ;;
+        --build-mode)     COSMOS_RL_BUILD_MODE="$2"; shift 2 ;;
+        --torch-variant)  COSMOS_RL_TORCH_VARIANT="$2"; shift 2 ;;
+        --max-jobs)       MAX_JOBS="$2"; shift 2 ;;
+        --nvcc-threads)   NVCC_THREADS="$2"; shift 2 ;;
+        --from-uri)       FROM_URI="$2"; shift 2 ;;
+        --no-build)       DO_BUILD=0; shift ;;
+        --no-bake-tests)  BAKE_TESTS=0; shift ;;
+        --no-clobber)     NO_CLOBBER=1; shift ;;
+        --force)          shift ;;  # deprecated no-op: overwrite is now default
+        -h|--help)        usage; exit 0 ;;
+        *) echo "Unknown argument: $1" >&2; usage; exit 1 ;;
+    esac
+done
+
+if [[ -z "${SQSH_OUT}" ]]; then
+    SQSH_OUT="${REPO_ROOT}/cosmos_rl_ci.sqsh"
+fi
+
+# --from-uri reuses an existing container source: no local build, no tests baked.
+if [[ -n "${FROM_URI}" ]]; then
+    DO_BUILD=0
+    BAKE_TESTS=0
+fi
+
+log() { echo "[build_ci_image] $*"; }
+
+command -v enroot >/dev/null 2>&1 || { echo "ERROR: 'enroot' not found on PATH" >&2; exit 1; }
+if [[ "${DO_BUILD}" -eq 1 ]]; then
+    command -v docker >/dev/null 2>&1 || { echo "ERROR: 'docker' not found on PATH" >&2; exit 1; }
+fi
+
+# Auto-pick a memory-safe MAX_JOBS if not specified: the heavy nvcc jobs (esp.
+# FA3) can peak well above 10 GB each, so cap by RAM as well as by core count.
+# Conservative by default (better slow than OOM); raise with --max-jobs.
+if [[ "${DO_BUILD}" -eq 1 && -z "${MAX_JOBS}" ]]; then
+    cores=$(nproc 2>/dev/null || echo 4)
+    mem_gb=$(free -g 2>/dev/null | awk '/^Mem:/{print $2}')
+    [[ -z "${mem_gb}" || "${mem_gb}" -lt 1 ]] && mem_gb=8
+    by_mem=$(( mem_gb / 16 ))
+    [[ "${by_mem}" -lt 1 ]] && by_mem=1
+    MAX_JOBS=$(( cores < by_mem ? cores : by_mem ))
+    log "Auto-selected MAX_JOBS=${MAX_JOBS} (cores=${cores}, mem=${mem_gb}Gi). Override with --max-jobs."
+fi
+
+# --- 1. docker build --------------------------------------------------------
+if [[ "${DO_BUILD}" -eq 1 ]]; then
+    if [[ "${BAKE_TESTS}" -eq 1 ]]; then
+        # Build the base image (same as GH CI) under a -base tag, then add a thin
+        # layer that bakes tests/ + configs/ in (the base Dockerfile rm -rf's the
+        # source tree, so tests/ is otherwise absent from the image).
+        BASE_TAG="${IMAGE_TAG%:*}-base:${IMAGE_TAG##*:}"
+    else
+        BASE_TAG="${IMAGE_TAG}"
+    fi
+
+    log "Building base docker image '${BASE_TAG}' from ${REPO_ROOT}"
+    log "  COSMOS_RL_BUILD_MODE=${COSMOS_RL_BUILD_MODE} COSMOS_RL_TORCH_VARIANT=${COSMOS_RL_TORCH_VARIANT} MAX_JOBS=${MAX_JOBS:-<all>} NVCC_THREADS=${NVCC_THREADS:-<default>}"
+    # Empty MAX_JOBS/NVCC_THREADS build-args are harmless: the Dockerfile ENVs
+    # treat "" as unset (torch's cpp_extension falls back to all cores).
+    docker build \
+        -t "${BASE_TAG}" \
+        -f "${REPO_ROOT}/Dockerfile" \
+        --build-arg "COSMOS_RL_BUILD_MODE=${COSMOS_RL_BUILD_MODE}" \
+        --build-arg "COSMOS_RL_TORCH_VARIANT=${COSMOS_RL_TORCH_VARIANT}" \
+        --build-arg "MAX_JOBS=${MAX_JOBS}" \
+        --build-arg "NVCC_THREADS=${NVCC_THREADS}" \
+        "${REPO_ROOT}"
+
+    if [[ "${BAKE_TESTS}" -eq 1 ]]; then
+        log "Baking tests/ + configs/ into '${IMAGE_TAG}' at ${BAKED_REPO_DIR} (layer on ${BASE_TAG})"
+        # Write the thin overlay Dockerfile to a temp file (avoids inline heredoc
+        # fragility). A 'scratch' default on BASE_IMAGE silences the BuildKit
+        # InvalidDefaultArgInFrom warning; the real base is passed via --build-arg.
+        ci_dockerfile="$(mktemp)"
+        {
+            echo 'ARG BASE_IMAGE=scratch'
+            echo 'FROM ${BASE_IMAGE}'
+            echo 'ARG BAKED_REPO_DIR=/workspace/cosmos-rl'
+            echo 'COPY tests ${BAKED_REPO_DIR}/tests'
+            echo 'COPY configs ${BAKED_REPO_DIR}/configs'
+            echo 'WORKDIR ${BAKED_REPO_DIR}'
+        } > "${ci_dockerfile}"
+        docker build \
+            -t "${IMAGE_TAG}" \
+            --build-arg "BASE_IMAGE=${BASE_TAG}" \
+            --build-arg "BAKED_REPO_DIR=${BAKED_REPO_DIR}" \
+            -f "${ci_dockerfile}" \
+            "${REPO_ROOT}"
+        rm -f "${ci_dockerfile}"
+    fi
+else
+    if [[ -n "${FROM_URI}" ]]; then
+        log "Reusing existing container source (no docker build): ${FROM_URI}"
+    else
+        log "Skipping docker build (--no-build); importing existing local image '${IMAGE_TAG}'"
+    fi
+fi
+
+# --- 2. enroot import -------------------------------------------------------
+if [[ -n "${FROM_URI}" ]]; then
+    SOURCE_URI="${FROM_URI}"
+else
+    SOURCE_URI="dockerd://${IMAGE_TAG}"
+fi
+if [[ -f "${SQSH_OUT}" ]]; then
+    if [[ "${NO_CLOBBER}" -eq 1 ]]; then
+        echo "ERROR: ${SQSH_OUT} already exists (--no-clobber set)." >&2
+        exit 1
+    fi
+    log "Overwriting existing ${SQSH_OUT}"
+    rm -f "${SQSH_OUT}"
+fi
+
+mkdir -p "$(dirname "${SQSH_OUT}")"
+log "Importing '${SOURCE_URI}' -> ${SQSH_OUT}"
+enroot import -o "${SQSH_OUT}" "${SOURCE_URI}"
+
+log "Done. CI container image ready at: ${SQSH_OUT}"
+log "Upload it to the slurm login node, then launch CI with:"
+if [[ "${DO_BUILD}" -eq 1 && "${BAKE_TESTS}" -eq 1 ]]; then
+    log "  ./cosmos_rl_ci_job.sh --container <uploaded.sqsh> --output-root-path <output-root>"
+    log "(tests/ baked in at ${BAKED_REPO_DIR}; add --repo-root-path <repo> to override)"
+else
+    log "  ./cosmos_rl_ci_job.sh --container <uploaded.sqsh> --repo-root-path <repo> --output-root-path <output-root>"
+    log "(no tests baked in this image; --repo-root-path is required to provide tests/)"
+fi

--- a/cosmos_rl/tools/slurm/cosmos_rl_ci_job.sh
+++ b/cosmos_rl/tools/slurm/cosmos_rl_ci_job.sh
@@ -1,0 +1,314 @@
+#!/bin/bash
+# =============================================================================
+# Standalone launcher: full cosmos-rl CI suite on a single 8-GPU Slurm node.
+# =============================================================================
+# This ONE file is both the submitter and the Slurm batch script:
+#
+#   * Run it directly on a login node to submit the job:
+#       ./cosmos_rl_ci_job.sh \
+#           --container /lustre/.../cosmos_rl_ci.sqsh \
+#           --repo-root-path /lustre/.../cosmos-rl \
+#           --output-root-path /lustre/.../ci-runs
+#
+#   * Slurm re-invokes this same file on the compute node (SLURM_JOB_ID set),
+#     where it runs `bash tests/run_test.sh` inside the container with all GPUs.
+#
+# It is self-contained: copy just this file (plus the .sqsh) to the login node.
+# No python, no template, no repo checkout needed for the launcher itself --
+# `sbatch` captures the script into its spool at submit time. A repo checkout is
+# still required via --repo-root-path to provide the tests/ directory, since the
+# container image does not ship it.
+#
+# Mirrors GitHub Actions CI (.github/workflows/build-and-test.yaml). The suite
+# already contains the multi-GPU paths (torchrun --nproc_per_node=8/4/2), so one
+# exclusive 8-GPU node covers it. One-shot: no autoresume/retry, so a failing CI
+# run fails the Slurm job directly.
+# =============================================================================
+
+set -o pipefail
+
+usage() {
+    cat <<'EOF'
+Launch the full cosmos-rl CI suite on a single 8-GPU Slurm node.
+
+Usage:
+  ./cosmos_rl_ci_job.sh --container <.sqsh> --output-root-path <dir> [options]
+
+Options:
+  --container, --cosmos-container PATH  CI container .sqsh (or URI)   [required]
+  --output-root-path DIR               Root dir for logs             [required]
+  --slurm-partition NAME               SLURM partition               [required]
+  --slurm-account NAME                 SLURM account                 [required]
+  --scratch-path DIR                   Writable scratch for /tmp + caches inside
+                                       the container. Avoids $HOME/Lustre per-user
+                                       quotas (EDQUOT) on HF downloads / tmp writes.
+                                       Default: node-local ${SLURM_TMPDIR:-${TMPDIR:-/tmp}}.
+  --hf-cache DIR                       Pre-populated HuggingFace cache to reuse
+                                       (mounted at /root/.cache/huggingface).
+                                       Default: a fresh dir under --scratch-path.
+  --repo-root-path DIR                 Repo to mount + test (provides tests/)
+  --job-name NAME                      SLURM job name        (default: cosmos_ci)
+  --ngpu-per-node N                    GPUs to request       (default: 8)
+  --test-timeout DUR                   timeout for run_test.sh (default: 2h)
+  --duration HOURS                     Override SLURM --time (hours). Default is
+                                       derived from --test-timeout + 30m buffer.
+  --slurm-job-time H:M:S               Override SLURM --time (overrides --duration)
+  --extra-sbatch-arg ARG               Extra sbatch arg (repeatable)
+  --dry-run                            Print the sbatch command, do not submit
+  -h, --help                           Show this help
+EOF
+}
+
+# Convert a `timeout`-style duration (e.g. 2h, 90m, 7200, 30s) to seconds.
+ci_to_seconds() {
+    local t="$1" num unit
+    num="${t%[smhdSMHD]}"
+    unit="${t#"${num}"}"
+    case "${unit}" in
+        s|S|"") echo "${num}" ;;
+        m|M)    echo $(( num * 60 )) ;;
+        h|H)    echo $(( num * 3600 )) ;;
+        d|D)    echo $(( num * 86400 )) ;;
+        *) echo "ERROR" ;;
+    esac
+}
+
+# =============================================================================
+# SUBMIT MODE (login node): no SLURM_JOB_ID -> parse args and `sbatch` self.
+# =============================================================================
+if [[ -z "${SLURM_JOB_ID:-}" ]]; then
+    JOB_NAME="cosmos_ci"
+    NGPU=8
+    PARTITION=""
+    ACCOUNT=""
+    CONTAINER=""
+    REPO_ROOT_PATH=""
+    OUTPUT_ROOT=""
+    SCRATCH_PATH=""
+    HF_CACHE_PATH=""
+    DURATION_HOURS=""
+    JOB_TIME=""
+    TEST_TIMEOUT="2h"
+    # Extra wall-clock on top of the test timeout for container pull/startup.
+    TIME_BUFFER_SEC=1800
+    DRY_RUN=0
+    EXTRA_SBATCH_ARGS=()
+
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --container|--cosmos-container) CONTAINER="$2"; shift 2 ;;
+            --output-root-path)             OUTPUT_ROOT="$2"; shift 2 ;;
+            --scratch-path)                 SCRATCH_PATH="$2"; shift 2 ;;
+            --hf-cache)                     HF_CACHE_PATH="$2"; shift 2 ;;
+            --repo-root-path)               REPO_ROOT_PATH="$2"; shift 2 ;;
+            --job-name)                     JOB_NAME="$2"; shift 2 ;;
+            --ngpu-per-node)                NGPU="$2"; shift 2 ;;
+            --slurm-partition)              PARTITION="$2"; shift 2 ;;
+            --slurm-account)                ACCOUNT="$2"; shift 2 ;;
+            --duration)                     DURATION_HOURS="$2"; shift 2 ;;
+            --slurm-job-time)               JOB_TIME="$2"; shift 2 ;;
+            --test-timeout)                 TEST_TIMEOUT="$2"; shift 2 ;;
+            --extra-sbatch-arg)             EXTRA_SBATCH_ARGS+=("$2"); shift 2 ;;
+            --dry-run)                      DRY_RUN=1; shift ;;
+            -h|--help)                      usage; exit 0 ;;
+            *) echo "ERROR: unknown argument: $1" >&2; usage; exit 1 ;;
+        esac
+    done
+
+    [[ -n "${CONTAINER}" ]] || { echo "ERROR: --container is required" >&2; exit 1; }
+    [[ -n "${OUTPUT_ROOT}" ]] || { echo "ERROR: --output-root-path is required" >&2; exit 1; }
+    [[ -n "${PARTITION}" ]] || { echo "ERROR: --slurm-partition is required" >&2; exit 1; }
+    [[ -n "${ACCOUNT}" ]] || { echo "ERROR: --slurm-account is required" >&2; exit 1; }
+
+    # Resolve SLURM --time. Precedence: --slurm-job-time > --duration > derived
+    # from --test-timeout + buffer (so the allocation always covers the tests).
+    if [[ -n "${JOB_TIME}" ]]; then
+        DURATION="${JOB_TIME}"
+    elif [[ -n "${DURATION_HOURS}" ]]; then
+        h=${DURATION_HOURS%.*}
+        frac=0
+        if [[ "${DURATION_HOURS}" == *.* ]]; then
+            frac=$(awk "BEGIN{printf \"%d\", (${DURATION_HOURS} - ${h}) * 60}")
+        fi
+        DURATION=$(printf "%d:%02d:00" "${h}" "${frac}")
+    else
+        test_secs=$(ci_to_seconds "${TEST_TIMEOUT}")
+        if [[ "${test_secs}" == "ERROR" || -z "${test_secs}" ]]; then
+            echo "ERROR: could not parse --test-timeout '${TEST_TIMEOUT}' (use e.g. 2h, 90m, 7200)" >&2
+            exit 1
+        fi
+        total_secs=$(( test_secs + TIME_BUFFER_SEC ))
+        DURATION=$(printf "%d:%02d:%02d" $(( total_secs / 3600 )) $(( (total_secs % 3600) / 60 )) $(( total_secs % 60 )))
+    fi
+
+    # Absolute paths (the container + repo must be reachable from compute nodes).
+    CONTAINER="$(readlink -f "${CONTAINER}" 2>/dev/null || echo "${CONTAINER}")"
+    if [[ -n "${REPO_ROOT_PATH}" ]]; then
+        REPO_ROOT_PATH="$(readlink -f "${REPO_ROOT_PATH}")"
+    fi
+    # Scratch/HF-cache are optional and may live on shared storage; resolve them
+    # to absolute only when given (node-local default is resolved on the node).
+    if [[ -n "${SCRATCH_PATH}" ]]; then
+        SCRATCH_PATH="$(readlink -f "${SCRATCH_PATH}" 2>/dev/null || echo "${SCRATCH_PATH}")"
+    fi
+    if [[ -n "${HF_CACHE_PATH}" ]]; then
+        HF_CACHE_PATH="$(readlink -f "${HF_CACHE_PATH}" 2>/dev/null || echo "${HF_CACHE_PATH}")"
+    fi
+
+    ts=$(date +%Y%m%d%H%M%S)
+    OUTPUT_DIR="${OUTPUT_ROOT}/${JOB_NAME}_${ts}"
+    SLURM_DIR="${OUTPUT_DIR}/slurm"
+
+    self="$(readlink -f "$0")"
+
+    sbatch_cmd=(
+        sbatch
+        --job-name="${JOB_NAME}"
+        --nodes=1
+        --exclusive
+        --partition="${PARTITION}"
+        --account="${ACCOUNT}"
+        --time="${DURATION}"
+        --gres=gpu:"${NGPU}"
+        --output="${SLURM_DIR}/slurm_%j.log"
+        --open-mode=append
+        --export="ALL,COSMOS_CI_CONTAINER=${CONTAINER},COSMOS_CI_REPO_ROOT=${REPO_ROOT_PATH},COSMOS_CI_OUTPUT_DIR=${OUTPUT_DIR},COSMOS_CI_SLURM_DIR=${SLURM_DIR},COSMOS_CI_TEST_TIMEOUT=${TEST_TIMEOUT},COSMOS_CI_SCRATCH=${SCRATCH_PATH},COSMOS_CI_HF_CACHE=${HF_CACHE_PATH},COSMOS_CI_SUBMIT_USER=${USER}"
+    )
+    for a in "${EXTRA_SBATCH_ARGS[@]}"; do sbatch_cmd+=("${a}"); done
+    sbatch_cmd+=("${self}")
+
+    if [[ "${DRY_RUN}" -eq 1 ]]; then
+        echo "[cosmos-rl-ci] Output dir: ${OUTPUT_DIR}"
+        echo "[cosmos-rl-ci] Would run:"
+        printf '  %q' "${sbatch_cmd[@]}"; echo
+        exit 0
+    fi
+
+    mkdir -p "${SLURM_DIR}"
+    echo "[cosmos-rl-ci] Output dir: ${OUTPUT_DIR}"
+    echo "[cosmos-rl-ci] Container : ${CONTAINER}"
+    exec "${sbatch_cmd[@]}"
+fi
+
+# =============================================================================
+# RUN MODE (compute node, under Slurm): execute the CI suite in the container.
+# =============================================================================
+export OUTPUT_DIR="${COSMOS_CI_OUTPUT_DIR}"
+export SLURM_DIR="${COSMOS_CI_SLURM_DIR}"
+export CONTAINER_IMAGE="${COSMOS_CI_CONTAINER}"
+export TEST_TIMEOUT="${COSMOS_CI_TEST_TIMEOUT:-2h}"
+export REPO_ROOT_PATH="${COSMOS_CI_REPO_ROOT}"
+export SUBMIT_USER="${COSMOS_CI_SUBMIT_USER}"
+
+# Scratch root for the container's /tmp and caches. Default to node-local scratch
+# ($SLURM_TMPDIR / $TMPDIR) so HF model downloads and /tmp writes don't hit the
+# submitter's $HOME or Lustre per-user quota (the EDQUOT / "Disk quota exceeded"
+# failures seen otherwise). Override with --scratch-path.
+SCRATCH_BASE="${COSMOS_CI_SCRATCH:-}"
+if [[ -z "${SCRATCH_BASE}" ]]; then
+    SCRATCH_BASE="${SLURM_TMPDIR:-${TMPDIR:-/tmp}}"
+fi
+SCRATCH_DIR="${SCRATCH_BASE}/cosmos_ci_${SLURM_JOB_ID}"
+
+# --- Ensure $USER is set correctly (important for containers) ---------------
+if [[ -n "${SUBMIT_USER}" ]]; then
+    export USER="${SUBMIT_USER}"
+fi
+
+log() {
+    local message="$1"
+    local timestamp
+    timestamp=$(date +"%Y-%m-%d %I:%M:%S.%3N %p %Z")
+    echo -e "[$timestamp][cosmos-rl-ci]: $message"
+}
+
+# --- Job info & directory setup --------------------------------------------
+echo "JOBID $SLURM_JOB_ID"
+log "Full-CI job started on $(hostname)"
+log "User: ${USER}, Submit User: ${SUBMIT_USER}"
+log "Container image: ${CONTAINER_IMAGE}"
+
+job_dir="${SLURM_DIR}"
+mkdir -p "${job_dir}"
+run_dir="${job_dir}/run_${SLURM_JOB_ID}"
+mkdir -p "${run_dir}"
+ln -sfn "${run_dir}" "${job_dir}/latest_run"
+log "Run dir: ${run_dir}"
+
+# --- Container mounts -------------------------------------------------------
+# All writable paths live under a roomy scratch dir (node-local by default) to
+# avoid per-user quota (EDQUOT) on HF downloads and /tmp writes.
+HOST_CACHE_DIR="${SCRATCH_DIR}/cache"        # -> /root/.cache (matches GH CI -v /tmp/cache)
+HOST_TMP_DIR="${SCRATCH_DIR}/tmp"            # -> /tmp (test configs, pycache, etc.)
+# HF cache: reuse a pre-populated dir if given, else a fresh one under scratch.
+HOST_HF_CACHE="${COSMOS_CI_HF_CACHE:-}"
+if [[ -z "${HOST_HF_CACHE}" ]]; then
+    HOST_HF_CACHE="${SCRATCH_DIR}/huggingface"
+fi
+mkdir -p "${HOST_CACHE_DIR}" "${HOST_TMP_DIR}" "${HOST_HF_CACHE}"
+log "Scratch dir: ${SCRATCH_DIR} (HF cache: ${HOST_HF_CACHE})"
+
+# Nested binds: /root/.cache/huggingface sits inside /root/.cache.
+MOUNTS="${HOST_CACHE_DIR}:/root/.cache"
+MOUNTS="${MOUNTS},${HOST_TMP_DIR}:/tmp"
+MOUNTS="${MOUNTS},${HOST_HF_CACHE}:/root/.cache/huggingface"
+
+# Mount the repo so the latest tests/ (and optionally working-tree code) run,
+# rather than only the code baked into the container image.
+if [[ -n "${REPO_ROOT_PATH}" ]]; then
+    MOUNTS="${MOUNTS},${REPO_ROOT_PATH}:/opt/cosmos-rl"
+fi
+
+log "Container mounts: ${MOUNTS}"
+
+# --- Run the CI suite -------------------------------------------------------
+srun \
+    --nodes=1 \
+    --ntasks=1 \
+    --container-image "${CONTAINER_IMAGE}" \
+    --container-mounts "${MOUNTS}" \
+    --no-container-mount-home \
+    --export=ALL,USER=${USER} \
+    -o "${run_dir}/run_test.out" \
+    -e "${run_dir}/run_test.err" \
+    bash -c '
+    set -o pipefail
+    # Match GH CI environment.
+    export PYTHONPYCACHEPREFIX=/tmp/pycache
+    # Keep temp files + HF downloads on the mounted scratch (roomy, no quota).
+    export TMPDIR=/tmp
+    export HF_HOME=/root/.cache/huggingface
+    # Disable NCCL NVLS to avoid potential instability on slurm clusters.
+    export NCCL_NVLS_ENABLE=0
+
+    python -c "import cosmos_rl; print(f\"cosmos_rl location: {cosmos_rl.__file__}\"); print(f\"cosmos_rl version: {cosmos_rl.__version__}\")" 2>/dev/null || true
+
+    if [[ -d /opt/cosmos-rl/tests ]]; then
+        # --repo-root-path was mounted: override the baked-in code/tests and run
+        # against the working-tree copy (PYTHONPATH shadows the installed pkg).
+        export PYTHONPATH="/opt/cosmos-rl:${PYTHONPATH}"
+        cd /opt/cosmos-rl
+        echo "Using mounted repo at /opt/cosmos-rl (overrides baked-in)"
+    elif [[ -d /workspace/cosmos-rl/tests ]]; then
+        # No mount: use the tests/ baked into the image (build_ci_image.sh).
+        cd /workspace/cosmos-rl
+        echo "Using tests baked into the image at /workspace/cosmos-rl"
+    else
+        echo "ERROR: no tests/ found. Build the image with tests baked in (default), or pass --repo-root-path." >&2
+        exit 1
+    fi
+
+    echo "Running tests from: $(pwd)"
+    timeout '"${TEST_TIMEOUT}"' bash tests/run_test.sh
+    ' \
+    | tee "${run_dir}/run_test.log"
+status=${PIPESTATUS[0]}
+
+log "tests/run_test.sh exited with status: ${status}"
+if [[ ${status} -eq 0 ]]; then
+    log "================ CI PASSED ================"
+else
+    log "================ CI FAILED (status=${status}) ================"
+fi
+
+exit ${status}

--- a/cosmos_rl/utils/constant.py
+++ b/cosmos_rl/utils/constant.py
@@ -13,9 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
 from enum import IntEnum
 from pathlib import Path
-import os
 
 CACHE_DIR = Path(
     os.environ.get("COSMOS_CACHE_DIR", Path.home() / ".cache" / "cosmos_rl")
@@ -31,6 +31,11 @@ COSMOS_HEARTBEAT_TIMEOUT = int(os.environ.get("COSMOS_HEARTBEAT_TIMEOUT", "200")
 COSMOS_HEARTBEAT_SEND_INTERVAL = int(
     os.environ.get("COSMOS_HEARTBEAT_SEND_INTERVAL", "60")
 )
+
+# Bound for control-plane HTTP calls (unregister/heartbeat). Without a timeout,
+# requests.post blocks forever on a hung/saturated controller socket during
+# teardown -- which strands the clean unregister.
+COSMOS_CONTROL_HTTP_TIMEOUT = float(os.environ.get("COSMOS_CONTROL_HTTP_TIMEOUT", "30"))
 
 COSMOS_ROLLOUT_SCAN_INTERVAL = int(os.environ.get("COSMOS_ROLLOUT_SCAN_INTERVAL", "10"))
 COSMOS_ROLLOUT_STEP_INTERVAL = int(
@@ -74,6 +79,14 @@ class CosmosHttpRetryConfig:
 
 COSMOS_HTTP_RETRY_CONFIG = CosmosHttpRetryConfig()
 COSMOS_HTTP_LONG_WAIT_MAX_RETRY = 100
+# Streaming poll reads (subscribe_command / subscribe_rollout) run inside their
+# own `while not shutdown_signal` loops, so the loop itself is the retry
+# mechanism. They must NOT run the deep (max_retries=60) exponential-backoff
+# storm internally: when the controller finalizes and tears down its embedded
+# Redis during shutdown, that storm blocks for ~50min ignoring shutdown_signal,
+# which hangs the teardown join in handle_shutdown. Fail fast (one attempt) and
+# let the outer loop re-check shutdown_signal and re-poll.
+COSMOS_HTTP_STREAM_POLL_MAX_RETRY = 1
 
 COSMOS_REWARD_DISPATCHER_PAYLOAD_PER_TASK = int(
     os.environ.get("COSMOS_REWARD_DISPATCHER_PAYLOAD_PER_TASK", "64")

--- a/cosmos_rl/utils/redis_stream.py
+++ b/cosmos_rl/utils/redis_stream.py
@@ -21,6 +21,7 @@ from cosmos_rl.utils.constant import (
     RedisStreamConstant,
     COSMOS_HTTP_RETRY_CONFIG,
     COSMOS_HTTP_LONG_WAIT_MAX_RETRY,
+    COSMOS_HTTP_STREAM_POLL_MAX_RETRY,
 )
 from typing import List, Dict
 from cosmos_rl.utils.network_util import make_request_with_retry
@@ -171,7 +172,9 @@ class RedisStreamHandler:
                     block=RedisStreamConstant.CMD_READING_TIMEOUT_MS,
                 ),
                 response_parser=None,
-                max_retries=COSMOS_HTTP_RETRY_CONFIG.max_retries,
+                # Polling read: the caller loops on shutdown_signal, so fail fast
+                # instead of running the deep retry storm that hangs teardown.
+                max_retries=COSMOS_HTTP_STREAM_POLL_MAX_RETRY,
             )
         except Exception as e:
             logger.error(
@@ -226,6 +229,7 @@ class RedisStreamHandler:
         Returns:
             list: A list of stream entries.
         """
+        messages = None
         try:
             messages = make_request_with_retry(
                 self.requests_for_alternative_clients(
@@ -237,7 +241,9 @@ class RedisStreamHandler:
                     block=RedisStreamConstant.ROLLOUT_READING_TIMEOUT_MS,
                 ),
                 response_parser=None,
-                max_retries=COSMOS_HTTP_RETRY_CONFIG.max_retries,
+                # Polling read: the caller loops on shutdown_signal, so fail fast
+                # instead of running the deep retry storm that hangs teardown.
+                max_retries=COSMOS_HTTP_STREAM_POLL_MAX_RETRY,
             )
         except Exception as e:
             logger.error(

--- a/tests/run_test.sh
+++ b/tests/run_test.sh
@@ -26,6 +26,24 @@ run() {
     fi
 }
 
+# FP8 requires GPU compute capability >= 8.9 (Ada/Hopper, e.g. L40S/H100).
+# On older GPUs (e.g. A100, cc 8.0) it errors out, so skip it there instead of
+# recording a spurious failure. Set COSMOS_FORCE_FP8=1 to run it regardless.
+gpu_supports_fp8() {
+    [[ "${COSMOS_FORCE_FP8:-0}" == "1" ]] && return 0
+    python - <<'PY'
+import sys
+try:
+    import torch
+    if not torch.cuda.is_available():
+        sys.exit(1)
+    major, minor = torch.cuda.get_device_capability(0)
+    sys.exit(0 if (major, minor) >= (8, 9) else 1)
+except Exception:
+    sys.exit(1)
+PY
+}
+
 run python -c "from cosmos_rl._version import version; print(version)"
 run python -c "import cosmos_rl, os; print('cosmos_rl imported from:', cosmos_rl.__file__)"
 
@@ -35,7 +53,12 @@ run python tests/test_cosmos_hf_precision.py
 run /bin/bash -c "CP_SIZE=2 TP_SIZE=1 DP_SIZE=2 torchrun --nproc_per_node=4 tests/test_context_parallel.py"
 run python tests/test_cache.py
 run python tests/test_comm.py
-run python tests/test_fp8.py
+if gpu_supports_fp8; then
+    run python tests/test_fp8.py
+else
+    echo
+    echo "================ SKIP: python tests/test_fp8.py (GPU compute capability < 8.9) ================"
+fi
 run python tests/test_lora.py
 run python tests/test_freeze_pattern.py
 # run python tests/test_grad_allreduce.py

--- a/tests/test_hf_models.py
+++ b/tests/test_hf_models.py
@@ -83,6 +83,13 @@ def test_cosmos_hf_model(model, inputs):
         return logits[:, -1, :]
 
 
+def _logits_equal(a: torch.Tensor, b: torch.Tensor) -> bool:
+    """Compare logits; generate() may upcast to float32 while forward stays bf16."""
+    if a.dtype != b.dtype:
+        a, b = a.float(), b.float()
+    return torch.equal(a, b)
+
+
 class TestHFModel(unittest.TestCase):
     def test_post_to_empty_hook(self):
         for model_id in [
@@ -317,10 +324,10 @@ class TestHFModel(unittest.TestCase):
                 cosmos_hf_logits = test_cosmos_hf_model(
                     cosmos_hf_model, copy.deepcopy(inputs)
                 )
-                assert torch.equal(hf_generate_logits, hf_forward_logits), (
+                assert _logits_equal(hf_generate_logits, hf_forward_logits), (
                     f"{hf_generate_logits} != {hf_forward_logits}"
                 )
-                assert torch.equal(hf_generate_logits, cosmos_hf_logits), (
+                assert _logits_equal(hf_generate_logits, cosmos_hf_logits), (
                     f"{hf_generate_logits} != {cosmos_hf_logits}"
                 )
 

--- a/tests/test_process_flow.py
+++ b/tests/test_process_flow.py
@@ -16,13 +16,85 @@
 import os
 
 os.environ["TORCH_CPP_LOG_LEVEL"] = "ERROR"
+# Enable faulthandler at interpreter startup in every child process (controller,
+# torchrun workers, launchers) that copies this env. With it set, a SIGABRT makes
+# each Python process dump *all* thread stacks to stderr before dying, so a
+# teardown hang is pinpointed in the logs. Test-only; no production code touched.
+os.environ.setdefault("PYTHONFAULTHANDLER", "1")
 import unittest
 import subprocess
 import sys
+import time
+import signal
 import toml
 import tempfile
 
 from cosmos_rl.utils import network_util
+
+
+# Bound for how long a process-flow scenario may take before a non-exiting
+# process is treated as hung. Generous (covers model load + a few steps + the
+# heartbeat-timeout teardown) but finite, so a hang fails fast and LOUD here
+# instead of silently burning the outer CI `timeout 2h`.
+_PROC_EXIT_TIMEOUT = float(os.environ.get("COSMOS_TEST_PROC_EXIT_TIMEOUT", "1200"))
+
+
+def _signal_tree(proc, sig):
+    """Send `sig` to a child's whole process group when it leads its own group.
+
+    Children run with PYTHONFAULTHANDLER=1 (set at module import), so SIGABRT
+    makes every Python process dump *all* thread stacks to stderr before dying
+    -- pinpointing exactly where a hang is. We only use killpg when
+    the child is its own session/group leader (started with start_new_session);
+    otherwise we fall back to a per-process signal so we never hit the test
+    runner's own group.
+    """
+    try:
+        pgid = os.getpgid(proc.pid)
+        if pgid == proc.pid:
+            os.killpg(pgid, sig)
+            return
+    except Exception:
+        pass
+    try:
+        proc.send_signal(sig)
+    except Exception:
+        pass
+
+
+def _diagnose_and_kill(processes):
+    for proc in processes:
+        if proc.poll() is None:
+            _signal_tree(proc, signal.SIGABRT)
+    # Let faulthandler flush all-thread stacks to stderr before the hard kill.
+    time.sleep(5.0)
+    for proc in processes:
+        if proc.poll() is None:
+            _signal_tree(proc, signal.SIGKILL)
+
+
+def _await_processes(processes, timeout=_PROC_EXIT_TIMEOUT):
+    """Wait for all processes to exit within `timeout`; diagnose + fail on hang.
+
+    On timeout we dump every process's thread stacks (via SIGABRT/faulthandler),
+    tear the tree down, and fail with a clear message -- instead of blocking
+    forever in communicate() as the previous loop did.
+    """
+    deadline = time.time() + timeout
+    for process in processes:
+        remaining = max(1.0, deadline - time.time())
+        try:
+            process.communicate(timeout=remaining)
+        except subprocess.TimeoutExpired:
+            _diagnose_and_kill(processes)
+            raise AssertionError(
+                f"Process pid={process.pid} did not exit within {timeout:.0f}s -- "
+                "likely a teardown/finalize hang. All-thread stack dumps were "
+                "emitted to stderr above (SIGABRT via faulthandler)."
+            )
+        assert process.returncode == 0, (
+            f"Process failed with code: {process.returncode}"
+        )
 
 
 class TestProcessFlow(unittest.TestCase):
@@ -58,6 +130,9 @@ class TestProcessFlow(unittest.TestCase):
             stdout=sys.stderr,
             stderr=sys.stderr,
             env=env_dict,
+            # Own session so a hang can be group-signaled (SIGABRT -> faulthandler
+            # all-thread dump) without touching the test runner's own group.
+            start_new_session=True,
         )
         os.environ["COSMOS_CONTROLLER_HOST"] = f"localhost:{port}"
         # Create the Python command for torchrun
@@ -99,6 +174,7 @@ class TestProcessFlow(unittest.TestCase):
             stdout=sys.stderr,
             stderr=sys.stderr,
             env=policy_env,
+            start_new_session=True,
         )
         rollout_env = dict(os.environ)
         rollout_env["CUDA_VISIBLE_DEVICES"] = "2,3"
@@ -107,17 +183,13 @@ class TestProcessFlow(unittest.TestCase):
             stdout=sys.stderr,
             stderr=sys.stderr,
             env=rollout_env,
+            start_new_session=True,
         )
 
         processes = [controller_process, policy_process, rollout_process]
 
-        # Wait for process to complete
-        for process in processes:
-            stdout, stderr = process.communicate()
-            # Check if process completed successfully
-            assert process.returncode == 0, (
-                f"Process failed with code: {process.returncode}"
-            )
+        # Wait for processes to complete (bounded; diagnoses hangs).
+        _await_processes(processes)
 
     def test_process_exit_sft(self):
         """Test sft all processes exit cleanly."""
@@ -150,6 +222,9 @@ class TestProcessFlow(unittest.TestCase):
             stdout=sys.stderr,
             stderr=sys.stderr,
             env=env_dict,
+            # Own session so a hang can be group-signaled (SIGABRT -> faulthandler
+            # all-thread dump) without touching the test runner's own group.
+            start_new_session=True,
         )
         os.environ["COSMOS_CONTROLLER_HOST"] = f"localhost:{port}"
         # Create the Python command for torchrun
@@ -176,16 +251,12 @@ class TestProcessFlow(unittest.TestCase):
             stdout=sys.stderr,
             stderr=sys.stderr,
             env=policy_env,
+            start_new_session=True,
         )
         processes = [controller_process, policy_process]
 
-        # Wait for process to complete
-        for process in processes:
-            stdout, stderr = process.communicate()
-            # Check if process completed successfully
-            assert process.returncode == 0, (
-                f"Process failed with code: {process.returncode}"
-            )
+        # Wait for processes to complete (bounded; diagnoses hangs).
+        _await_processes(processes)
 
 
 class TestValidationFlow(unittest.TestCase):
@@ -212,16 +283,12 @@ class TestValidationFlow(unittest.TestCase):
             stdout=sys.stderr,
             stderr=sys.stderr,
             env=env,
+            start_new_session=True,
         )
         processes = [process]
 
-        # Wait for process to complete
-        for process in processes:
-            stdout, stderr = process.communicate()
-            # Check if process completed successfully
-            assert process.returncode == 0, (
-                f"Process failed with code: {process.returncode}"
-            )
+        # Wait for processes to complete (bounded; diagnoses hangs).
+        _await_processes(processes)
 
 
 class TestRewardFlow(unittest.TestCase):
@@ -248,16 +315,12 @@ class TestRewardFlow(unittest.TestCase):
             stdout=sys.stderr,
             stderr=sys.stderr,
             env=env,
+            start_new_session=True,
         )
         processes = [process]
 
-        # Wait for process to complete
-        for process in processes:
-            stdout, stderr = process.communicate()
-            # Check if process completed successfully
-            assert process.returncode == 0, (
-                f"Process failed with code: {process.returncode}"
-            )
+        # Wait for processes to complete (bounded; diagnoses hangs).
+        _await_processes(processes)
 
 
 class TestSFTDDPLoadFlow(unittest.TestCase):
@@ -284,16 +347,12 @@ class TestSFTDDPLoadFlow(unittest.TestCase):
             stdout=sys.stderr,
             stderr=sys.stderr,
             env=env,
+            start_new_session=True,
         )
         processes = [process]
 
-        # Wait for process to complete
-        for process in processes:
-            stdout, stderr = process.communicate()
-            # Check if process completed successfully
-            assert process.returncode == 0, (
-                f"Process failed with code: {process.returncode}"
-            )
+        # Wait for processes to complete (bounded; diagnoses hangs).
+        _await_processes(processes)
 
 
 class TestMultiReplicaSFT(unittest.TestCase):
@@ -339,6 +398,9 @@ class TestMultiReplicaSFT(unittest.TestCase):
             stdout=sys.stderr,
             stderr=sys.stderr,
             env=env_dict,
+            # Own session so a hang can be group-signaled (SIGABRT -> faulthandler
+            # all-thread dump) without touching the test runner's own group.
+            start_new_session=True,
         )
         os.environ["COSMOS_CONTROLLER_HOST"] = f"localhost:{port}"
         # Create the Python command for torchrun
@@ -363,18 +425,14 @@ class TestMultiReplicaSFT(unittest.TestCase):
                     stdout=sys.stderr,
                     stderr=sys.stderr,
                     env=rollout_env,
+                    start_new_session=True,
                 )
             )
 
         processes = [controller_process] + rollout_processes
 
-        # Wait for process to complete
-        for process in processes:
-            stdout, stderr = process.communicate()
-            # Check if process completed successfully
-            assert process.returncode == 0, (
-                f"Process failed with code: {process.returncode}"
-            )
+        # Wait for processes to complete (bounded; diagnoses hangs).
+        _await_processes(processes)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Add tooling to run the GitHub Actions CI suite (tests/run_test.sh, incl. the multi-GPU torchrun tests) on a single exclusive 8-GPU Slurm node via pyxis/enroot:

- cosmos_rl_ci_job.sh: standalone, self-submitting launcher. Run it on a login node to sbatch itself; Slurm re-invokes it on the compute node to run `timeout bash tests/run_test.sh` in the container with GH-CI-matching env (PYTHONPYCACHEPREFIX, /root/.cache, NCCL_NVLS_ENABLE=0). --repo-root-path is an optional override of the baked-in tests.
- build_ci_image.sh: docker build + bake tests/+configs/ + enroot import to a .sqsh. Supports --no-build, --from-uri (reuse a registry image), and --max-jobs (auto-capped from RAM/cores) to avoid OOM during the from-source CUDA-extension builds.
- Dockerfile: add MAX_JOBS/NVCC_THREADS build-args (empty default = unchanged) to bound parallelism of the from-source builds.
- README: document the build -> upload -> submit flow and container reuse.

- harden replica teardown so test_process_flow no longer hangs for hours: fail-fast Redis stream polls during shutdown, controller finalize on heartbeat-death reap (with a startup guard so SFT controllers do not self-destruct before workers register), bounded HTTP timeouts, teardown progress logging, and a bounded test-side wait with faulthandler diagnostics.