### PR TITLE
nsys global-step profiling support

### DIFF
--- a/cosmos_rl/dispatcher/command.py
+++ b/cosmos_rl/dispatcher/command.py
@@ -33,6 +33,7 @@ class CommandType(StrEnum):
     ROLLOUT_TO_ROLLOUT_BROADCAST = "ROLLOUT_TO_ROLLOUT_BROADCAST"
     DATA_FETCH = "DATA_FETCH"
     TRAINING_COMPLETE = "TRAINING_COMPLETE"
+    PROFILE_CONTROL = "PROFILE_CONTROL"
     ALL_REDUCE = "ALL_REDUCE"
     STOP = "STOP"
     VALIDATE = "VALIDATE"
@@ -85,6 +86,8 @@ class Command(ABC):
             sub_cls = TrainingCompleteCommand
         elif dict_v["command_type"] == CommandType.STOP:
             sub_cls = StopCommand
+        elif dict_v["command_type"] == CommandType.PROFILE_CONTROL:
+            sub_cls = ProfileControlCommand
 
         if sub_cls is None:
             raise ValueError(f"Unknown command type: {dict_v['command_type']}")
@@ -613,6 +616,55 @@ class TrainingCompleteCommand(Command):
         if self.global_step is not None and self.total_steps is not None:
             return self.global_step >= self.total_steps
         return False
+
+    @classmethod
+    def from_dict(cls, dict_v: Dict):
+        return cls(**dict_v)
+
+
+class ProfileControlCommand(Command):
+    """
+    Start or stop an external profiler capture window on a replica.
+
+    This is intentionally separate from DataFetchCommand so the controller can
+    synchronize policy and rollout capture windows by global training step.
+    """
+
+    def __init__(
+        self,
+        action: str,
+        global_step: int,
+        total_steps: int,
+        label: str,
+        **kwargs,
+    ):
+        kwargs["scope"] = CommandScope.GLOBAL
+        kwargs["command_type"] = CommandType.PROFILE_CONTROL
+        super().__init__(**kwargs)
+        self.action = action
+        self.global_step = global_step
+        self.total_steps = total_steps
+        self.label = label
+
+    action: str
+    global_step: int
+    total_steps: int
+    label: str
+
+    @classmethod
+    def trigger(
+        cls,
+        replicas: List[Replica],
+        action: str,
+        global_step: int,
+        total_steps: int,
+        label: str,
+        redis_handler: RedisStreamHandler,
+    ):
+        cmd = cls(action, global_step, total_steps, label)
+        for replica in replicas:
+            if replica.in_mesh:
+                redis_handler.publish_command(cmd.pack(), replica.name)
 
     @classmethod
     def from_dict(cls, dict_v: Dict):

--- a/cosmos_rl/dispatcher/controller.py
+++ b/cosmos_rl/dispatcher/controller.py
@@ -203,6 +203,7 @@ maxmemory-policy allkeys-lfu
         self.rollout_status_manager.setup(
             config, self.redis_controller, self.policy_status_manager, self.data_fetcher
         )
+        self.policy_status_manager.rollout_status_manager = self.rollout_status_manager
 
         # Register the exit function to be called when the program exits
         def exit_server(redis_server_proc, redis_free_port):

--- a/cosmos_rl/dispatcher/status.py
+++ b/cosmos_rl/dispatcher/status.py
@@ -322,6 +322,9 @@ class PolicyStatusManager:
 
         # For rank specific data dispatch
         self.rollout_buffer_per_rank: List[Queue] = []
+        self.rollout_status_manager = None
+        self._nsys_global_started = False
+        self._nsys_global_stopped = False
 
         # --- Weight-sync coalescing (depth-1 drop-to-latest) state ---
         # ``_weight_last_staged_step``: weight_step of the most recent issued
@@ -1693,6 +1696,16 @@ class PolicyStatusManager:
                         f"[Controller] Warning reporting training results: {e}\n{traceback.format_exc()}"
                     )
 
