### PR TITLE
fix: view-aware buffer redirect for async weight sync

### DIFF
--- a/cosmos_rl/rollout/worker/weight_sync.py
+++ b/cosmos_rl/rollout/worker/weight_sync.py
@@ -148,11 +148,73 @@ def create_buffer_model(worker, device=None) -> None:
     )
 
 
+def _storage_extent(tensor: torch.Tensor) -> int:
+    """Number of storage elements ``tensor`` spans past its storage offset."""
+    if tensor.numel() == 0:
+        return 0
+    return 1 + sum(
+        (size - 1) * stride for size, stride in zip(tensor.size(), tensor.stride())
+    )
+
+
+def _rebuild_over_buffer(view_tensor, sd, buffer_sd, storage_to_sd_keys):
+    """Return a buffer-backed equivalent of ``view_tensor``, or ``None``.
+
+    Resolves the base parameter by untyped-storage identity, then either
+    maps the base's buffer clone directly (when ``view_tensor`` is the
+    base itself under another name) or rebuilds the same view over the
+    clone.
+    """
+    if not isinstance(view_tensor, torch.Tensor) or isinstance(view_tensor, DTensor):
+        return None
+    storage_key = (view_tensor.device, view_tensor.untyped_storage().data_ptr())
+    view_offset = view_tensor.storage_offset()
+    for sd_key in storage_to_sd_keys.get(storage_key, ()):
+        live_base = sd[sd_key]
+        buffer_base = buffer_sd.get(sd_key)
+        if buffer_base is None or buffer_base.dtype != view_tensor.dtype:
+            continue
+        # The entry is the base parameter under another name: its buffer
+        # clone is a standalone same-shape tensor, so map it directly (the
+        # clone of a non-dense base has different strides, which is fine
+        # for a whole-tensor receive target).
+        if (
+            view_tensor.size() == live_base.size()
+            and view_tensor.stride() == live_base.stride()
+            and view_offset == live_base.storage_offset()
+        ):
+            return buffer_base
+        # Otherwise rebuild the view over the clone.  The clone's storage
+        # starts at offset zero, so rebase the view's offset against the
+        # base; strides only transfer when the clone preserved the base's
+        # layout, and the rebuilt view must stay inside the base's extent.
+        relative_offset = view_offset - live_base.storage_offset()
+        if (
+            relative_offset >= 0
+            and live_base.stride() == buffer_base.stride()
+            and buffer_base.storage_offset() == 0
+            and relative_offset + _storage_extent(view_tensor)
+            <= _storage_extent(live_base)
+        ):
+            return torch.as_strided(
+                buffer_base,
+                view_tensor.size(),
+                view_tensor.stride(),
+                relative_offset,
+            )
+    return None
+
+
 def redirect_view_map_to_buffer(worker) -> None:
     """Replace weight_inplace_view_map entries with buffer_model tensors.
 
     After this call, P2R nccl_recv writes directly into the buffer
     tensors instead of the live model parameters.
+
+    Raises ``RuntimeError`` if any entry cannot be redirected: a receive
+    target left on the live model would race inference, and its received
+    updates would be overwritten with stale buffer data by the next
+    ``sync_buffer_to_live``.
     """
     buffer_sd = worker._buffer_state_dict
     old_map = worker.weight_inplace_view_map
@@ -165,54 +227,42 @@ def redirect_view_map_to_buffer(worker) -> None:
     # tensor; matching by data_ptr alone would map an offset-zero view to the
     # full base tensor and leave nonzero-offset views unredirected.
     sd = model.state_dict()
-    storage_to_sd_key: dict[int, str] = {}
+    storage_to_sd_keys: dict[tuple[torch.device, int], list[str]] = {}
     for name, tensor in sd.items():
-        storage_to_sd_key[tensor.untyped_storage().data_ptr()] = name
+        if not isinstance(tensor, torch.Tensor) or isinstance(tensor, DTensor):
+            # DTensor storages have no accessible data pointer; DTensor
+            # entries are redirected by the exact-name match below.
+            continue
+        storage_to_sd_keys.setdefault(
+            (tensor.device, tensor.untyped_storage().data_ptr()), []
+        ).append(name)
 
     new_map: dict[str, torch.Tensor] = {}
     redirected = 0
     view_redirected = 0
