### PR TITLE
fix: port selection owns ports by binding, never shifts advertised endpoints

### DIFF
--- a/cosmos_rl/dispatcher/controller.py
+++ b/cosmos_rl/dispatcher/controller.py
@@ -48,6 +48,26 @@ from cosmos_rl.dispatcher.data.schema import RLPayload
 from cosmos_rl.dispatcher.data.data_fetcher import ControllerDataFetcher
 
 
+def _wait_for_redis_ready(port: int, timeout: float) -> bool:
+    """Return True once a redis server on ``port`` answers PING, False on timeout."""
+    import redis
+
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        try:
+            # socket_timeout bounds the PING reply as well: if a non-redis
+            # process holds the port, the connect succeeds but no RESP answer
+            # ever comes, and an unbounded recv would hang here forever.
+            client = redis.Redis(
+                port=port, socket_connect_timeout=1.0, socket_timeout=1.0
+            )
+            if client.ping():
+                return True
+        except redis.exceptions.RedisError:
+            time.sleep(0.2)
+    return False
+
+
 class Controller:
     _instance = None
 
@@ -138,9 +158,6 @@ class Controller:
             is_rl=self.is_rl,
         )
 
-        redis_free_port = network_util.find_available_port(redis_port)
-        self.config.redis = str(redis_free_port)
-
         ips = network_util.get_eth_ips()
         if len(ips) > 0:
             self.config.eth_ips = ";".join(ips)