+            _, stop_step = self._nsys_global_window_steps()
+            if (
+                self.config.profiler.enable_nsys
+                and self.config.profiler.nsys_capture_scope == "global_step"
+                and step == stop_step
+                and not self._nsys_global_stopped
+            ):
+                self._trigger_rollout_profile_control("stop", step)
+                self._nsys_global_stopped = True
+
             # All replicas have been reduced, trigger weight sync
             any_loaded_replica = None
             sorted_replicas = sorted(
@@ -1858,6 +1871,45 @@ class PolicyStatusManager:
         # Only `do_save` when checkpointing is enabled
         return do_save and self.config.train.ckpt.enable_checkpoint
 
+    def _nsys_global_window_steps(self) -> tuple[int, int]:
+        sub_config = self.config.profiler.sub_profiler_config
+        start_step = sub_config.wait_steps + sub_config.warmup_steps + 1
+        stop_step = sub_config.wait_steps + sub_config.warmup_steps + sub_config.active_steps
+        return start_step, stop_step
+
+    def _trigger_rollout_profile_control(self, action: str, global_step: int):
+        if (
+            not self.config.profiler.enable_nsys
+            or self.config.profiler.nsys_capture_scope != "global_step"
+            or self.rollout_status_manager is None
+        ):
+            return
+
+        rollout_replicas = self.rollout_status_manager.get_all_atoms_arrived_replicas()
+        if not rollout_replicas:
+            return
+
+        start_step, stop_step = self._nsys_global_window_steps()
+        label = (
+            "cosmos.nsys.global_step_window "
+            f"start_step={start_step} stop_step={stop_step}"
+        )
+        command.ProfileControlCommand.trigger(
+            replicas=rollout_replicas,
+            action=action,
+            global_step=global_step,
+            total_steps=self.total_steps,
+            label=label,
+            redis_handler=self.redis_handler,
+        )
+        logger.info(
+            "[Controller][Nsight] sent rollout profile %s at global step %s for window [%s, %s]",
+            action,
+            global_step,
+            start_step,
+            stop_step,
+        )
+
     def try_trigger_data_fetch_and_training(self):
         # If the validation dataloader is activated, do not trigger data fetch and training
         if self.data_fetcher.activated_val_iter is not None:
@@ -1884,6 +1936,15 @@ class PolicyStatusManager:
 
             # From controller's perspective, the training step is already increased
             self.current_step += 1
+            start_step, _ = self._nsys_global_window_steps()
+            if (
+                self.config.profiler.enable_nsys
+                and self.config.profiler.nsys_capture_scope == "global_step"
+                and self.current_step == start_step
+                and not self._nsys_global_started
+            ):
+                self._trigger_rollout_profile_control("start", self.current_step)
+                self._nsys_global_started = True
 
             # Record the actual rollout count dispatched for this step so
             # ``train_ack`` can later decrement ``samples_on_the_fly`` by the

--- a/cosmos_rl/dispatcher/status.py
+++ b/cosmos_rl/dispatcher/status.py
@@ -1874,7 +1874,9 @@ class PolicyStatusManager:
     def _nsys_global_window_steps(self) -> tuple[int, int]:
         sub_config = self.config.profiler.sub_profiler_config
         start_step = sub_config.wait_steps + sub_config.warmup_steps + 1
-        stop_step = sub_config.wait_steps + sub_config.warmup_steps + sub_config.active_steps
+        stop_step = (
+            sub_config.wait_steps + sub_config.warmup_steps + sub_config.active_steps
+        )
         return start_step, stop_step
 
     def _trigger_rollout_profile_control(self, action: str, global_step: int):

--- a/cosmos_rl/launcher/launch_replica.sh
+++ b/cosmos_rl/launcher/launch_replica.sh
@@ -11,6 +11,14 @@ SCRIPT_ARGS=()
 CONFIG=""
 BACKEND="vllm"
 WFM_MODE="False"
+NSYS="0"
+NSYS_EXPLICIT="0"
+NSYS_OUTPUT_DIR=""
+NSYS_OUTPUT_PREFIX="nsys"
+NSYS_TRACE="cuda,nvtx,osrt,cudnn,cublas"
+NSYS_CAPTURE_RANGE="cudaProfilerApi"
+NSYS_CAPTURE_RANGE_END="stop"
+NSYS_EXTRA_ARGS=()
 
 print_help() {
   echo ""
@@ -26,6 +34,11 @@ print_help() {
   echo "  --config <path>                       The path to the config file."
   echo "  --backend <vllm|vllm_async|trtllm>    The backend to use for the job. Default: vllm"
   echo "  --wfm-mode <True|False>               Whether to launch in wfm mode. Default: False"
+  echo "  --nsys                                Wrap this replica with Nsight Systems regardless of TOML role filters."
+  echo "  --nsys-output-dir <path>              Directory to save Nsight Systems reports."
+  echo "  --nsys-output-prefix <prefix>         Report file prefix. Default: nsys"
+  echo "  --nsys-trace <domains>                Domains for nsys --trace. Default: cuda,nvtx,osrt,cudnn,cublas"
+  echo "  --nsys-extra-arg <arg>                Additional argument appended to nsys profile. Can be repeated."
   echo "  --help                                Show this help message"
   echo "Examples:"
   echo "  ./launch_replica.sh --type rollout --ngpus 4 --log-rank 0,1"
@@ -39,6 +52,113 @@ set_env() {
   local upper_type="${TYPE^^}"
   echo "[Cosmos-RL] $upper_type Pre-setting environment variable $env_name=$env_value"
   export "$env_name=$env_value"
+}
+
+load_nsys_config() {
+  if [ -z "$CONFIG" ]; then
+    return
+  fi
+
+  while IFS= read -r line; do
+    eval "$line"
+  done < <(python - "$CONFIG" "$TYPE" <<'PY'
+import os
+import shlex
+import sys
+
+import toml
+
+config_path = sys.argv[1]
+role = sys.argv[2]
+
+try:
+    config = toml.load(config_path)
+except Exception:
+    sys.exit(0)
+
+profiler = config.get("profiler", {})
+train = config.get("train", {})
+
+target_roles = profiler.get("nsys_target_roles", ["policy"])
+if isinstance(target_roles, str):
+    target_roles = [target_roles]
+
+enable = bool(profiler.get("enable_nsys", False)) and role in target_roles
+
+train_output_dir = train.get("output_dir", "./outputs")
+default_output_dir = os.path.join(os.path.dirname(train_output_dir), "nsys_profile")
+output_dir = profiler.get("nsys_output_dir") or default_output_dir
+
+extra_args = profiler.get("nsys_extra_args", [])
+if isinstance(extra_args, str):
+    extra_args = [extra_args]
+
+values = {
+    "NSYS_CONFIG_ENABLE": "1" if enable else "0",
+    "NSYS_CONFIG_OUTPUT_DIR": output_dir,
+    "NSYS_CONFIG_OUTPUT_PREFIX": profiler.get("nsys_output_prefix", "nsys"),
+    "NSYS_CONFIG_TRACE": profiler.get("nsys_trace", "cuda,nvtx,osrt,cudnn,cublas"),
+    "NSYS_CONFIG_CAPTURE_RANGE": profiler.get("nsys_capture_range", "cudaProfilerApi"),
+    "NSYS_CONFIG_CAPTURE_RANGE_END": profiler.get("nsys_capture_range_end", "stop"),
+    "NSYS_CONFIG_EXTRA_ARGS": shlex.join([str(arg) for arg in extra_args]),
+}
+
+for key, value in values.items():
+    print(f"{key}={shlex.quote(str(value))}")
+PY
+  )
+
+  if [ "$NSYS_EXPLICIT" != "1" ]; then
+    NSYS="${NSYS_CONFIG_ENABLE:-0}"
+  fi
+  if [ -z "$NSYS_OUTPUT_DIR" ]; then
+    NSYS_OUTPUT_DIR="${NSYS_CONFIG_OUTPUT_DIR:-}"
+  fi
+  if [ "$NSYS_OUTPUT_PREFIX" == "nsys" ]; then
+    NSYS_OUTPUT_PREFIX="${NSYS_CONFIG_OUTPUT_PREFIX:-$NSYS_OUTPUT_PREFIX}"
+  fi
+  if [ "$NSYS_TRACE" == "cuda,nvtx,osrt,cudnn,cublas" ]; then
+    NSYS_TRACE="${NSYS_CONFIG_TRACE:-$NSYS_TRACE}"
+  fi
+  if [ "$NSYS_CAPTURE_RANGE" == "cudaProfilerApi" ]; then
+    NSYS_CAPTURE_RANGE="${NSYS_CONFIG_CAPTURE_RANGE:-$NSYS_CAPTURE_RANGE}"
+  fi
+  if [ "$NSYS_CAPTURE_RANGE_END" == "stop" ]; then
+    NSYS_CAPTURE_RANGE_END="${NSYS_CONFIG_CAPTURE_RANGE_END:-$NSYS_CAPTURE_RANGE_END}"
+  fi
+  if [ -n "${NSYS_CONFIG_EXTRA_ARGS:-}" ]; then
+    eval "NSYS_EXTRA_ARGS+=( ${NSYS_CONFIG_EXTRA_ARGS} )"
+  fi
+}
+
+apply_nsys_wrapper() {
+  if [ "$NSYS" != "1" ]; then
+    return
+  fi
+  if ! command -v nsys >/dev/null 2>&1; then
+    echo "Error: [profiler].enable_nsys is true or --nsys was passed, but 'nsys' is not available in PATH."
+    exit 1
+  fi
+
+  if [ -z "$NSYS_OUTPUT_DIR" ]; then
+    NSYS_OUTPUT_DIR="./outputs/nsys_profile"
+  fi
+  mkdir -p "$NSYS_OUTPUT_DIR"
+
+  local output_pattern="${NSYS_OUTPUT_DIR}/${NSYS_OUTPUT_PREFIX}_${TYPE}_%h_%p"
+  local nsys_cmd=(
+    nsys profile
+    --force-overwrite=true
+    --capture-range="$NSYS_CAPTURE_RANGE"
+    --trace="$NSYS_TRACE"
+    --output="$output_pattern"
+  )
+  if [ "$NSYS_CAPTURE_RANGE" != "none" ]; then
+    nsys_cmd+=(--capture-range-end="$NSYS_CAPTURE_RANGE_END")
+  fi
+
+  echo "[Cosmos-RL] ${TYPE^^} Nsight Systems profiling enabled. Reports: ${output_pattern}.nsys-rep"
+  LAUNCH_CMD=("${nsys_cmd[@]}" "${NSYS_EXTRA_ARGS[@]}" "${LAUNCH_CMD[@]}")
 }
 
 while [[ $# -gt 0 ]]; do
@@ -77,6 +197,35 @@ while [[ $# -gt 0 ]]; do
     ;;
   --wfm-mode)
     WFM_MODE="$2"
+    shift 2
+    ;;
+  --nsys)
+    NSYS="1"
+    NSYS_EXPLICIT="1"
+    shift
+    ;;
+  --nsys-output-dir)
+    NSYS_OUTPUT_DIR="$2"
+    shift 2
+    ;;
+  --nsys-output-prefix)
+    NSYS_OUTPUT_PREFIX="$2"
+    shift 2
+    ;;
+  --nsys-trace)
+    NSYS_TRACE="$2"
+    shift 2
+    ;;
+  --nsys-capture-range)
+    NSYS_CAPTURE_RANGE="$2"
+    shift 2
+    ;;
+  --nsys-capture-range-end)
+    NSYS_CAPTURE_RANGE_END="$2"
+    shift 2
+    ;;
+  --nsys-extra-arg)
+    NSYS_EXTRA_ARGS+=("$2")
     shift 2
     ;;
   --help)