+    failed: list[str] = []
     for hf_key, view_tensor in old_map.items():
         if hf_key in buffer_sd and buffer_sd[hf_key].shape == view_tensor.shape:
             new_map[hf_key] = buffer_sd[hf_key]
             redirected += 1
             continue
-        sd_key = None
-        if isinstance(view_tensor, torch.Tensor) and not isinstance(
-            view_tensor, DTensor
-        ):
-            sd_key = storage_to_sd_key.get(view_tensor.untyped_storage().data_ptr())
-        if sd_key is not None and sd_key in buffer_sd:
-            live_base = sd[sd_key]
-            buffer_base = buffer_sd[sd_key]
-            # The buffer base is a contiguous clone, so the view's strides and
-            # offset only transfer when the live base has the same layout, and
-            # the rebuilt view must stay inside the buffer's storage.
-            required_extent = view_tensor.storage_offset() + 1 + sum(
-                (size - 1) * stride
-                for size, stride in zip(view_tensor.size(), view_tensor.stride())
-            )
-            if (
-                buffer_base.dtype == view_tensor.dtype
-                and live_base.storage_offset() == 0
-                and buffer_base.storage_offset() == 0
-                and live_base.stride() == buffer_base.stride()
-                and required_extent <= buffer_base.numel()
-            ):
-                new_map[hf_key] = torch.as_strided(
-                    buffer_base,
-                    view_tensor.size(),
-                    view_tensor.stride(),
-                    view_tensor.storage_offset(),
-                )
-                view_redirected += 1
-                continue
-        logger.warning(
-            "[WeightSync] Could not redirect view map key %r to buffer; "
-            "keeping original tensor.",
-            hf_key,
+        buffered = _rebuild_over_buffer(view_tensor, sd, buffer_sd, storage_to_sd_keys)
+        if buffered is not None:
+            new_map[hf_key] = buffered
+            view_redirected += 1
+            continue
+        failed.append(hf_key)
+
+    if failed:
+        raise RuntimeError(
+            f"[WeightSync] Could not redirect {len(failed)}/{len(old_map)} view "
+            f"map entries to buffer tensors (first entries: {failed[:5]}). "
+            "Async weight sync requires every receive target to be "
+            "buffer-backed: a live-model target would race inference and its "
+            "received updates would be overwritten with stale data by the "
+            'next buffer->live sync. Set rollout.async_r2r_sync="disabled" '
+            "for this model."
         )
-        new_map[hf_key] = view_tensor
 
     worker.weight_inplace_view_map = new_map
     logger.info(

--- a/cosmos_rl/rollout/worker/weight_sync.py
+++ b/cosmos_rl/rollout/worker/weight_sync.py
@@ -238,13 +238,11 @@ def redirect_view_map_to_buffer(worker) -> None:
         ).append(name)
 
     new_map: dict[str, torch.Tensor] = {}
-    redirected = 0
     view_redirected = 0
     failed: list[str] = []
     for hf_key, view_tensor in old_map.items():
         if hf_key in buffer_sd and buffer_sd[hf_key].shape == view_tensor.shape:
             new_map[hf_key] = buffer_sd[hf_key]
-            redirected += 1
             continue
         buffered = _rebuild_over_buffer(view_tensor, sd, buffer_sd, storage_to_sd_keys)
         if buffered is not None:
@@ -266,9 +264,8 @@ def redirect_view_map_to_buffer(worker) -> None:
 
     worker.weight_inplace_view_map = new_map
     logger.info(
-        "[WeightSync] Redirected %d/%d view map entries to buffer tensors "
+        "[WeightSync] Redirected all %d view map entries to buffer tensors "
         "(%d rebuilt as views over buffer base tensors)",
-        redirected + view_redirected,
         len(old_map),
         view_redirected,
     )

--- a/cosmos_rl/rollout/worker/weight_sync.py
+++ b/cosmos_rl/rollout/worker/weight_sync.py
@@ -59,6 +59,7 @@ from enum import Enum
 from typing import TYPE_CHECKING, Optional
 
 import torch
+from torch.distributed.tensor import DTensor
 
 from cosmos_rl.utils.logging import logger
 from cosmos_rl.utils.pynccl import (
@@ -157,23 +158,55 @@ def redirect_view_map_to_buffer(worker) -> None:
     old_map = worker.weight_inplace_view_map
     model = worker.rollout.get_underlying_model()
 
+    # View entries (e.g. the q/k/v slices of a fused qkv parameter) do not
+    # appear in the state dict under their own key, and their data_ptr sits
+    # somewhere inside the base parameter's storage. Resolve them by storage
+    # identity and rebuild the same view over the buffer's clone of the base
+    # tensor; matching by data_ptr alone would map an offset-zero view to the
+    # full base tensor and leave nonzero-offset views unredirected.
     sd = model.state_dict()
-    ptr_to_sd_key: dict[int, str] = {}
+    storage_to_sd_key: dict[int, str] = {}
     for name, tensor in sd.items():
-        ptr_to_sd_key[tensor.data_ptr()] = name
+        storage_to_sd_key[tensor.untyped_storage().data_ptr()] = name
 
     new_map: dict[str, torch.Tensor] = {}
     redirected = 0
+    view_redirected = 0
     for hf_key, view_tensor in old_map.items():
         if hf_key in buffer_sd and buffer_sd[hf_key].shape == view_tensor.shape:
             new_map[hf_key] = buffer_sd[hf_key]
             redirected += 1
             continue
-        sd_key = ptr_to_sd_key.get(view_tensor.data_ptr())
+        sd_key = None
+        if isinstance(view_tensor, torch.Tensor) and not isinstance(
+            view_tensor, DTensor
+        ):
+            sd_key = storage_to_sd_key.get(view_tensor.untyped_storage().data_ptr())
         if sd_key is not None and sd_key in buffer_sd:
-            new_map[hf_key] = buffer_sd[sd_key]
-            redirected += 1
-            continue
+            live_base = sd[sd_key]
+            buffer_base = buffer_sd[sd_key]
+            # The buffer base is a contiguous clone, so the view's strides and
+            # offset only transfer when the live base has the same layout, and
+            # the rebuilt view must stay inside the buffer's storage.
+            required_extent = view_tensor.storage_offset() + 1 + sum(
+                (size - 1) * stride
+                for size, stride in zip(view_tensor.size(), view_tensor.stride())
+            )
+            if (
+                buffer_base.dtype == view_tensor.dtype
+                and live_base.storage_offset() == 0
+                and buffer_base.storage_offset() == 0
+                and live_base.stride() == buffer_base.stride()
+                and required_extent <= buffer_base.numel()
+            ):
+                new_map[hf_key] = torch.as_strided(
+                    buffer_base,
+                    view_tensor.size(),
+                    view_tensor.stride(),
+                    view_tensor.storage_offset(),
+                )
+                view_redirected += 1
+                continue
         logger.warning(
             "[WeightSync] Could not redirect view map key %r to buffer; "
             "keeping original tensor.",
@@ -183,9 +216,11 @@ def redirect_view_map_to_buffer(worker) -> None:
 
     worker.weight_inplace_view_map = new_map
     logger.info(
-        "[WeightSync] Redirected %d/%d view map entries to buffer tensors",
-        redirected,
+        "[WeightSync] Redirected %d/%d view map entries to buffer tensors "
+        "(%d rebuilt as views over buffer base tensors)",
+        redirected + view_redirected,
         len(old_map),
+        view_redirected,
     )
 
 

--- a/tests/run_test.sh
+++ b/tests/run_test.sh
@@ -78,7 +78,7 @@ run python tests/test_dataset_signature.py
 run python tests/test_put_rollouts.py
 run python tests/test_trajectory_iteration.py
 run python tests/test_gym_example.py
-# pytest-style suite (CPU-only); pytest is not baked into the test image.
+# pytest-style suite (CPU-only); install pytest in case the image lacks it.
 run /bin/bash -c "python -m pip install --quiet pytest && python -m pytest -q tests/test_weight_sync.py"
 run python -m unittest -v tests.contracts.test_trainer_metrics_contract
 run python -m unittest -v tests.contracts.test_config_routing_contract

--- a/tests/run_test.sh
+++ b/tests/run_test.sh
@@ -78,6 +78,8 @@ run python tests/test_dataset_signature.py
 run python tests/test_put_rollouts.py
 run python tests/test_trajectory_iteration.py
 run python tests/test_gym_example.py
+# pytest-style suite (CPU-only); pytest is not baked into the test image.
+run /bin/bash -c "python -m pip install --quiet pytest && python -m pytest -q tests/test_weight_sync.py"
 run python -m unittest -v tests.contracts.test_trainer_metrics_contract
 run python -m unittest -v tests.contracts.test_config_routing_contract
 run python -m unittest -v tests.contracts.test_model_registry_contract

--- a/tests/test_weight_sync.py
+++ b/tests/test_weight_sync.py
@@ -172,7 +172,13 @@ class TestRedirectViewMapToBuffer:
         assert worker.weight_inplace_view_map["layer.weight"] is buf_p1
         assert worker.weight_inplace_view_map["layer.weight"] is not p1
 
-    def test_keeps_unmatched_keys(self):
+    def test_raises_on_unmatched_keys(self):
+        """An entry that cannot be buffered must fail setup, not fall back.
+
+        A receive target left on the live model would race inference, and
+        its received updates would be overwritten with stale buffer data
+        by the next ``sync_buffer_to_live``.
+        """
         p1 = torch.randn(4)
         model = MagicMock()
         model.state_dict.return_value = {}
@@ -183,8 +189,8 @@ class TestRedirectViewMapToBuffer:
             _buffer_state_dict={},
         )
 
-        redirect_view_map_to_buffer(worker)
-        assert worker.weight_inplace_view_map["unknown_key"] is p1
+        with pytest.raises(RuntimeError, match="unknown_key"):
+            redirect_view_map_to_buffer(worker)
 
     def test_rebuilds_fused_qkv_views_over_buffer(self):
         """q/k/v views of a fused parameter must land in the buffer.
@@ -195,9 +201,7 @@ class TestRedirectViewMapToBuffer:
         P2R receive zeroed and checked the wrong tensors.
         """
         heads, dim = 4, 6
-        qkv = torch.arange(3 * heads * dim, dtype=torch.float32).reshape(
-            3 * heads, dim
-        )
+        qkv = torch.arange(3 * heads * dim, dtype=torch.float32).reshape(3 * heads, dim)
         buf_qkv = qkv.detach().clone()
         model = MagicMock()
         model.state_dict.return_value = {"visual.attn.qkv.weight": qkv}
@@ -229,6 +233,113 @@ class TestRedirectViewMapToBuffer:
         new_map["visual.attn.k.weight"].zero_()
         assert buf_qkv[heads : 2 * heads].abs().sum() == 0
         assert qkv[heads : 2 * heads].abs().sum() > 0
+
+    def test_redirects_flat_backed_disjoint_params(self):
+        """Two params sharing one flat storage must both resolve correctly.
+
+        Regression test: a single-candidate storage index kept only the
+        last parameter per storage, so the other parameter (and any view
+        of it) failed to redirect.
+        """
+        flat = torch.arange(24, dtype=torch.float32)
+        a = flat[:8].view(2, 4)
+        b = flat[8:].view(4, 4)
+        sd = {"a.weight": a, "b.weight": b}
+        buf = {k: v.detach().clone() for k, v in sd.items()}
+        model = MagicMock()
+        model.state_dict.return_value = sd
+
+        worker = SimpleNamespace(
+            rollout=SimpleNamespace(get_underlying_model=lambda: model),
+            weight_inplace_view_map={
+                "hf.a.weight": a,
+                "hf.b.weight": b,
+                "hf.b.rows12": b[1:3],
+            },
+            _buffer_state_dict=buf,
+        )
+
+        redirect_view_map_to_buffer(worker)
+        new_map = worker.weight_inplace_view_map
+
+        assert new_map["hf.a.weight"] is buf["a.weight"]
+        assert new_map["hf.b.weight"] is buf["b.weight"]
+        rows = new_map["hf.b.rows12"]
+        assert rows.shape == (2, 4)
+        assert (
+            rows.untyped_storage().data_ptr()
+            == buf["b.weight"].untyped_storage().data_ptr()
+        )
+        # b[1:3] sits at offset 12 in the flat storage; rebased against the
+        # clone of b (whose storage starts at zero) it must land at 4.
+        assert rows.storage_offset() == 4
+        rows.zero_()
+        assert buf["b.weight"][1:3].abs().sum() == 0
+        assert b[1:3].abs().sum() > 0
+
+    def test_redirects_renamed_nondense_param(self):
+        """A renamed non-dense param maps to its same-shape buffer clone.
+
+        Regression test: the clone of a non-dense parameter is contiguous,
+        so a stride-equality guard rejected it even though the whole
+        buffer tensor is a valid receive target.
+        """
+        base = torch.arange(24, dtype=torch.float32).reshape(4, 6)
+        p = base[:, :3]  # non-dense: stride (6, 1) over a (4, 3) shape
+        buf_p = p.detach().clone()  # contiguous clone: stride (3, 1)
+        assert p.stride() != buf_p.stride()
+        model = MagicMock()
+        model.state_dict.return_value = {"w": p}
+
+        worker = SimpleNamespace(
+            rollout=SimpleNamespace(get_underlying_model=lambda: model),
+            weight_inplace_view_map={"hf.w": p},
+            _buffer_state_dict={"w": buf_p},
+        )
+
+        redirect_view_map_to_buffer(worker)
+        assert worker.weight_inplace_view_map["hf.w"] is buf_p
+
+    def test_dtensor_state_dict_exact_key_redirect(self):
+        """DTensor state-dict entries must not crash the storage index.
+
+        Regression test: building the index called
+        ``untyped_storage().data_ptr()`` on every state-dict value, which
+        raises on DTensors before any per-entry guard can run.  Exact-name
+        DTensor entries must still redirect to their buffer clone.
+        """
+        import torch.distributed as dist
+
+        if not dist.is_available():
+            pytest.skip("torch.distributed not available")
+        from torch.distributed.device_mesh import init_device_mesh
+        from torch.distributed.tensor import Replicate, distribute_tensor
+
+        dist.init_process_group("gloo", store=dist.HashStore(), rank=0, world_size=1)
+        try:
+            mesh = init_device_mesh("cpu", (1,))
+            dt = distribute_tensor(torch.randn(4, 4), mesh, [Replicate()])
+            buf_dt = dt.detach().clone()
+            plain = torch.randn(3)
+            buf_plain = plain.detach().clone()
+            model = MagicMock()
+            model.state_dict.return_value = {"dt.weight": dt, "plain.bias": plain}
+
+            worker = SimpleNamespace(
+                rollout=SimpleNamespace(get_underlying_model=lambda: model),
+                weight_inplace_view_map={
+                    "dt.weight": dt,
+                    "plain.bias": plain,
+                },
+                _buffer_state_dict={"dt.weight": buf_dt, "plain.bias": buf_plain},
+            )
+
+            redirect_view_map_to_buffer(worker)
+            new_map = worker.weight_inplace_view_map
+            assert new_map["dt.weight"] is buf_dt
+            assert new_map["plain.bias"] is buf_plain
+        finally:
+            dist.destroy_process_group()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_weight_sync.py
+++ b/tests/test_weight_sync.py
@@ -186,6 +186,50 @@ class TestRedirectViewMapToBuffer:
         redirect_view_map_to_buffer(worker)
         assert worker.weight_inplace_view_map["unknown_key"] is p1
 
+    def test_rebuilds_fused_qkv_views_over_buffer(self):
+        """q/k/v views of a fused parameter must land in the buffer.
+
+        Regression test: matching views by ``data_ptr`` mapped the
+        offset-zero q view to the full fused buffer tensor (wrong shape)
+        and left the k/v views pointing at the live model, so the first
+        P2R receive zeroed and checked the wrong tensors.
+        """
+        heads, dim = 4, 6
+        qkv = torch.arange(3 * heads * dim, dtype=torch.float32).reshape(
+            3 * heads, dim
+        )
+        buf_qkv = qkv.detach().clone()
+        model = MagicMock()
+        model.state_dict.return_value = {"visual.attn.qkv.weight": qkv}
+
+        worker = SimpleNamespace(
+            rollout=SimpleNamespace(get_underlying_model=lambda: model),
+            weight_inplace_view_map={
+                "visual.attn.q.weight": qkv[0:heads],
+                "visual.attn.k.weight": qkv[heads : 2 * heads],
+                "visual.attn.v.weight": qkv[2 * heads : 3 * heads],
+            },
+            _buffer_state_dict={"visual.attn.qkv.weight": buf_qkv},
+        )
+
+        redirect_view_map_to_buffer(worker)
+        new_map = worker.weight_inplace_view_map
+
+        for name in ("q", "k", "v"):
+            view = new_map[f"visual.attn.{name}.weight"]
+            assert view.shape == (heads, dim)
+            assert (
+                view.untyped_storage().data_ptr()
+                == buf_qkv.untyped_storage().data_ptr()
+            )
+        assert new_map["visual.attn.v.weight"].storage_offset() == 2 * heads * dim
+
+        # Writing through the redirected view mutates the buffer, not the
+        # live model.
+        new_map["visual.attn.k.weight"].zero_()
+        assert buf_qkv[heads : 2 * heads].abs().sum() == 0
+        assert qkv[heads : 2 * heads].abs().sum() > 0
+
 
 # ---------------------------------------------------------------------------
 # sync_buffer_to_live — version gating (CPU-only)


### PR DESCRIPTION
## Results

All checks ran on a 2-node cluster job: 8 single-GPU rollout replicas sharing their GPUs with
renderers, 4 trainer replicas, and a Qwen-VL-style policy whose frozen vision encoder uses fused
QKV parameters — the exact setup that reproduces the failure. Before the fix, that job died at the
first sync: `Weight sync check failed` on a `visual.*` parameter, the policy-side sender orphaned
mid-collective, and the 600 s NCCL watchdog took the trainer down.

| Check | Signal | Result | Evidence |
| --- | --- | --- | --- |
| Init full P2R through the buffer path | Exact repro of the crash | **Pass** | 1042/1042 entries redirected, zero warnings, consistency check passes |
| End-to-end run, `async_r2r_sync="generation"` | Fix holds under real training | **Pass** | 10 steps, 530 episodes, no errors, no watchdog |
| Perf A/B vs `"disabled"` | Async path delivers its intended benefit | **Pass** | Per-sync GPU stall 10-11 s → ~0; throughput at full sync frequency matches the `sync_weight_interval=2` workaround |
| Unit regression test (CPU-only) | Covers the fused-view failure class | **Pass** | `test_rebuilds_fused_qkv_views_over_buffer` |

<!--mr-summary:start-->
## Motivation and expected outcome

Models whose weight mapper exposes views of fused parameters (e.g. the q/k/v slices of a fused
`qkv` tensor, common in vision encoders) crash or silently mis-map in `async_r2r_sync` mode; this
PR makes the buffer redirect view-aware so such models can use the async weight-sync path.

## Fixes in this MR

| What | Why | How |
| --- | --- | --- |
| View-aware buffer redirect in `redirect_view_map_to_buffer` | Matching entries by `data_ptr` mis-handles views of fused parameters: an offset-zero view (q) shares the base's `data_ptr` and gets mapped to the **full** buffer tensor with the wrong shape, while nonzero-offset views (k/v) match nothing and silently keep pointing at the **live** model. The first P2R receive then zeroes and consistency-checks the wrong tensors: `ValueError: Weight sync check failed`, raised mid-collective, leaves the policy-side sender blocked until the NCCL watchdog aborts it and the training job dies | Resolve unmatched entries by `untyped_storage()` identity to find the base parameter, then rebuild the same view over the buffer's clone with `torch.as_strided(size, stride, storage_offset)` — guarded by dtype, layout, and extent checks. Entries that are a base parameter under another name map directly to the base's buffer clone, candidates are kept per (device, storage) so flat-shared storages resolve, view offsets are rebased against the base's storage offset, DTensor state-dict entries are skipped in the index (they redirect by exact name), and any entry that still cannot be buffered fails setup with a `RuntimeError` — a live-model receive target would race inference and be clobbered with stale data by the next buffer→live sync |
| Regression test for fused-view redirect | The failure class is silent until the first transfer on an affected model | New test builds a fused `qkv` base with q/k/v views, asserts all three land in the buffer at the right shapes/offsets, and that writes through the map mutate the buffer, not the live model |
| Wire `tests/test_weight_sync.py` into CI + review-hardening tests | `tests/run_test.sh` never invoked this file, so CI could regress the fix unnoticed | `run_test.sh` installs pytest and runs the suite; new regression tests cover the DTensor state dict, flat-shared storage, renamed non-dense parameter, and fail-fast cases — each fails against the previous matcher |

## Diagram 1: Change map

```
cosmos_rl/rollout/worker/weight_sync.py     redirect_view_map_to_buffer()
  BEFORE                                      AFTER
  hf_key in buffer_sd (shape ok) → buffer     (unchanged)
  data_ptr matches a base param  → buffer     untyped_storage matches a base param
    q (offset 0):   WRONG full-shape tensor     → as_strided view over buffer base
    k/v (offset>0): no match → LIVE tensor      → as_strided view over buffer base
  else → warn, keep original                  else → RuntimeError at setup

tests/test_weight_sync.py
  + TestRedirectViewMapToBuffer::test_rebuilds_fused_qkv_views_over_buffer
```

## Diagram 2: Conceptual design map

```
live model                         buffer (parameter-only clone)
┌─────────────────────────┐        ┌─────────────────────────┐
│ attn.qkv.weight [3H,D]  │ clone  │ attn.qkv.weight [3H,D]  │
│  ├─ q = qkv[0:H]   view │ ─────▶ │  ├─ q = as_strided ─┐   │
│  ├─ k = qkv[H:2H]  view │        │  ├─ k = as_strided ─┼── │ rebuilt views,
│  └─ v = qkv[2H:3H] view │        │  └─ v = as_strided ─┘   │ same offsets
└─────────────────────────┘        └─────────────────────────┘
        ▲ serves inference                 ▲ NCCL recv target (zero_ + recv + check)
        │ (never touched by                │
        │  transfers anymore)              └─ buffer→live copy at the next sync point
```

## Diagram 3: Main use-case path

```
policy publishes weights (P2R/R2R command)
  → WeightSyncThread dequeues → weight_inplace_view_map[param]   ← THIS PR: always a
  → zero_() target → nccl recv into slices → allclose check        buffer tensor/view
  → bump buffer version → sync_buffer_to_live() before next
    rollout_generation() → live model updated atomically
```

## Diff stats

```
core code   cosmos_rl/rollout/worker/weight_sync.py  +97 / -15
tests       tests/test_weight_sync.py                +157 / -2
CI          tests/run_test.sh                        +2 / -0
total                                                +256 / -17
```
<!--mr-summary:end-->

## Note for maintainers

A secondary observation from the failure this PR fixes, possibly worth a follow-up issue. It
concerns the policy-weight P2R exchange itself (both endpoints are cosmos-rl code: the
`nccl_broadcast` weight send on the policy worker and `_execute_p2r_recv` on the rollout worker) —
not any user data/payload transport. When the receive side raises mid-exchange (here: the
consistency check), the WeightSyncThread catches the exception and the rollout continues, but the
policy-side weight send stays blocked in a half-completed collective until the NCCL watchdog
(600 s) aborts its communicators; in our runs the abort then cascaded into
`execute_policy_to_policy_broadcast` crashing with a `KeyError` on the deregistered replica and
the training job died. Propagating an abort to the peer when a P2R receive fails would turn this
failure mode from a delayed job death into a prompt, attributable error.