@@ -154,30 +171,55 @@ class Controller:
 maxmemory 500G
 maxmemory-policy allkeys-lfu
 """
-        redis_cfg_path = network_util.write_redis_config(
-            redis_free_port,
-            redis_logfile_path,
-            file_path=config_file_path.name,
-            custom_config=custom_config,
-        )
-        redis_server_cmd = f'redis-server {redis_cfg_path} --dbfilename {random_db_file_name} --save ""'
-
-        redis_server_proc = subprocess.Popen(
-            redis_server_cmd, shell=True, stdout=sys.stdout, stderr=sys.stderr
-        )
-
-        # Check if the redis server started successfully
-        redis_server_proc.wait()
-        ret_code = redis_server_proc.returncode
-
-        if ret_code is not None and ret_code != 0:
-            raise RuntimeError(
-                f"Failed to start redis server with command: {redis_server_cmd} with return code {ret_code}"
+        # redis-server binds its port itself, in a daemonized child (see
+        # write_redis_config), so neither the port probe nor the parent exit
+        # code can guarantee the port: a process grabbing it between the probe
+        # and redis's bind used to go unnoticed until workers failed to
+        # connect. Only a successful PING proves the server is up; on failure
+        # retry on the next free port. self.config.redis is set only after
+        # verification, so workers never see a port redis does not serve on.
+        max_attempts = 10
+        candidate_port = redis_port
+        for attempt in range(max_attempts):
+            redis_free_port = network_util.find_available_port(candidate_port)
+            redis_cfg_path = network_util.write_redis_config(
+                redis_free_port,
+                redis_logfile_path,
+                file_path=config_file_path.name,
+                custom_config=custom_config,
             )
+            redis_server_cmd = f'redis-server {redis_cfg_path} --dbfilename {random_db_file_name} --save ""'
+
+            redis_server_proc = subprocess.Popen(
+                redis_server_cmd, shell=True, stdout=sys.stdout, stderr=sys.stderr
+            )
+
+            # The parent exits immediately after daemonizing; a non-zero code
+            # still catches config errors, for which retrying cannot help.
+            redis_server_proc.wait()
+            ret_code = redis_server_proc.returncode
+            if ret_code is not None and ret_code != 0:
+                raise RuntimeError(
+                    f"Failed to start redis server with command: {redis_server_cmd} with return code {ret_code}"
+                )
+
+            if _wait_for_redis_ready(redis_free_port, timeout=10.0):
+                logger.info(
+                    f"[Controller] Redis server started on port {redis_free_port} with command {redis_server_cmd}"
+                )
+                break
+            logger.warning(
+                f"[Controller] Redis server did not come up on port {redis_free_port} "
+                f"(attempt {attempt + 1}/{max_attempts}, likely lost the port to another "
+                "process); retrying on the next free port"
+            )
+            candidate_port = redis_free_port + 1
         else:
-            logger.info(
-                f"[Controller] Redis server started on port {redis_free_port} with command {redis_server_cmd}"
+            raise RuntimeError(
+                f"Redis server failed to start after {max_attempts} attempts, "
+                f"starting from port {redis_port}. Check {redis_logfile_path} for details."
             )
+        self.config.redis = str(redis_free_port)
 
         self.redis_controller = RedisStreamHandler(
             ips=["0.0.0.0"], port=redis_free_port

--- a/cosmos_rl/dispatcher/run_web_panel.py
+++ b/cosmos_rl/dispatcher/run_web_panel.py
@@ -16,6 +16,7 @@
 import os
 import argparse
 import signal
+import socket
 import time
 import uvicorn
 import toml
@@ -55,7 +56,7 @@ from cosmos_rl.dispatcher.protocol import (
     Role,
 )
 from cosmos_rl.policy.config import Config as CosmosConfig
-from cosmos_rl.utils.network_util import find_available_port
+from cosmos_rl.utils.network_util import bind_available_port
 from cosmos_rl.utils.logging import logger
 from cosmos_rl.utils.constant import (
     COSMOS_HEARTBEAT_TIMEOUT,
@@ -877,12 +878,28 @@ def main(
             f"Failed to load or parse config file {args.config}: {e}.",
         )
 
-    config = uvicorn.Config(
-        app, host="0.0.0.0", port=find_available_port(args.port), access_log=False
-    )
+    # Serve on the port every worker was told to reach us at. Re-probing for a
+    # different port here would silently strand the workers (and the launcher,
+    # which polls the advertised URL for readiness). Prefer the pre-bound
+    # listening socket inherited from the launcher — that reservation is
+    # race-free; otherwise bind exactly args.port and fail fast if it is taken.
+    listen_fd = os.environ.get("COSMOS_CONTROLLER_LISTEN_FD")
+    if listen_fd is not None:
+        listen_sock = socket.socket(fileno=int(listen_fd))
+        port = listen_sock.getsockname()[1]
+    else:
+        try:
+            listen_sock = bind_available_port(args.port, args.port + 1)
+        except RuntimeError:
+            raise RuntimeError(
+                f"Controller port {args.port} is already in use. It cannot be "
+                "substituted because workers connect to this exact endpoint."
+            )
+        port = args.port
+    config = uvicorn.Config(app, host="0.0.0.0", port=port, access_log=False)
     global server
     server = uvicorn.Server(config)
-    server.run()
+    server.run(sockets=[listen_sock])
 
 
 if __name__ == "__main__":

--- a/cosmos_rl/launcher/launch_all.py
+++ b/cosmos_rl/launcher/launch_all.py
@@ -15,7 +15,7 @@
 
 #!/usr/bin/env python3
 
-import socket
+import http.client
 import subprocess
 import sys
 import time
@@ -47,38 +47,37 @@ from cosmos_rl.utils.dist_signal_handler import DistributedSignalHandler
 
 def wait_for_url_ready(url: str, process: Optional[subprocess.Popen] = None):
     """
-    Wait for a URL to be ready by sending a GET request.
+    Wait for the controller HTTP API to be ready.
 
     Args:
-        url: The URL to check
+        url: The controller URL to check
 
     Returns:
         None
     """
+    host, port = url.rsplit(":", 1)
     while True:
-        # create TCP socket
+        if process is not None and process.poll() is not None:
+            if process.returncode != 0:
+                logger.error(
+                    f"Process {process.pid} exited with code {process.returncode}. Exiting."
+                )
+                sys.exit(process.returncode)
+            logger.error(f"Process {process.pid} exited as soon as launched. Exiting.")
+            sys.exit(1)
+
+        connection = http.client.HTTPConnection(host, int(port), timeout=1)
         try:
-            if process is not None:
-                if process.poll() is not None:
-                    if process.returncode != 0:
-                        logger.error(
-                            f"Process {process.pid} exited with code {process.returncode}. Exiting."
-                        )
-                        sys.exit(process.returncode)
-                    else:
-                        logger.error(
-                            f"Process {process.pid} exited as soon as launched. Exiting."
-                        )
-                        sys.exit(1)
-            sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-            sock.settimeout(1)
-            host, port = url.split(":")
-            sock.connect((host, int(port)))
-            sock.close()
-            break
-        except socket.error:
-            # If the connection fails, wait and retry
-            time.sleep(1)
+            connection.request("GET", "/api/meta")
+            response = connection.getresponse()
+            response.read()
+            if response.status == 200:
+                return
+        except (OSError, http.client.HTTPException):
+            pass
+        finally:
+            connection.close()
+        time.sleep(1)
 
 
 def read_config(config_file: str) -> Dict[str, Any]:

--- a/cosmos_rl/launcher/launch_all.py
+++ b/cosmos_rl/launcher/launch_all.py
@@ -690,16 +690,33 @@ cosmos-rl --config config.toml"""
     else:
         cur_work_idx = args.worker_idx
 
+    # When this node hosts the controller, the port is reserved here by binding
+    # a listening socket that the controller process later inherits. Selecting a
+    # port without binding it would leave a window for another process to steal
+    # it; shifting to a different port instead is never safe once other workers
+    # were told to reach the controller at the advertised one.
     control_url = None
+    controller_listen_sock = None
     if args.url is not None:
         ip, port = args.url.split(":")
         if ip in get_local_ip():
-            # If the IP is the local IP, launch the controller on the local machine
-            port = network_util.find_available_port(int(port))
+            # This node hosts the controller. Every worker derived its
+            # controller URL from args.url, so exactly this port must be used.
+            try:
+                controller_listen_sock = network_util.bind_available_port(
+                    int(port), int(port) + 1
+                )
+            except RuntimeError:
+                raise RuntimeError(
+                    f"Controller port {port} from --url {args.url} is already in "
+                    "use on this node. It cannot be substituted because all "
+                    "workers connect to this exact endpoint."
+                )
             logger.info(f"Using local IP: {ip} so launching controller on port {port}")
         else:
             control_url = args.url
     else:
+        multi_worker = args.num_workers is not None and args.num_workers > 1
         if (
             "LEPTON_JOB_WORKER_INDEX" in os.environ
             and int(os.environ.get("LEPTON_JOB_WORKER_INDEX")) != 0
@@ -712,14 +729,26 @@ cosmos-rl --config config.toml"""
             primary_hostname = f"{prefix}-0.{subdomain}"
             primary_hostname = resolve_host_blocking(primary_hostname)
             control_url = f"{primary_hostname}:{args.port}"
-        elif "LEPTON_JOB_WORKER_INDEX" in os.environ:
-            # If we're in a Lepton job prime node, check if the port is available
-            if not network_util.is_port_free(args.port):
-                raise RuntimeError(f"Port {args.port} is not available")
-            else:
-                port = args.port
+        elif "LEPTON_JOB_WORKER_INDEX" in os.environ or multi_worker:
+            # Primary node of a multi-node job: non-primary workers already
+            # derived their controller URL from args.port, so exactly this
+            # port must be used.
+            try:
+                controller_listen_sock = network_util.bind_available_port(
+                    args.port, args.port + 1
+                )
+            except RuntimeError:
+                raise RuntimeError(
+                    f"Controller port {args.port} is already in use on this "
+                    "node. It cannot be substituted because non-primary "
+                    "workers connect to this exact endpoint."
+                )
+            port = args.port
         else:
-            port = network_util.find_available_port(args.port)
+            # Single-node job: nobody else derived a URL from args.port yet,
+            # so scanning for the nearest free port is safe.
+            controller_listen_sock = network_util.bind_available_port(args.port)
+            port = controller_listen_sock.getsockname()[1]
 
     if control_url is None:
         logger.info(f"Controller will be launched locally on port {port}.")
@@ -846,6 +875,8 @@ cosmos-rl --config config.toml"""
 
     if controller_cmd is not None:
         command_collections = SingleWorkerCommands(cur_work_idx)
+        # The controller inherits the pre-bound listening socket, so the port
+        # reserved above is served without ever being released in between.
         command_collections.append_command(
             controller_cmd,
             "",
@@ -853,11 +884,14 @@ cosmos-rl --config config.toml"""
             os.path.join(output_dir, "controller.log")
             if output_dir is not None
             else None,
-            env=None,
+            env={"COSMOS_CONTROLLER_LISTEN_FD": str(controller_listen_sock.fileno())},
+            pass_fds=(controller_listen_sock.fileno(),),
         )
         controller_process = launch_processes(command_collections)
         controller_id = len(processes)
         processes.append(controller_process[0])
+        # The controller process owns the socket now; drop the launcher's copy.
+        controller_listen_sock.close()
 
     logger.info(f"Waiting for controller to be ready at {control_url}")
     wait_for_url_ready(

--- a/cosmos_rl/launcher/utility.py
+++ b/cosmos_rl/launcher/utility.py
@@ -15,7 +15,7 @@
 
 import os
 import subprocess
-from typing import List, Optional, Dict, Any, NamedTuple, Iterator, Callable
+from typing import List, Optional, Dict, Any, NamedTuple, Iterator, Callable, Tuple
 import time
 import argparse
 import sys
@@ -381,9 +381,11 @@ class CommandItem(NamedTuple):
     control_url: Optional[str]
     output_file: Optional[str]
     env: Optional[Dict[str, str]]
+    # File descriptors (e.g. a pre-bound listening socket) the subprocess inherits.
+    pass_fds: Tuple[int, ...] = ()
 
     def __repr__(self) -> str:
-        return f"CommandItem(command={self.command}, gpu_devices={self.gpu_devices}, control_url={self.control_url}, output_file={self.output_file}, env={self.env})"
+        return f"CommandItem(command={self.command}, gpu_devices={self.gpu_devices}, control_url={self.control_url}, output_file={self.output_file}, env={self.env}, pass_fds={self.pass_fds})"
 
 
 class SingleWorkerCommands:
@@ -399,12 +401,13 @@ class SingleWorkerCommands:
         control_url: Optional[str],
         output_file: Optional[str],
         env: Optional[Dict[str, str]] = None,
+        pass_fds: Tuple[int, ...] = (),
     ):
         logger.info(
-            f"Appending command: {command} with gpu devices: {gpu_devices}, control URL: {control_url}, output files: {output_file}, env: {env}"
+            f"Appending command: {command} with gpu devices: {gpu_devices}, control URL: {control_url}, output files: {output_file}, env: {env}, pass_fds: {pass_fds}"
         )
         self.command_items.append(
-            CommandItem(command, gpu_devices, control_url, output_file, env)
+            CommandItem(command, gpu_devices, control_url, output_file, env, pass_fds)
         )
 
     def extend_commands(
@@ -827,7 +830,12 @@ def launch_processes(
             # Launch process and capture output
             logger.info(f"Launching process with command: {cmd}")
             process = subprocess.Popen(
-                cmd, shell=True, stdout=cout, stderr=cerr, env=env
+                cmd,
+                shell=True,
+                stdout=cout,
+                stderr=cerr,
+                env=env,
+                pass_fds=command_item.pass_fds,
             )
             processes.append(process)
             if ofile is not None:

--- a/cosmos_rl/utils/distributed.py
+++ b/cosmos_rl/utils/distributed.py
@@ -741,26 +741,21 @@ class DistKVStore:
             local_ips = network_util.get_eth_ips()
             assert len(local_ips) > 0, "No IP addresses found"
             local_ip = local_ips[0]
-            free_port = network_util.find_available_port(22000)
-
-            max_retry = 300
-            for _ in range(max_retry):
-                try:
-                    # Init TCPStore may fail when multi processes concurrently init TCPStore, so we need to retry to find another available port
-                    self.local_store = dist.TCPStore(
-                        host_name="0.0.0.0",
-                        port=free_port,
-                        # world_size=self.world_size,
-                        is_master=True,
-                        timeout=timedelta(seconds=constant.COSMOS_TCP_STORE_TIMEOUT),
-                    )
-                    break
-                except Exception:
-                    logger.error(
-                        f"[DistKVStore] Failed to bind port {free_port}, try another"
-                    )
-                    time.sleep(1)
-                    free_port = network_util.find_available_port(20000)
+            # Bind the listening socket ourselves and hand its fd to TCPStore.
+            # The kernel reserves the port at selection time, so concurrent
+            # processes scanning the same range can no longer race us between
+            # probing a port and serving on it. Keep a reference: the fd must
+            # outlive the store.
+            self._listen_sock = network_util.bind_available_port(22000)
+            free_port = self._listen_sock.getsockname()[1]
+            self.local_store = dist.TCPStore(
+                host_name="0.0.0.0",
+                port=free_port,
+                # world_size=self.world_size,
+                is_master=True,
+                timeout=timedelta(seconds=constant.COSMOS_TCP_STORE_TIMEOUT),
+                master_listen_fd=self._listen_sock.fileno(),
+            )
 
             logger.info(f"Local store started at {local_ip}:{free_port}")
             dist.broadcast_object_list(

--- a/cosmos_rl/utils/network_util.py
+++ b/cosmos_rl/utils/network_util.py
@@ -268,21 +268,61 @@ def get_eth_ips():
 
 
 def is_port_free(port: int) -> bool:
+    # A bind test on the wildcard address is the only reliable probe: services
+    # here bind 0.0.0.0, so a port held on any interface (or bound but not yet
+    # listening, which a connect() probe misses) must count as taken.
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-        s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-        return s.connect_ex(("127.0.0.1", port)) != 0
+        try:
+            s.bind(("0.0.0.0", port))
+            return True
+        except OSError:
+            return False
 
 
 def find_available_port(start_port, max_port=65536):
+    """Return the first port in [start_port, max_port) that is currently free.
+
+    WARNING: this only probes; it cannot reserve the port. Another process may
+    grab the port between this call and the caller's own bind. Callers that can
+    hold a socket should use ``bind_available_port`` instead; remaining callers
+    (e.g. ports handed to subprocesses or remote peers) must tolerate losing
+    the race by retrying their own bind.
+    """
     for port in range(start_port, max_port):
         try:
             with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-                s.bind(("localhost", port))
+                # Bind the wildcard address: consumers of the returned port
+                # bind 0.0.0.0, so a port taken on any interface is not free.
+                s.bind(("0.0.0.0", port))
                 return port
         except OSError:
             continue
 
     raise RuntimeError("No available port found in the specified range.")
+
+
+def bind_available_port(start_port: int, max_port: int = 65536) -> socket.socket:
+    """Bind and return a listening socket on the first free port in range.
+
+    Unlike ``find_available_port``, the returned socket *owns* the port: the
+    kernel reserves it at selection time, so there is no window in which
+    another process can steal it. Hand the socket (or its fd) to the server
+    that will serve on it; read the port via ``sock.getsockname()[1]``.
+
+    Use ``bind_available_port(port, port + 1)`` to reserve exactly ``port``.
+    """
+    for port in range(start_port, max_port):
+        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        try:
+            sock.bind(("0.0.0.0", port))
+            sock.listen(128)
+            return sock
+        except OSError:
+            sock.close()
+            continue
+
+    raise RuntimeError(f"No available port found in range [{start_port}, {max_port}).")
 
 
 def _redis_legacy_skip_tls_port() -> bool:

--- a/tests/run_test.sh
+++ b/tests/run_test.sh
@@ -84,6 +84,7 @@ run python -m unittest -v tests.contracts.test_trainer_metrics_contract
 run python -m unittest -v tests.contracts.test_config_routing_contract
 run python -m unittest -v tests.contracts.test_model_registry_contract
 run python -m unittest -v tests.contracts.test_rl_worker_trainer_surface_contract
+run python -m unittest -v tests.utils.test_network_util
 run python tests/test_sequence_packing.py
 run python tests/test_integration.py --stream
 run python tests/test_hf_models.py

--- a/tests/utils/test_network_util.py
+++ b/tests/utils/test_network_util.py
@@ -1,0 +1,110 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import socket
+import unittest
+
+from cosmos_rl.utils.network_util import (
+    bind_available_port,
+    find_available_port,
+    is_port_free,
+)
+
+
+class TestPortProbing(unittest.TestCase):
+    """Port probes must reject ports occupied on any local interface."""
+
+    def test_find_available_port_skips_port_held_on_other_interface(self):
+        # Occupy a port on 127.0.0.2 only. A loopback-only probe would not
+        # see it, but the services the probe guards bind 0.0.0.0 and would
+        # collide with it.
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as occupied:
+            occupied.bind(("127.0.0.2", 0))
+            occupied.listen()
+            occupied_port = occupied.getsockname()[1]
+
+            chosen = find_available_port(occupied_port)
+
+            self.assertNotEqual(chosen, occupied_port)
+            self.assertGreater(chosen, occupied_port)
+
+    def test_find_available_port_returns_free_start_port(self):
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as probe:
+            probe.bind(("0.0.0.0", 0))
+            free_port = probe.getsockname()[1]
+
+        self.assertEqual(find_available_port(free_port), free_port)
+
+    def test_is_port_free_sees_port_held_on_other_interface(self):
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as occupied:
+            occupied.bind(("127.0.0.2", 0))
+            occupied.listen()
+            occupied_port = occupied.getsockname()[1]
+
+            self.assertFalse(is_port_free(occupied_port))
+
+        self.assertTrue(is_port_free(occupied_port))
+
+
+class TestPortOwnership(unittest.TestCase):
+    """bind_available_port must reserve the port, not merely report it."""
+
+    def test_bind_available_port_reserves_the_port(self):
+        # With probe-only selection both calls would return the same port;
+        # ownership means the second caller is pushed to a different one.
+        first = bind_available_port(20000)
+        try:
+            first_port = first.getsockname()[1]
+            second = bind_available_port(first_port)
+            try:
+                self.assertNotEqual(second.getsockname()[1], first_port)
+            finally:
+                second.close()
+        finally:
+            first.close()
+
+    def test_bind_available_port_socket_is_listening(self):
+        sock = bind_available_port(20000)
+        try:
+            port = sock.getsockname()[1]
+            with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as client:
+                client.settimeout(5.0)
+                client.connect(("127.0.0.1", port))
+        finally:
+            sock.close()
+
+    def test_bind_available_port_exact_raises_when_port_taken(self):
+        holder = bind_available_port(20000)
+        try:
+            held_port = holder.getsockname()[1]
+            with self.assertRaises(RuntimeError):
+                bind_available_port(held_port, held_port + 1)
+        finally:
+            holder.close()
+
+    def test_bind_available_port_exact_reserves_free_port(self):
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as probe:
+            probe.bind(("0.0.0.0", 0))
+            free_port = probe.getsockname()[1]
+
+        sock = bind_available_port(free_port, free_port + 1)
+        try:
+            self.assertEqual(sock.getsockname()[1], free_port)
+        finally:
+            sock.close()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem

Port selection is probe-then-close everywhere: `find_available_port` binds a socket to check availability, closes it, and returns the number for someone else to bind later. Nothing reserves the port in the gap. The probe also tests only the loopback interface, while every consumer (uvicorn web panel, TCPStore, redis) binds `0.0.0.0`, so a port held on a non-loopback interface passes the probe and collides at bind time.

Two call sites additionally substitute a **different** port after the original one was already advertised to other processes:

1. **Multi-node split-brain**: on the primary node, `launch_all` re-probes `args.port` and silently shifts to the next free port — but non-primary workers already derived their controller URL from the original port. The cluster forks across two endpoints and hangs. (This bit us in production: multi-node Slurm jobs where the advertised controller port happened to be taken on the primary.)
2. **Single-node wedge**: `run_web_panel` re-probes `args.port` inside the controller process. If it shifts, even the launcher that spawned it waits forever in `wait_for_url_ready` on the URL it advertised.

There are also two latent bugs in the same area:

- `DistKVStore` retries TCPStore init up to 300 times, but the loopback-only probe keeps returning the same port when it is held on another interface — the retry loop spins without progress.
- redis-server daemonizes before binding, so the launcher's exit-code check cannot see a lost bind race; `self.config.redis` was published based on the probe alone, and workers discovered the dead port only when they failed to connect.

## Fix

The principle: **the port is chosen by the act of binding, by the process that keeps the socket** — and an endpoint that has been advertised is a contract, never silently substituted.

- `network_util.bind_available_port(start_port, max_port)` scans, binds `0.0.0.0`, and returns the live listening socket; the kernel reserves the port at selection time. `bind_available_port(p, p + 1)` reserves exactly `p`. `find_available_port` / `is_port_free` keep the probe-only contract for callers that cannot hold a socket (torchrun rendezvous, collective ranges, reward service), but now probe the wildcard address.
- `launch_all` binds the controller listening socket up front — scanning on single-node jobs, requiring exactly the advertised port on multi-node paths (`--url` on the controller node, Lepton prime node, `--num-workers > 1`) — and hands it to the controller process via `pass_fds` + `COSMOS_CONTROLLER_LISTEN_FD`. A busy contract port is now an immediate, clearly-attributed error on the right node instead of a silent endpoint fork.
- `run_web_panel` serves uvicorn on the inherited socket (`server.run(sockets=[...])`). Without one (direct invocation), it binds exactly `args.port` and fails fast rather than drifting.
- `DistKVStore` passes its bound socket to `TCPStore` via `master_listen_fd`, replacing the probe + retry loop — the collision window is gone entirely.
- The controller verifies redis with a bounded `PING` before publishing the port and retries on the next free port if the bind race was lost.

## Testing

- New `tests/utils/test_network_util.py` (added to `run_test.sh`, CPU-only): probes reject ports held on non-loopback interfaces; `bind_available_port` actually reserves (second call cannot get the same port), exact-mode raises when the port is taken, returned socket accepts connections.
- Verified end-to-end that a socket bound in the launcher survives the `launch_controller.sh` shell hop via `pass_fds`/`COSMOS_CONTROLLER_LISTEN_FD` and serves HTTP through uvicorn `run(sockets=[...])`.
- Verified `TCPStore(master_listen_fd=...)` against a pre-bound socket: master/client set/get works and the port stays owned for the store's lifetime.
- Verified the redis PING gate against both a real redis-server (ready) and a non-redis listener holding the port (bounded timeout, no hang).

Out of scope: `launch_vision.py` and `reward_service` keep the (now interface-correct) probe-only helpers; they don't spawn the process that binds, and the vision path never launches a controller locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