@@ -237,6 +386,9 @@ if [ -n "$CONFIG" ]; then
     --config "$CONFIG"
   )
 fi
+
+load_nsys_config
+apply_nsys_wrapper
 
 echo "Launching command: ${LAUNCH_CMD[@]}"
 

--- a/cosmos_rl/policy/config/__init__.py
+++ b/cosmos_rl/policy/config/__init__.py
@@ -735,11 +735,77 @@ class ProfilerConfig(BaseModel):
     )
     enable_nsys: bool = Field(
         default=False,
-        description="Enable nsys for training",
+        description=(
+            "Enable Nsight Systems profiling. The replica launcher wraps target "
+            "roles with `nsys profile`, and workers use cudaProfilerStart/Stop "
+            "to capture the configured profiler step window."
+        ),
+    )
+    nsys_target_roles: List[str] = Field(
+        default_factory=lambda: ["policy"],
+        description=(
+            "Replica roles to wrap with Nsight Systems when enable_nsys is true. "
+            "Valid values are policy, rollout, and reference."
+        ),
+    )
+    nsys_output_dir: str = Field(
+        default="",
+        description=(
+            "Directory for Nsight Systems reports. If empty, the launcher uses "
+            "<train.output_dir>/nsys_profile."
+        ),
+    )
+    nsys_output_prefix: str = Field(
+        default="nsys",
+        description="Prefix for Nsight Systems report names.",
+    )
+    nsys_trace: str = Field(
+        default="cuda,nvtx,osrt,cudnn,cublas",
+        description="Comma-separated domains passed to `nsys profile --trace`.",
+    )
+    nsys_capture_range: str = Field(
+        default="cudaProfilerApi",
+        description=(
+            "Nsight Systems capture range. The default pairs with "
+            "cudaProfilerStart/Stop so only the selected training steps are captured."
+        ),
+    )
+    nsys_capture_range_end: str = Field(
+        default="stop",
+        description="Value passed to `nsys profile --capture-range-end`.",
+    )
+    nsys_capture_scope: str = Field(
+        default="local_step",
+        description=(
+            "Semantic scope for cudaProfilerApi start/stop. `local_step` uses each "
+            "worker's local profiler step counter. `global_step` lets the controller "
+            "open/close a shared wall-clock window for policy and rollout replicas."
+        ),
+    )
+    nsys_extra_args: List[str] = Field(
+        default_factory=list,
+        description="Additional raw arguments appended to `nsys profile`.",
     )
     sub_profiler_config: SubProfilerConfig = Field(
         default_factory=SubProfilerConfig, description="Sub profiler config"
     )
+
+    @model_validator(mode="after")
+    def check_nsys_roles(self):
+        valid_roles = {"policy", "rollout", "reference"}
+        invalid_roles = sorted(set(self.nsys_target_roles) - valid_roles)
+        if invalid_roles:
+            raise ValueError(
+                f"nsys_target_roles contains invalid roles {invalid_roles}; "
+                f"valid roles are {sorted(valid_roles)}"
+            )
+        valid_scopes = {"local_step", "global_step"}
+        if self.nsys_capture_scope not in valid_scopes:
+            raise ValueError(
+                f"nsys_capture_scope must be one of {sorted(valid_scopes)}, "
+                f"got {self.nsys_capture_scope}"
+            )
+        return self
 
 
 class FP8Config(BaseModel):

--- a/cosmos_rl/policy/worker/multi_replica_sft_worker.py
+++ b/cosmos_rl/policy/worker/multi_replica_sft_worker.py
@@ -33,6 +33,7 @@ from cosmos_rl.utils.parallelism import ParallelDims
 from cosmos_rl.policy.config import Config as CosmosConfig
 from cosmos_rl.utils import util
 from cosmos_rl.utils.distributed import destroy_distributed
+from cosmos_rl.utils.nvtx import nvtx_range
 
 from cosmos_rl.policy.trainer.llm_trainer.sft_trainer import SFTTrainer
 from cosmos_rl.policy.worker import RLPolicyWorker, SFTPolicyWorker
@@ -460,31 +461,19 @@ class MultiReplicaSFTPolicyWorker(RLPolicyWorker):
                         self.config.train.train_batch_per_replica // self.dp_world_size
                     )
                 ]
-                if (
-                    self.config.profiler.enable_nsys
-                    and self.profiler.global_rank in self.profiler.rank_filter
-                ):
-                    if (
-                        self.train_step
-                        == self.profiler.wait_steps + self.profiler.warmup_steps
-                    ):
-                        torch.cuda.cudart().cudaProfilerStart()
-                    elif (
-                        self.train_step
-                        == self.profiler.wait_steps
-                        + self.profiler.warmup_steps
-                        + self.profiler.active_steps
-                    ):
-                        torch.cuda.cudart().cudaProfilerStop()
+                self.profiler.maybe_start_nsys()
 
-                report_data = self.trainer.step_training(
-                    global_batch=global_batch,
-                    total_steps=self.total_steps,
-                    train_step=self.train_step,
-                    save_freq=self._save_freq,
-                    inter_policy_nccl=self.inter_policy_nccl,
-                    data_arrival_event=data_arrival_event,
-                )
+                with nvtx_range(
+                    f"cosmos.policy.multi_sft_step replica={self.replica_name} step={self.train_step}"
+                ):
+                    report_data = self.trainer.step_training(
+                        global_batch=global_batch,
+                        total_steps=self.total_steps,
+                        train_step=self.train_step,
+                        save_freq=self._save_freq,
+                        inter_policy_nccl=self.inter_policy_nccl,
+                        data_arrival_event=data_arrival_event,
+                    )
 
                 self.train_step += 1
 

--- a/cosmos_rl/policy/worker/rl_worker.py
+++ b/cosmos_rl/policy/worker/rl_worker.py
@@ -41,6 +41,7 @@ from cosmos_rl.utils.distributed import HighAvailabilitylNccl, destroy_distribut
 from cosmos_rl.utils.parallelism_map import (
     ParallelTopoMapperGroup,
 )
+from cosmos_rl.utils.nvtx import nvtx_range
 from cosmos_rl.utils.pynccl import (
     bounded_drain_or_abort,
     nccl_group_start,
@@ -530,6 +531,20 @@ class RLPolicyWorker(PolicyWorkerBase):
 
     @CommMixin.register_policy_command_handler(DataFetchCommand)
     def execute_data_fetch(self, command: DataFetchCommand):
+        use_global_nsys = (
+            self.config.profiler.enable_nsys
+            and self.config.profiler.nsys_capture_scope == "global_step"
+        )
+        nsys_start_step = (
+            self.config.profiler.sub_profiler_config.wait_steps
+            + self.config.profiler.sub_profiler_config.warmup_steps
+            + 1
+        )
+        nsys_stop_step = (
+            self.config.profiler.sub_profiler_config.wait_steps
+            + self.config.profiler.sub_profiler_config.warmup_steps
+            + self.config.profiler.sub_profiler_config.active_steps
+        )
         if command.do_profile:
             self.profiler.start_dynamic(
                 active_steps=command.active_steps,
@@ -539,10 +554,18 @@ class RLPolicyWorker(PolicyWorkerBase):
                 with_stack=command.with_stack,
                 with_modules=command.with_modules,
             )
+        elif self.config.profiler.enable_nsys and not use_global_nsys:
+            self.profiler.start_nsys()
 
         assert self.replica_name == command.replica_name
         self.replica_batch_for_this_step = command.items_count
 
+        if use_global_nsys and command.global_step == nsys_start_step:
+            self.profiler.start_nsys_capture(
+                f"cosmos.nsys.global_step_window role=policy start_step={nsys_start_step} stop_step={nsys_stop_step}"
+            )
+        elif not use_global_nsys:
+            self.profiler.maybe_start_nsys()
         do_save_checkpoint = command.do_save
         if (
             self.signal_handler is not None
@@ -555,18 +578,23 @@ class RLPolicyWorker(PolicyWorkerBase):
             self.signal_handled = True
 
         self.trainer.update_lr_schedulers(command.total_steps)
-        report_data = self.trainer.step_training(
-            rollouts=self.dispatch_rollouts(),
-            current_step=command.global_step,
-            total_steps=command.total_steps,
-            remain_samples_num=command.remain_samples_num,
-            do_save_checkpoint=do_save_checkpoint,
-            inter_policy_nccl=self.inter_policy_nccl,
-            is_master_replica=self.is_master_replica,
-        )
+        with nvtx_range(
+            f"cosmos.policy.step_training replica={self.replica_name} step={command.global_step}"
+        ):
+            report_data = self.trainer.step_training(
+                rollouts=self.dispatch_rollouts(),
+                current_step=command.global_step,
+                total_steps=command.total_steps,
+                remain_samples_num=command.remain_samples_num,
+                do_save_checkpoint=do_save_checkpoint,
+                inter_policy_nccl=self.inter_policy_nccl,
+                is_master_replica=self.is_master_replica,
+            )
 
         # For profiling
         self.profiler.step()
+        if use_global_nsys and command.global_step == nsys_stop_step:
+            self.profiler.stop_nsys(mark_finished=True)
 
         # Train ACK
         if is_master_rank(self.parallel_dims, self.global_rank):

--- a/cosmos_rl/policy/worker/sft_worker.py
+++ b/cosmos_rl/policy/worker/sft_worker.py
@@ -34,6 +34,7 @@ from cosmos_rl.policy.config import Config as CosmosConfig
 from cosmos_rl.policy.trainer.base import TrainerRegistry
 from cosmos_rl.utils import util
 from cosmos_rl.utils.distributed import destroy_distributed
+from cosmos_rl.utils.nvtx import nvtx_range
 import cosmos_rl.utils.distributed as dist_utils
 import torch.distributed as dist
 from cosmos_rl.utils.report.wandb_logger import (
@@ -979,32 +980,18 @@ class SFTPolicyWorker(PolicyWorkerBase):
             data_arrival_event.record()
             # global_batch is a list of items from `datapacker.sft_process_sample()`
             for global_batch in self.get_batch_from_dataloader(self.train_data_loader):
-                # if [profiler.enable_nsys] is true, cudaProfilerStart() / cudaProfilerStop() are used to trigger nsys capture
-                # settings from [profiler.sub_profiler_config] are reused
-                if (
-                    self.config.profiler.enable_nsys
-                    and self.profiler.global_rank in self.profiler.rank_filter
-                ):
-                    if (
-                        self.train_step
-                        == self.profiler.wait_steps + self.profiler.warmup_steps
-                    ):
-                        torch.cuda.cudart().cudaProfilerStart()
-                    elif (
-                        self.train_step
-                        == self.profiler.wait_steps
-                        + self.profiler.warmup_steps
-                        + self.profiler.active_steps
-                    ):
-                        torch.cuda.cudart().cudaProfilerStop()
+                self.profiler.maybe_start_nsys()
 
-                report_data = self.trainer.step_training(
-                    global_batch=global_batch,
-                    total_steps=self.total_steps,
-                    train_step=self.train_step,
-                    save_freq=self._save_freq,
-                    data_arrival_event=data_arrival_event,
-                )
+                with nvtx_range(
+                    f"cosmos.policy.sft_step replica={self.replica_name} step={self.train_step}"
+                ):
+                    report_data = self.trainer.step_training(
+                        global_batch=global_batch,
+                        total_steps=self.total_steps,
+                        train_step=self.train_step,
+                        save_freq=self._save_freq,
+                        data_arrival_event=data_arrival_event,
+                    )
                 report_data["train/epoch"] = cur_epoch
 
                 self.train_step += 1

--- a/cosmos_rl/rollout/worker/rollout_control.py
+++ b/cosmos_rl/rollout/worker/rollout_control.py
@@ -33,16 +33,19 @@ from cosmos_rl.utils.model_config import load_model_config
 from cosmos_rl.utils.parallelism import ParallelDims
 from cosmos_rl.policy.config import Config as CosmosConfig
 from cosmos_rl.utils.logging import logger
+from cosmos_rl.utils.profiler import CosmosProfiler
 from cosmos_rl.utils.constant import (
     COSMOS_REWARD_DISPATCHER_PAYLOAD_PER_TASK,
     COSMOS_REWARD_DISPATCHER_CONCURRENCY,
 )
+from cosmos_rl.utils.nvtx import nvtx_range
 import cosmos_rl.utils.distributed as dist_utils
 from cosmos_rl.rollout.rollout_base import RolloutRegistry, RolloutBase
 from cosmos_rl.dispatcher.protocol import RolloutRequest, ValidationReportRequest
 from cosmos_rl.dispatcher.command import (
     BuildMeshCommand,
     PolicyToRolloutUnicastCommand,
+    ProfileControlCommand,
     RolloutToRolloutBroadcastCommand,
     StopCommand,
     Command,
@@ -141,6 +144,12 @@ class DisaggregatedRolloutControlWorker(RolloutWorkerBase):
 
         self.state = State()
         self.is_diffusers = self.config.policy.is_diffusers
+        self.profiler = CosmosProfiler(
+            self.config,
+            parallel_dims,
+            replica_name=self.replica_name,
+            api_client=self.api_client,
+        )
 
         if self.config.rollout.parallelism.dp_shard_size == -1:
             self.config.rollout.parallelism.dp_shard_size = parallel_dims.dp_shard
@@ -532,6 +541,19 @@ class DisaggregatedRolloutControlWorker(RolloutWorkerBase):
         )
         self.shutdown_signal.set()
         self.shutdown_mp_signal.set()
+
+    @RolloutWorkerBase.register_rollout_command_handler(ProfileControlCommand)
+    def execute_profile_control(self, command: ProfileControlCommand):
+        label = (
+            f"{command.label} role=rollout action={command.action} "
+            f"global_step={command.global_step} total_steps={command.total_steps}"
+        )
+        if command.action == "start":
+            self.profiler.start_nsys_capture(label)
+        elif command.action == "stop":
+            self.profiler.stop_nsys(mark_finished=True)
+        else:
+            raise ValueError(f"Unsupported profile control action: {command.action}")
 
     @RolloutWorkerBase.register_rollout_command_handler(BuildMeshCommand)
     def build_global_mesh(self, build_mesh_command: BuildMeshCommand):
@@ -1605,6 +1627,10 @@ class DisaggregatedRolloutControlWorker(RolloutWorkerBase):
                 command = Command.depack(instruction)
                 logger.debug(f"[Rollout] Received command: {command.command_type}")
 
+                if isinstance(command, ProfileControlCommand):
+                    self.execute_profile_control(command)
+                    continue
+
                 wst = getattr(self, "_weight_sync_thread", None)
                 if wst is not None and isinstance(
                     command, PolicyToRolloutUnicastCommand
@@ -1927,12 +1953,28 @@ class DisaggregatedRolloutControlWorker(RolloutWorkerBase):
             sync_buffer_to_live(self)
 
         kwargs["current_weight_version"] = self.current_weight_version
-        return self.rollout.rollout_generation(**kwargs)
+        payloads = kwargs.get("payloads") or []
+        is_validation = kwargs.get("is_validation", False)
+        use_global_nsys = (
+            self.config.profiler.enable_nsys
+            and self.config.profiler.nsys_capture_scope == "global_step"
+        )
+        if not is_validation and not use_global_nsys:
+            self.profiler.maybe_start_nsys()
+        with nvtx_range(
+            f"cosmos.rollout.rollout_generation replica={self.replica_name} weight_version={self.current_weight_version} batch={len(payloads)}"
+        ):
+            rollout_results = self.rollout.rollout_generation(**kwargs)
+        if not is_validation and not use_global_nsys:
+            self.profiler.step()
+        return rollout_results
 
     @torch.no_grad()
     def main_loop(self):
         async_mode = get_async_r2r_sync_mode(self)
         logger.info("[Rollout] main_loop async_r2r_sync mode: %s", async_mode.value)
+        if self.config.profiler.nsys_capture_scope != "global_step":
+            self.profiler.start()
 
         assert not (
             self._is_async_rollout and async_mode != AsyncR2RSyncMode.DISABLED

--- a/cosmos_rl/utils/nvtx.py
+++ b/cosmos_rl/utils/nvtx.py
@@ -1,0 +1,30 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from contextlib import contextmanager
+
+import torch
+
+
+@contextmanager
+def nvtx_range(message: str):
+    """Best-effort NVTX range that is a no-op when CUDA/NVTX is unavailable."""
+    if not torch.cuda.is_available():
+        yield
+        return
+
+    pushed = False
+    try:
+        torch.cuda.nvtx.range_push(message)
+        pushed = True
+    except Exception:
+        pushed = False
+
+    try:
+        yield
+    finally:
+        if pushed:
+            try:
+                torch.cuda.nvtx.range_pop()
+            except Exception:
+                pass

--- a/cosmos_rl/utils/profiler.py
+++ b/cosmos_rl/utils/profiler.py
@@ -47,6 +47,11 @@ class CosmosProfiler:
         self.profiler = None
         self.thread_pool = None
         self.api_client = api_client
+        self.enable_nsys = config.profiler.enable_nsys
+        self.nsys_armed = False
+        self.nsys_started = False
+        self.nsys_nvtx_range_pushed = False
+        self.nsys_step_num = 0
         # We do not want the timestamp part of output dir for profiling data.
         output_dir = os.path.dirname(config.train.output_dir)
         self.output_dir = os.path.join(
@@ -86,8 +91,88 @@ class CosmosProfiler:
             self.is_finished = False
         return finished
 
+    def _nsys_rank_enabled(self):
+        return (
+            self.enable_nsys
+            and self.global_rank in self.rank_filter
+            and torch.cuda.is_available()
+        )
+
+    def start_nsys(self):
+        if not self._nsys_rank_enabled():
+            return
+        self._validate_config()
+        if not self.nsys_armed:
+            logger.info(
+                f"[Profiler][Nsight] arm cudaProfilerApi capture for rank: {self.global_rank}"
+            )
+            self.nsys_armed = True
+            self.nsys_started = False
+            self.nsys_nvtx_range_pushed = False
+            self.nsys_step_num = 0
+            self.is_finished = False
+
+    def maybe_start_nsys(self):
+        if not self.nsys_armed or self.nsys_started:
+            return
+        if self.nsys_step_num == self.wait_steps + self.warmup_steps:
+            self.start_nsys_capture()
+
+    def start_nsys_capture(self, label: str | None = None):
+        if not self._nsys_rank_enabled():
+            return
+        self._validate_config()
+        if self.nsys_started:
+            return
+        if not self.nsys_armed:
+            self.nsys_armed = True
+        capture_label = label or "cosmos.nsys.capture"
+        logger.info(
+            f"[Profiler][Nsight] start cudaProfilerApi capture for rank: {self.global_rank}, label: {capture_label}"
+        )
+        torch.cuda.cudart().cudaProfilerStart()
+        try:
+            torch.cuda.nvtx.range_push(
+                f"{capture_label} rank={self.global_rank} replica={self.replica_name}"
+            )
+            self.nsys_nvtx_range_pushed = True
+        except Exception:
+            self.nsys_nvtx_range_pushed = False
+        self.nsys_started = True
+
+    def _step_nsys(self):
+        if not self.nsys_armed:
+            return
+        self.nsys_step_num += 1
+        if (
+            self.nsys_started
+            and self.nsys_step_num
+            >= self.wait_steps + self.warmup_steps + self.active_steps
+        ):
+            self.stop_nsys(mark_finished=True)
+
+    def stop_nsys(self, mark_finished: bool = False):
+        if not self.nsys_armed:
+            return
+        if self.nsys_started:
+            logger.info(
+                f"[Profiler][Nsight] stop cudaProfilerApi capture for rank: {self.global_rank}"
+            )
+            if self.nsys_nvtx_range_pushed:
+                try:
+                    torch.cuda.nvtx.range_pop()
+                except Exception:
+                    pass
+                self.nsys_nvtx_range_pushed = False
+            torch.cuda.cudart().cudaProfilerStop()
+        self.nsys_armed = False
+        self.nsys_started = False
+        if mark_finished:
+            self.is_finished = True
+
     def start(self):
         # start the profiler with static config
+        self.start_nsys()
         if self.enable_profile:
             if self.global_rank not in self.rank_filter:
                 return
@@ -160,6 +245,11 @@ class CosmosProfiler:
                 )
                 self.thread_pool = futures.ThreadPoolExecutor(max_workers=4)
 
+        if self.enable_nsys:
+            self.active_steps = active_steps
+            self.rank_filter = rank_filter
+            self.start_nsys()
+
         if self.check():
             if not self.is_started:
                 logger.info(f"[Profiler] start to trace for rank: {self.global_rank}")
@@ -174,6 +264,7 @@ class CosmosProfiler:
             self.is_started = False
 
     def step(self):
+        self._step_nsys()
         if self.check() and self.is_started:
             logger.debug(
                 f"[Profiler] Step ahead for rank: {self.global_rank}, step_num: {self.profiler.step_num}"

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -101,6 +101,7 @@ Main Features
    :caption: Profiler
 
    profiler/overview
+   profiler/nsight_systems
 
 .. toctree::
    :caption: World Foundational Models

--- a/docs/profiler/nsight_systems.rst
+++ b/docs/profiler/nsight_systems.rst
@@ -1,0 +1,104 @@
+Nsight Systems
+==============
+
+Cosmos-RL can launch selected replicas under NVIDIA Nsight Systems and use
+``cudaProfilerStart`` / ``cudaProfilerStop`` to capture only a small training
+window. This is useful for the asynchronous, disaggregated RL flow because the
+target process must be wrapped by ``nsys profile`` at launch time, while the
+interesting policy step is usually selected later by the controller.
+
+Configuration
+-------------
+
+Enable Nsight Systems in the TOML config:
+
+.. code-block:: toml
+
+   [profiler]
+   enable_nsys = true
+   nsys_target_roles = ["policy"]
+   nsys_output_dir = "./outputs/nsys_profile"
+   nsys_output_prefix = "qwen_grpo"
+   nsys_trace = "cuda,nvtx,osrt,cudnn,cublas"
+   nsys_extra_args = ["--sample=none"]
+
+   [profiler.sub_profiler_config]
+   wait_steps = 1
+   warmup_steps = 1
+   active_steps = 2
+   rank_filter = [0]
+
+When ``enable_nsys`` is true, ``launch_replica.sh`` wraps matching roles with:
+
+.. code-block:: bash
+
+   nsys profile \
+     --capture-range=cudaProfilerApi \
+     --capture-range-end=stop \
+     --trace=cuda,nvtx,osrt,cudnn,cublas \
+     --output=<nsys_output_dir>/<prefix>_<role>_%h_%p \
+     torchrun ...
+
+Only ranks in ``rank_filter`` call ``cudaProfilerStart`` / ``cudaProfilerStop``.
+The capture window follows ``wait_steps + warmup_steps + active_steps`` and does
+not change the model forward, backward, optimizer, rollout, or reward logic.
+
+NVTX Markers
+------------
+
+Cosmos-RL emits lightweight NVTX ranges around the major policy and rollout
+phases. These annotations are best-effort and automatically become no-ops when
+CUDA/NVTX is unavailable.
+
+Common ranges include:
+
+- ``cosmos.nsys.capture ...`` for the active CUDA Profiler API capture window
+- ``cosmos.policy.step_training ...`` for RL policy optimization steps
+- ``cosmos.policy.sft_step ...`` for SFT policy optimization steps
+- ``cosmos.rollout.rollout_generation ...`` for rollout generation calls
+
+Keep ``nvtx`` in ``nsys_trace`` if you want these ranges to appear in the
+Nsight Systems timeline.
+
+Runtime Trigger
+---------------
+
+For RL policy replicas, you can still use the existing CLI command to choose a
+policy replica at runtime:
+
+.. code-block:: bash
+
+   python -m cosmos_rl.cli.cli profile set <replica-name> \
+     --active-steps 2 \
+     --rank-filter 0 \
+     -cp 8000 -ch localhost
+
+The process must already have been launched with ``enable_nsys = true`` or the
+``--nsys`` launcher flag. The CLI arms the runtime capture window; the launcher
+provides the required ``nsys profile`` parent process.
+
+Launcher Override
+-----------------
+
+For a quick smoke test without editing TOML, pass ``--nsys`` directly:
+
+.. code-block:: bash
+
+   COSMOS_CONTROLLER_HOST=localhost:8000 \
+   ./cosmos_rl/launcher/launch_replica.sh \
+     --type policy \
+     --ngpus 8 \
+     --config config.toml \
+     --nsys \
+     --nsys-output-dir ./outputs/nsys_smoke \
+     --nsys-extra-arg --sample=none
+
+Notes
+-----
+
+- Nsight Systems must be installed and ``nsys`` must be in ``PATH``.
+- Capturing all ranks and all roles can produce very large reports. Start with
+  one policy rank and a small ``active_steps`` value.
+- For rollout or reference profiling, add the role to ``nsys_target_roles``.
+  Additional runtime CUDA capture points may be needed if you want a narrower
+  rollout-only window than whole-process capture.

--- a/docs/profiler/overview.rst
+++ b/docs/profiler/overview.rst
@@ -97,6 +97,13 @@ You can open it with:
 
 Perfetto is recommended.
 
+Nsight Systems
+--------------
+
+Cosmos-RL also supports launch-time Nsight Systems wrapping plus runtime
+``cudaProfilerApi`` capture windows for asynchronous, disaggregated jobs. See
+:doc:`nsight_systems` for configuration and usage details.
+
 Quick Troubleshooting
 ---------------------
 

--- a/tests/launch_test_worker.py
+++ b/tests/launch_test_worker.py
@@ -55,6 +55,7 @@ from cosmos_rl.utils.distributed import (
     destroy_distributed,
     cosmos_device_type,
 )
+from cosmos_rl.utils.nvtx import nvtx_range
 from cosmos_rl.dispatcher.api.client import APIClient
 from cosmos_rl.dispatcher.protocol import Role
 from cosmos_rl.policy.model.gpt.weight_converter import convert_weight_from_hf
@@ -2616,7 +2617,7 @@ async def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("--shm_name", type=str)  # 1st arg
     parser.add_argument("--shm_size", type=int)  # 2nd arg
-    parser.add_argument("--mode", type=str, required=True)  # 3rd arg
+    parser.add_argument("--mode", type=str, default=None)  # 3rd arg
     parser.add_argument(
         "--parallel_config",
         type=str,
@@ -2631,8 +2632,19 @@ async def main():
         default=False,
         help="If only trainable params are synced. If set, part of the params will be frozen.",
     )  # 4th arg
+    parser.add_argument("--config", type=str, default=None)
+    parser.add_argument("--port", type=int, default=None)
+    parser.add_argument("--redis-logfile-path", type=str, default=None)
     args = parser.parse_args()
     mode = args.mode
+    if mode is None:
+        role = os.environ.get("COSMOS_ROLE")
+        if role == "Policy":
+            mode = "dummy_policy"
+            args.mode = mode
+        elif role == "Rollout":
+            mode = "dummy_rollout"
+            args.mode = mode
     shm_name = args.shm_name
     shm_size = args.shm_size
     mode = args.mode
@@ -2640,15 +2652,23 @@ async def main():
         args.trainable_param_sync
     )  # If only trainable params are synced
 
+    if mode is None and os.environ.get("COSMOS_ROLE") == "Controller":
+        from cosmos_rl.dispatcher.run_web_panel import main as controller_main
+
+        controller_main(args=args)
+        exit(0)
+
     if mode == "dummy_policy":
         os.environ["COSMOS_ROLE"] = "Policy"
         # Dummy policy process for testing
-        run_dummy_policy(args=args)
+        with nvtx_range("cosmos.test.dummy_policy"):
+            run_dummy_policy(args=args)
         exit(0)
     elif mode == "dummy_rollout":
         os.environ["COSMOS_ROLE"] = "Rollout"
         # Dummy rollout process for testing
-        run_dummy_rollout(args=args)
+        with nvtx_range("cosmos.test.dummy_rollout"):
+            run_dummy_rollout(args=args)
         exit(0)
     elif mode == "test_overfit":
         run_overfitting_policy(args=args)
@@ -2741,5 +2761,20 @@ async def main():
     destroy_distributed()
 
 
+def _run_controller_entry():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--config", type=str, required=True)
+    parser.add_argument("--port", type=int, default=None)
+    parser.add_argument("--redis-logfile-path", type=str, default=None)
+    args = parser.parse_args()
+
+    from cosmos_rl.dispatcher.run_web_panel import main as controller_main
+
+    controller_main(args=args)
+
+
 if __name__ == "__main__":
-    asyncio.run(main())
+    if os.environ.get("COSMOS_ROLE") == "Controller":
+        _run_controller_entry()
+    else:
+        asyncio.run(main())

--- a/tests/test_nsys_profiler.py
+++ b/tests/test_nsys_profiler.py
@@ -1,0 +1,226 @@
+import importlib.util
+import os
+import sys
+import tempfile
+import types
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from unittest import mock
+
+import toml
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _load_profiler_config_class():
+    spec = importlib.util.spec_from_file_location(
+        "cosmos_config_under_test",
+        REPO_ROOT / "cosmos_rl" / "policy" / "config" / "__init__.py",
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module.ProfilerConfig
+
+
+def _install_profiler_import_stubs():
+    logger = mock.Mock()
+    logging_mod = types.ModuleType("cosmos_rl.utils.logging")
+    logging_mod.logger = logger
+
+    policy_config_mod = types.ModuleType("cosmos_rl.policy.config")
+    policy_config_mod.Config = object
+
+    parallelism_mod = types.ModuleType("cosmos_rl.utils.parallelism")
+    parallelism_mod.ParallelDims = object
+
+    s3_utils_mod = types.ModuleType("cosmos_rl.utils.s3_utils")
+    s3_utils_mod.upload_folder_to_s3 = mock.Mock()
+
+    api_client_mod = types.ModuleType("cosmos_rl.dispatcher.api.client")
+    api_client_mod.APIClient = object
+
+    protocol_mod = types.ModuleType("cosmos_rl.dispatcher.protocol")
+
+    class SetTracePathRequest:
+        def __init__(self, replica_name, trace_path, global_rank):
+            self.replica_name = replica_name
+            self.trace_path = trace_path
+            self.global_rank = global_rank
+
+    protocol_mod.SetTracePathRequest = SetTracePathRequest
+
+    stubs = {
+        "cosmos_rl": types.ModuleType("cosmos_rl"),
+        "cosmos_rl.utils": types.ModuleType("cosmos_rl.utils"),
+        "cosmos_rl.utils.logging": logging_mod,
+        "cosmos_rl.policy": types.ModuleType("cosmos_rl.policy"),
+        "cosmos_rl.policy.config": policy_config_mod,
+        "cosmos_rl.utils.parallelism": parallelism_mod,
+        "cosmos_rl.utils.s3_utils": s3_utils_mod,
+        "cosmos_rl.dispatcher": types.ModuleType("cosmos_rl.dispatcher"),
+        "cosmos_rl.dispatcher.api": types.ModuleType("cosmos_rl.dispatcher.api"),
+        "cosmos_rl.dispatcher.api.client": api_client_mod,
+        "cosmos_rl.dispatcher.protocol": protocol_mod,
+    }
+    old_modules = {name: sys.modules.get(name) for name in stubs}
+    sys.modules.update(stubs)
+    return old_modules
+
+
+def _restore_modules(old_modules):
+    for name, module in old_modules.items():
+        if module is None:
+            sys.modules.pop(name, None)
+        else:
+            sys.modules[name] = module
+
+
+def _load_profiler_class():
+    old_modules = _install_profiler_import_stubs()
+    try:
+        spec = importlib.util.spec_from_file_location(
+            "cosmos_profiler_under_test",
+            REPO_ROOT / "cosmos_rl" / "utils" / "profiler.py",
+        )
+        module = importlib.util.module_from_spec(spec)
+        assert spec.loader is not None
+        spec.loader.exec_module(module)
+        return module.CosmosProfiler
+    finally:
+        _restore_modules(old_modules)
+
+
+def _load_nvtx_range():
+    spec = importlib.util.spec_from_file_location(
+        "cosmos_nvtx_under_test",
+        REPO_ROOT / "cosmos_rl" / "utils" / "nvtx.py",
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module.nvtx_range
+
+
+ProfilerConfig = _load_profiler_config_class()
+CosmosProfiler = _load_profiler_class()
+nvtx_range = _load_nvtx_range()
+
+
+class TestNsightProfilerConfig(unittest.TestCase):
+    def test_nsys_config_round_trip(self):
+        with tempfile.NamedTemporaryFile(mode="w+", suffix=".toml", delete=False) as f:
+            toml.dump(
+                {
+                    "redis": "12808",
+                    "train": {
+                        "output_dir": "./outputs/nsys-test",
+                        "train_policy": {"type": "sft", "dataset": {"name": ""}},
+                    },
+                    "profiler": {
+                        "enable_nsys": True,
+                        "nsys_target_roles": ["policy", "rollout"],
+                        "nsys_output_dir": "./outputs/nsys",
+                        "nsys_output_prefix": "smoke",
+                        "nsys_trace": "cuda,nvtx",
+                        "nsys_extra_args": ["--sample=none"],
+                    },
+                },
+                f,
+            )
+            path = f.name
+        try:
+            cfg = ProfilerConfig.model_validate(toml.load(path)["profiler"])
+            self.assertTrue(cfg.enable_nsys)
+            self.assertEqual(cfg.nsys_target_roles, ["policy", "rollout"])
+            self.assertEqual(cfg.nsys_output_prefix, "smoke")
+            self.assertEqual(cfg.nsys_trace, "cuda,nvtx")
+            self.assertEqual(cfg.nsys_extra_args, ["--sample=none"])
+        finally:
+            os.unlink(path)
+
+    def test_default_nsys_trace_includes_cuda_and_nvtx(self):
+        cfg = ProfilerConfig()
+        traces = {item.strip() for item in cfg.nsys_trace.split(",")}
+        self.assertIn("cuda", traces)
+        self.assertIn("nvtx", traces)
+
+    def test_invalid_nsys_role_fails_fast(self):
+        with self.assertRaises(ValueError):
+            ProfilerConfig.model_validate(
+                {
+                    "enable_nsys": True,
+                    "nsys_target_roles": ["policy", "trainer"],
+                }
+            )
+
+
+class TestNsightProfilerRuntime(unittest.TestCase):
+    def _profiler(self):
+        config = SimpleNamespace(
+            profiler=SimpleNamespace(
+                enable_profiler=False,
+                enable_nsys=True,
+                sub_profiler_config=SimpleNamespace(
+                    wait_steps=1,
+                    warmup_steps=1,
+                    active_steps=2,
+                    rank_filter=[0],
+                    record_shape=False,
+                    profile_memory=False,
+                    with_stack=False,
+                    with_modules=False,
+                ),
+            ),
+            train=SimpleNamespace(
+                output_dir="./outputs/run",
+                ckpt=SimpleNamespace(upload_s3=False),
+            ),
+        )
+        parallel_dims = SimpleNamespace(global_rank=0)
+        return CosmosProfiler(config, parallel_dims, "replica", mock.Mock())
+
+    @mock.patch("torch.cuda.is_available", return_value=True)
+    @mock.patch("torch.cuda.nvtx")
+    @mock.patch("torch.cuda.cudart")
+    def test_nsys_capture_window_uses_cuda_profiler_api(
+        self, mock_cudart, mock_nvtx, _mock_is_available
+    ):
+        cudart = mock.Mock()
+        mock_cudart.return_value = cudart
+        profiler = self._profiler()
+
+        profiler.start_nsys()
+        profiler.maybe_start_nsys()
+        cudart.cudaProfilerStart.assert_not_called()
+
+        profiler.step()
+        profiler.maybe_start_nsys()
+        cudart.cudaProfilerStart.assert_not_called()
+
+        profiler.step()
+        profiler.maybe_start_nsys()
+        cudart.cudaProfilerStart.assert_called_once()
+        mock_nvtx.range_push.assert_called_once()
+
+        profiler.step()
+        cudart.cudaProfilerStop.assert_not_called()
+
+        profiler.step()
+        cudart.cudaProfilerStop.assert_called_once()
+        mock_nvtx.range_pop.assert_called_once()
+        self.assertTrue(profiler.check_finished())
+
+    @mock.patch("torch.cuda.is_available", return_value=True)
+    @mock.patch("torch.cuda.nvtx")
+    def test_nvtx_range_pushes_and_pops(self, mock_nvtx, _mock_is_available):
+        with nvtx_range("cosmos.policy.test"):
+            pass
+        mock_nvtx.range_push.assert_called_once_with("cosmos.policy.test")
+        mock_nvtx.range_pop.assert_called_once()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Add Nsight Systems profiling support for policy and rollout workers

Introduce NVTX annotations and controller-orchestrated Nsight capture windows so policy and rollout profiles can be collected over the same global training steps without changing training computation logic.