### PR TITLE
[Cosmos RL] Finalize multirank rollout draining

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -102,6 +102,7 @@ RUN pip install -U pip setuptools wheel packaging psutil
 
 # even though we don't depend on torchaudio, vllm does. in order to
 # make sure the cuda version matches, we install it here.
+# Transformer Engine 2.17's NCCL-EP extension requires PyTorch 2.11 or newer.
 RUN set -eux; \
         case "${COSMOS_RL_TORCH_VARIANT}" in \
             2.8) \
@@ -132,7 +133,7 @@ RUN set -eux; \
             ${FLASH_ATTN_WHEEL:-flash_attn=="${FLASH_ATTN_VERSION}"} \
             vllm=="${VLLM_VERSION}" \
             flashinfer-python=="${FLASHINFER_VERSION}" \
-            transformer_engine[pytorch] --no-build-isolation
+            "transformer_engine[pytorch]==2.16.1" --no-build-isolation
 
 # install apex
 RUN APEX_CPP_EXT=1 APEX_CUDA_EXT=1 pip install -v --no-build-isolation git+https://github.com/NVIDIA/apex@bf903a2

--- a/cosmos_rl/colocated/api_client.py
+++ b/cosmos_rl/colocated/api_client.py
@@ -57,13 +57,14 @@ class ColocatedAPIClient(APIClient):
         """
         return super().get_next_prompt(batch_size, validation_step, rank_in_mesh)
 
-    def post_rollout_completion(self, response: RolloutRequest):
+    def post_rollout_completion(self, response: RolloutRequest) -> bool:
         """
         Post the rollout completion response to the controller.
         Args:
             response: The rollout completion response.
         """
         self.controller.put_rollouts(response)
+        return True
 
     def post_policy_train_ack(
         self,

--- a/cosmos_rl/dispatcher/api/client.py
+++ b/cosmos_rl/dispatcher/api/client.py
@@ -588,7 +588,7 @@ class APIClient(object):
             )
             return [], False
 
-    def post_rollout_completion(self, response: RolloutRequest):
+    def post_rollout_completion(self, response: RolloutRequest) -> bool:
         try:
             make_request_with_retry(
                 partial(
@@ -598,7 +598,9 @@ class APIClient(object):
                 self.get_alternative_urls(COSMOS_API_ROLLOUT_SUFFIX),
                 max_retries=self.max_retries,
             )
+            return True
         except Exception as e:
             logger.error(
                 f"[Rollout] Failed in sending rollout completion to controller after retries {e}."
             )
+            return False

--- a/cosmos_rl/dispatcher/command.py
+++ b/cosmos_rl/dispatcher/command.py
@@ -565,6 +565,8 @@ class TrainingCompleteCommand(Command):
         profile_memory: Optional[bool] = None,
         with_stack: Optional[bool] = None,
         with_modules: Optional[bool] = None,
+        final_step: Optional[int] = None,
+        checkpoint_total_steps: Optional[int] = None,
         **kwargs,
     ):
         kwargs["scope"] = CommandScope.LOCAL
@@ -573,6 +575,10 @@ class TrainingCompleteCommand(Command):
         self.replica_name = replica_name
         self.global_step = global_step
         self.total_steps = total_steps
+        self.final_step = global_step - 1 if final_step is None else final_step
+        self.checkpoint_total_steps = (
+            total_steps if checkpoint_total_steps is None else checkpoint_total_steps
+        )
         self.remain_samples_num = remain_samples_num
         self.do_save = do_save
         self.do_profile = do_profile
@@ -592,20 +598,24 @@ class TrainingCompleteCommand(Command):
         remain_samples_num: int,
         do_save: bool,
         redis_handler: RedisStreamHandler,
+        final_step: Optional[int] = None,
+        checkpoint_total_steps: Optional[int] = None,
     ):
         cmd = cls(
-            replica.name,
-            global_step,
-            total_steps,
-            remain_samples_num,
-            do_save,
-            replica.sub_profiler_config.do_profile,
-            replica.sub_profiler_config.active_steps,
-            replica.sub_profiler_config.rank_filter,
-            replica.sub_profiler_config.record_shape,
-            replica.sub_profiler_config.profile_memory,
-            replica.sub_profiler_config.with_stack,
-            replica.sub_profiler_config.with_modules,
+            replica_name=replica.name,
+            global_step=global_step,
+            total_steps=total_steps,
+            final_step=final_step,
+            checkpoint_total_steps=checkpoint_total_steps,
+            remain_samples_num=remain_samples_num,
+            do_save=do_save,
+            do_profile=replica.sub_profiler_config.do_profile,
+            active_steps=replica.sub_profiler_config.active_steps,
+            rank_filter=replica.sub_profiler_config.rank_filter,
+            record_shape=replica.sub_profiler_config.record_shape,
+            profile_memory=replica.sub_profiler_config.profile_memory,
+            with_stack=replica.sub_profiler_config.with_stack,
+            with_modules=replica.sub_profiler_config.with_modules,
         )
         redis_handler.publish_command(cmd.pack(), replica.name)
 

--- a/cosmos_rl/dispatcher/controller.py
+++ b/cosmos_rl/dispatcher/controller.py
@@ -622,10 +622,9 @@ maxmemory-policy allkeys-lfu
         # used to rely on a forced last-step weight sync ("ending signal") that
         # races rollout teardown and wedges ``ncclCommAbort`` (see
         # rollout_multirank_shutdown.md).  Asserting ``is_end`` once training is
-        # finished routes BOTH cases through the same prompt-stream
-        # ``prompt_consume_end`` stop path (keyed on ``prompt_fetch_end``);
-        # the explicit ``StopCommand`` broadcast is the cross-rank backstop
-        # for any rank that never observes ``is_end``.
+        # finished routes BOTH cases through the same prompt-stream checkout
+        # path (keyed on ``prompt_fetch_end``). Checked-out workers remain
+        # command participants until the explicit ``StopCommand`` broadcast.
         #
         # Safe against starvation: the controller advances ``current_step``
         # only at dispatch time, and only after it has buffered enough rollouts

--- a/cosmos_rl/dispatcher/protocol.py
+++ b/cosmos_rl/dispatcher/protocol.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 from pydantic import BaseModel, model_validator
-from typing import List, Dict, Any
+from typing import List, Dict, Any, Optional
 from cosmos_rl.dispatcher.data.schema import RLPayload
 
 
@@ -79,6 +79,8 @@ class ValidationReportRequest(BaseModel):
 
 class RolloutRequest(BaseModel):
     src_replica_name: str
+    src_global_rank: Optional[int] = None
+    stays_command_participant: bool = False
     payloads: List[RLPayload]
     metrics: Dict[str, Any] = {}
     is_end: bool = False

--- a/cosmos_rl/dispatcher/run_web_panel.py
+++ b/cosmos_rl/dispatcher/run_web_panel.py
@@ -676,29 +676,45 @@ async def put_rollout_group(rollout: RolloutRequest):
     try:
         if rollout.is_end:
             logger.info(
-                f"[Controller] Received rollout end signal from {rollout.src_replica_name}"
+                "[Controller] Received rollout end signal from %s rank=%s",
+                rollout.src_replica_name,
+                rollout.src_global_rank,
             )
-            controller.rollout_status_manager.rollout_end(rollout.src_replica_name)
-            controller.policy_status_manager.on_rollout_is_end(
-                controller.rollout_status_manager
+            replica_ended = controller.rollout_status_manager.rollout_end(
+                rollout.src_replica_name,
+                src_global_rank=rollout.src_global_rank,
+                stays_command_participant=rollout.stays_command_participant,
             )
+            if replica_ended:
+                controller.policy_status_manager.on_rollout_is_end(
+                    controller.rollout_status_manager
+                )
 
             return {"message": "Rollout end signal received"}
 
         rollouts_list = extract_rollouts(rollout.payloads, rollout.is_end)
-        # Update the statistics for dynamic sampling used for metrics collection
-        if controller.config.train.train_policy.variant == "dapo":
-            controller.policy_status_manager.update_dynamic_sampling_statistics(
-                rollout.metrics
-            )
-        # Flatten the rollouts into a single list
+        # Flatten immediately after extraction so terminal cleanup has concrete
+        # payload references, but runs before any metric/filter mutation.
         rollouts = [
-            rollout
+            extracted
             for rollouts_group in rollouts_list
-            for rollout in rollouts_group  # rollouts_group: all rollouts of the same prompt.
+            for extracted in rollouts_group
         ]
+        policy_status = controller.policy_status_manager
+        is_dapo = controller.config.train.train_policy.variant == "dapo"
+        if policy_status.rollout_admission_closed():
+            policy_status.cleanup_terminal_rollouts(
+                rollouts,
+                rollout.metrics,
+                is_dapo=is_dapo,
+            )
+            return {"message": "Terminal rollout cleaned"}
+
+        # Update the statistics for dynamic sampling used for metrics collection
+        if is_dapo:
+            policy_status.update_dynamic_sampling_statistics(rollout.metrics)
         # Filter out outdated rollouts
-        rollouts = controller.policy_status_manager.filter_outdated_rollouts(rollouts)
+        rollouts = policy_status.filter_outdated_rollouts(rollouts)
         if len(rollouts) > 0:
             logger.debug(
                 f"[RolloutGroup] from replica: {rollout.src_replica_name} with {len(rollout.payloads)} samples:"

--- a/cosmos_rl/dispatcher/status.py
+++ b/cosmos_rl/dispatcher/status.py
@@ -15,7 +15,7 @@
 
 import time
 import math
-from queue import Queue
+from queue import Empty, Queue
 from strenum import StrEnum
 from typing import Dict, List, Iterator, Any, Optional, Callable
 from cosmos_rl.utils.constant import COSMOS_HEARTBEAT_TIMEOUT
@@ -23,7 +23,7 @@ from cosmos_rl.utils.logging import logger
 from cosmos_rl.utils.util import RollingDict
 from cosmos_rl.policy.config import Config
 from cosmos_rl.dispatcher.replica import Replica, Atom, Rollout
-from cosmos_rl.dispatcher.protocol import Role
+from cosmos_rl.dispatcher.protocol import MESH_NAMES, Role
 import cosmos_rl.dispatcher.command as command
 from cosmos_rl.utils.redis_stream import RedisStreamHandler
 from cosmos_rl.utils.payload_transport import PayloadTransportRegistry
@@ -283,19 +283,9 @@ class PolicyStatusManager:
         self.remain_samples_num = 0
         self.samples_on_the_fly = 0
 
-        # Per-step record of how many rollouts the controller dispatched for
-        # each training step.  Populated at dispatch time by
-        # ``try_trigger_data_fetch_and_training`` (which knows the real count,
-        # including the ``TrainingCompleteCommand`` case where it is zero) and
-        # consumed by ``train_ack`` to compute the symmetric
-        # ``samples_on_the_fly`` decrement.  Without this, ``train_ack``
-        # decrements by ``train_batch_per_replica * arrived_replicas``
-        # unconditionally, which underflows the counter on the fake-last-cmd
-        # path (dispatched zero, decrements two) and trips the
-        # ``samples_on_the_fly >= 0`` assertion.  Keyed by ``current_step``
-        # value at dispatch (= ``global_step`` sent in DataFetchCommand =
-        # ``step`` received in train_ack); entries are popped on ack so the
-        # map size stays bounded by in-flight step count.
+        # Actual rollout count for each in-flight real training command.
+        # Entries are keyed by the command step and consumed after its full
+        # policy ACK set, keeping samples_on_the_fly accounting symmetric.
         self.dispatched_rollouts_by_step: Dict[int, int] = {}
 
         self.status = {}
@@ -319,6 +309,13 @@ class PolicyStatusManager:
 
         # Non-validation RL: explicit end-of-data phase (see ``JobPhase``).
         self.job_phase = JobPhase.RUNNING
+        self.draining_total_steps: Optional[int] = None
+        self.last_real_datafetch_acked_step: Optional[int] = None
+        self.last_real_datafetch_acked_total_steps: Optional[int] = None
+        self.completion_step: Optional[int] = None
+        self.completion_recipients: set[str] = set()
+        self.completion_acks: set[str] = set()
+        self.terminal_complete = False
 
         # For rank specific data dispatch
         self.rollout_buffer_per_rank: List[Queue] = []
@@ -415,7 +412,20 @@ class PolicyStatusManager:
         """
         Check if the training is finished.
         """
-        return self.current_step >= self.total_steps and self.total_steps > 0
+        total_steps = self.training_horizon()
+        return self.terminal_complete or (
+            self.current_step >= total_steps and total_steps > 0
+        )
+
+    def training_horizon(self) -> int:
+        """Return the immutable drain horizon once rollout input is closed."""
+        if self.draining_total_steps is not None:
+            return self.draining_total_steps
+        return self.total_steps
+
+    def rollout_admission_closed(self) -> bool:
+        """Whether new rollout results can no longer feed a training step."""
+        return self.terminal_complete or self.completion_step is not None
 
     def maintain_life_status(self):
         """
@@ -451,7 +461,7 @@ class PolicyStatusManager:
         """
         Set the ranks of the policies.
         """
-        if self.training_finished():
+        if self.job_phase == JobPhase.DRAINING or self.training_finished():
             # Training is finished, do not recompute total steps
             return
         # Update total_steps based on remaining samples and replicas
@@ -488,83 +498,43 @@ class PolicyStatusManager:
         return steps_by_dataset
 
     def enter_draining_phase(self) -> None:
-        """Enter DRAINING on the first rollout HTTP ``is_end`` POST."""
+        """Close rollout input and freeze the advertised training horizon."""
         if self.job_phase != JobPhase.RUNNING:
             return
         self.job_phase = JobPhase.DRAINING
-        logger.info("[Controller] Job phase RUNNING -> DRAINING")
-        self.recompute_total_steps(
-            explicit_num_remaining_samples=self.total_pending_rollouts()
+        self.draining_total_steps = self.total_steps
+        logger.info(
+            "[Controller] Job phase RUNNING -> DRAINING at frozen horizon %d",
+            self.draining_total_steps,
         )
 
     def finish_draining_phase(
         self,
         rollout_status_manager: "RolloutStatusManager",
     ) -> None:
-        """Final buffer reconcile when every rollout has POSTed ``is_end``."""
+        """Dispatch complete tail batches, then complete without inventing work."""
         if not rollout_status_manager.all_rollouts_ended():
             return
-        total_pending_rollouts = self.total_pending_rollouts()
-        logger.info(
-            "[Controller] DRAINING finish: recompute total steps with "
-            "%d remaining rollouts in buffer...",
-            total_pending_rollouts,
-        )
-        original_total_steps = self.total_steps
-        self.recompute_total_steps(
-            explicit_num_remaining_samples=total_pending_rollouts
-        )
-        new_total_steps = self.total_steps
-        if new_total_steps > self.current_step:
-            logger.info("[Controller] There are still remaining steps, no op required")
-            return
-        rollouts_per_step = self.config.train.train_batch_per_replica * len(
-            self.get_all_atoms_arrived_replicas()
-        )
-        if (
-            rollouts_per_step > 0
-            and total_pending_rollouts >= rollouts_per_step
-            and self.current_step < original_total_steps
-        ):
-            # Buffer still holds at least one full training step and the
-            # policy has not reached the pre-recompute ``total_steps`` yet.
-            # ``train_ack`` will dispatch that step via ``try_trigger``; do
-            # not cut training short (custom_rollout CI: computed_cnt check).
-            logger.info(
-                "[Controller] DRAINING: %d buffered rollouts (>= %d/step) "
-                "but policy at step %d/%d; deferring TrainingComplete",
-                total_pending_rollouts,
-                rollouts_per_step,
-                self.current_step,
-                original_total_steps,
-            )
-            return
-        if self.current_step == original_total_steps and total_pending_rollouts == 0:
-            logger.info(
-                "[Controller] No remaining steps, policy and rollouts happen to "
-                "finish at the same time"
-            )
+        if self.job_phase == JobPhase.RUNNING:
+            self.enter_draining_phase()
+
+        if self.rollout_admission_closed():
+            self.cleanup_buffered_rollouts()
             return
         if not self.all_ready_or_reduced():
-            logger.info(
-                "[Controller] DRAINING: policy still has in-flight work at step "
-                "%d (statuses=%s); deferring TrainingComplete until train_ack",
-                self.current_step,
-                {name: r.status for name, r in self.policy_replicas.items()},
-            )
             return
-        if self.current_step == original_total_steps:
-            logger.info(
-                "[Controller] No remaining steps with %d buffered rollouts; "
-                "clearing buffer and triggering TrainingComplete",
-                total_pending_rollouts,
-            )
-        else:
-            logger.info(
-                "[Controller] Clear the rollout buffer, and trigger TrainingComplete"
-            )
-        self.rollout_buffer.queue.clear()
-        self.total_steps = self.current_step + 1
+
+        frozen_total = self.training_horizon()
+        if self.current_step < frozen_total and self.rollouts_enough_for_one_step():
+            previous_step = self.current_step
+            self.try_trigger_data_fetch_and_training()
+            if self.current_step > previous_step:
+                return
+
+        self.cleanup_buffered_rollouts()
+        if self.real_terminal_command_acked():
+            self.terminal_complete = True
+            return
         self.trigger_training_complete()
 
     def on_rollout_is_end(
@@ -574,8 +544,8 @@ class PolicyStatusManager:
         """Single entry for rollout HTTP ``is_end`` POST (not prompt fetch)."""
         if self.config.validation.enable:
             return
-        if self.job_phase == JobPhase.RUNNING:
-            self.enter_draining_phase()
+        if not rollout_status_manager.all_rollouts_ended():
+            return
         self.finish_draining_phase(rollout_status_manager)
 
     def should_weight_sync_after_train_ack(
@@ -623,60 +593,64 @@ class PolicyStatusManager:
         return need_sync_weight
 
     def trigger_training_complete(self) -> None:
-        """Dispatch ``TrainingCompleteCommand`` for the genuine final step."""
+        """Stop policy replicas at synthetic coordinates without advancing K."""
         if self.data_fetcher.activated_val_iter is not None:
             return
 
         arrived_replicas = self.get_all_atoms_arrived_replicas()
         if len(arrived_replicas) == 0:
             return
-
-        if self.training_finished():
+        if self.completion_step is not None:
             return
 
-        required_rollouts = 0
-        assert self.current_step + 1 == self.total_steps, (
-            "TrainingComplete should advance to the final step"
-        )
+        frozen_total = self.training_horizon()
+        completion_step = self.current_step + 1
+        recipients = {replica.name for replica in arrived_replicas}
 
-        self.remain_samples_num -= required_rollouts
-        self.current_step += 1
-        self.dispatched_rollouts_by_step[self.current_step] = required_rollouts
+        # Stage the complete recipient snapshot before the first publish.  A
+        # partial publication can then hang, but can never look successful or
+        # admit late rollout results that no future trainer can consume.
+        self.completion_step = completion_step
+        self.completion_recipients = recipients
+        self.completion_acks = set()
+        for replica in arrived_replicas:
+            self.set_status(replica.name, PolicyStatus.RUNNING)
 
-        if self.config.validation.enable and (
-            self.current_step % self.config.validation.freq == 0
-            or self.current_step == self.total_steps
-        ):
-            self.data_fetcher.validation_activate_dataloader(self.current_step)
-
-        do_save = self.check_checkpoint_saving(required_rollouts)
-
+        do_save = bool(frozen_total > 0 and self.config.train.ckpt.enable_checkpoint)
         for replica in arrived_replicas:
             command.TrainingCompleteCommand.trigger(
                 replica=replica,
-                global_step=self.current_step,
-                total_steps=self.total_steps,
+                global_step=completion_step,
+                total_steps=completion_step,
+                final_step=self.current_step,
+                checkpoint_total_steps=frozen_total,
                 remain_samples_num=self.remain_samples_num,
                 do_save=do_save,
                 redis_handler=self.redis_handler,
             )
-            self.set_status(replica.name, PolicyStatus.RUNNING)
+
+    def record_completion_ack(self, replica_name: str, step: int) -> bool:
+        """Record one ACK for the active synthetic completion command."""
+        if (
+            step != self.completion_step
+            or replica_name not in self.completion_recipients
+        ):
+            return False
+        if replica_name in self.completion_acks:
+            return True
+        self.completion_acks.add(replica_name)
+        if self.completion_acks == self.completion_recipients:
+            self.terminal_complete = True
+        return True
 
     def _weight_sync_rollout_targets(
         self,
         rollout_status_manager: "RolloutStatusManager",
     ) -> List[Replica]:
-        """Rollout replicas that can still service a P2R/R2R weight sync."""
-        exclude_ended = not self.config.validation.enable
-        sorted_replicas = sorted(
-            rollout_status_manager.get_all_atoms_arrived_replicas(),
-            key=lambda x: x.start_time,
+        """Return a communicator-safe rollout recipient set."""
+        return rollout_status_manager.get_safe_weight_sync_replicas(
+            validation_enabled=self.config.validation.enable
         )
-        return [
-            rollout_replica
-            for rollout_replica in sorted_replicas
-            if not (exclude_ended and rollout_replica.status.ended)
-        ]
 
     def _expected_validation_rollout_count(self) -> int:
         val_datasize = getattr(self.data_fetcher, "val_datasize", 0)
@@ -775,7 +749,7 @@ class PolicyStatusManager:
         self.status.pop(replica_name)
         self.replica_scaling_log.append(ReplicaScalingLog.down(replica))
 
-        if self.training_finished():
+        if self.training_finished() or replica_name in self.completion_acks:
             # This policy replica is normally finished
             # Do not trigger rebuild mesh since everything is gonna be finished shortly
             logger.info(f"[Controller] Replica {replica_name} is stopping.")
@@ -1131,6 +1105,109 @@ class PolicyStatusManager:
             return sum(q.qsize() for q in self.rollout_buffer_per_rank)
         return self.rollout_buffer.qsize()
 
+    @staticmethod
+    def _parse_non_negative_count(metrics: Dict[str, Any], key: str) -> int:
+        value = metrics.get(key, 0)
+        if type(value) is int and value >= 0:
+            return value
+        logger.warning(
+            "[Controller] Ignoring malformed DAPO metric %s=%r; expected a "
+            "non-negative integer",
+            key,
+            value,
+        )
+        return 0
+
+    @classmethod
+    def parse_dynamic_sampling_counts(
+        cls, metrics: Optional[Dict[str, Any]]
+    ) -> Dict[str, int]:
+        """Sanitize DAPO counts once before any metric or counter mutation."""
+        metrics = metrics or {}
+        return {
+            key: cls._parse_non_negative_count(metrics, key)
+            for key in ("sampled", "filtered_positive", "filtered_negative")
+        }
+
+    def _settle_samples_on_the_fly(self, count: int, source: str) -> None:
+        if count <= 0:
+            return
+        before = self.samples_on_the_fly
+        self.samples_on_the_fly = max(0, before - count)
+        _log_samples_on_the_fly_mutation(
+            source,
+            before,
+            self.samples_on_the_fly,
+            extra=f"settled_count={count}",
+        )
+
+    def _discard_rollouts(self, rollouts: List[Rollout], source: str) -> int:
+        if not rollouts:
+            return 0
+        self._publish_payload_transport_cleanup(rollouts, [])
+        self._settle_samples_on_the_fly(len(rollouts), source)
+        return len(rollouts)
+
+    def cleanup_buffered_rollouts(self) -> int:
+        """Release every buffered rollout without consuming resumable budget."""
+        dropped: List[Rollout] = []
+        queues = (
+            self.rollout_buffer_per_rank
+            if self.config.train.train_policy.data_dispatch_as_rank_in_mesh
+            else [self.rollout_buffer]
+        )
+        for rollout_queue in queues:
+            while True:
+                try:
+                    dropped.append(rollout_queue.get_nowait())
+                except Empty:
+                    break
+        return self._discard_rollouts(dropped, "terminal_buffer_cleanup")
+
+    def cleanup_terminal_rollouts(
+        self,
+        rollouts: List[Rollout],
+        metrics: Optional[Dict[str, Any]],
+        *,
+        is_dapo: bool,
+    ) -> int:
+        """Settle a post-terminal HTTP result without normal admission."""
+        if rollouts:
+            self._publish_payload_transport_cleanup(rollouts, [])
+        settled_count = len(rollouts)
+        if is_dapo:
+            counts = self.parse_dynamic_sampling_counts(metrics)
+            if counts["sampled"] != len(rollouts):
+                logger.warning(
+                    "[Controller] DAPO sampled=%d does not match %d extracted "
+                    "terminal rollouts; using extracted count",
+                    counts["sampled"],
+                    len(rollouts),
+                )
+            settled_count += counts["filtered_positive"] + counts["filtered_negative"]
+        self._settle_samples_on_the_fly(settled_count, "terminal_result_cleanup")
+        return settled_count
+
+    def real_terminal_command_acked(self) -> bool:
+        """Whether this controller observed a fully ACKed real T/T command."""
+        terminal_step = self.training_horizon()
+        return (
+            self.last_real_datafetch_acked_step == terminal_step
+            and self.last_real_datafetch_acked_total_steps == terminal_step
+        )
+
+    def record_real_datafetch_acked(self, step: int, total_steps: int) -> None:
+        """Record a fully ACKed real command and close natural-final input."""
+        self.last_real_datafetch_acked_step = step
+        self.last_real_datafetch_acked_total_steps = total_steps
+        terminal_step = self.training_horizon()
+        if step != terminal_step or total_steps != terminal_step:
+            return
+        # Activate first so a result handler cannot re-admit work between the
+        # final ACK and cleanup.  FastAPI handlers do not yield in this region.
+        self.terminal_complete = True
+        self.cleanup_buffered_rollouts()
+
     def get_all_atoms_arrived_replicas(self) -> List[Replica]:
         """
         Get all the replicas that have all atoms arrived.
@@ -1207,14 +1284,16 @@ class PolicyStatusManager:
         """
         Update the dynamic sampling statistics.
         """
+        counts = self.parse_dynamic_sampling_counts(filter_records)
         for k in ["sampled", "filtered_positive", "filtered_negative"]:
-            self.filter_records[k] = self.filter_records.get(k, 0) + filter_records.get(
-                k, 0
-            )
+            self.filter_records[k] = self.filter_records.get(k, 0) + counts[k]
 
         # Update the remaining samples number to reflect the filtering results
-        self.remain_samples_num -= filter_records.get("filtered_positive", 0)
-        self.remain_samples_num -= filter_records.get("filtered_negative", 0)
+        filtered_count = counts["filtered_positive"] + counts["filtered_negative"]
+        self.remain_samples_num -= filtered_count
+        # Filtered DAPO generations have no payload and can never reach a
+        # training ACK, so settle their prompt-side in-flight accounting here.
+        self._settle_samples_on_the_fly(filtered_count, "dapo_filter")
 
     def filter_outdated_rollouts(self, rollouts: List[Rollout]) -> List[Rollout]:
         """
@@ -1291,21 +1370,7 @@ class PolicyStatusManager:
         self.filter_records[k] = self.filter_records.get(k, 0) + discarded_count
 
         if discarded_count > 0:
-            # Filtered rollouts were counted into ``samples_on_the_fly`` at
-            # dispatch time (controller._get_batched_prompt_impl) but are
-            # dropped here without ever reaching ``train_ack``, where the
-            # symmetric decrement lives.  Without this clamp the counter
-            # drifts upward on every filter event and eventually pins the
-            # soft throttle on permanently — the system loses its
-            # rollout-parallel regime and never autonomically recovers.
-            _sotf_before = self.samples_on_the_fly
-            self.samples_on_the_fly = max(0, self.samples_on_the_fly - discarded_count)
-            _log_samples_on_the_fly_mutation(
-                "filter_outdated",
-                _sotf_before,
-                self.samples_on_the_fly,
-                extra=f"discarded_count={discarded_count}",
-            )
+            self._settle_samples_on_the_fly(discarded_count, "filter_outdated")
             self._publish_payload_transport_cleanup(rollouts, filtered_rollouts)
 
         return filtered_rollouts
@@ -1450,6 +1515,13 @@ class PolicyStatusManager:
         if replica_name not in self:
             raise Exception(f"Replica {replica_name} not found")
 
+        # Synthetic completion ACKs have their own persistent recipient set.
+        # Record them before logging/reduction bookkeeping and before the
+        # worker can unregister.  They are never real DataFetch evidence.
+        if self.record_completion_ack(replica_name, step):
+            self.set_status(replica_name, PolicyStatus.REDUCED)
+            return
+
         if not hasattr(self, "report_data_list"):
             self.report_data_list = []
         self.report_data_list.append(report_data)
@@ -1467,20 +1539,19 @@ class PolicyStatusManager:
 
         if self.all_reduced():
             _sotf_before = self.samples_on_the_fly
-            # Decrement by the actual rollout count we dispatched for this
-            # step (recorded in ``try_trigger_data_fetch_and_training``),
-            # NOT by ``train_batch_per_replica * arrived_replicas``.  The
-            # two are equal on normal steps but diverge on the
-            # ``TrainingCompleteCommand`` step, where the controller dispatches
-            # zero rollouts but the trainer still acks.  Without the
-            # symmetric lookup, that ack underflows the counter and trips
-            # the ``samples_on_the_fly >= 0`` assertion below.
-            _train_decrement = self.dispatched_rollouts_by_step.pop(step, 0)
-            if _train_decrement == 0 and step not in (
+            # Settle exactly the rollout count recorded for this real command.
+            _missing_dispatch = object()
+            _dispatch_record = self.dispatched_rollouts_by_step.pop(
+                step, _missing_dispatch
+            )
+            _train_decrement = (
+                0 if _dispatch_record is _missing_dispatch else _dispatch_record
+            )
+            if _dispatch_record is _missing_dispatch and step not in (
                 self.total_steps,
                 self.total_steps - 1,
             ):
-                # Unexpected: a non-fake step popped 0.  Either the
+                # Unexpected: a real step had no dispatch record. Either the
                 # dispatch record was already consumed (double-ack) or a
                 # step number is mismatched.  Log loudly but do not crash;
                 # ``samples_on_the_fly`` stays balanced regardless.
@@ -1506,13 +1577,18 @@ class PolicyStatusManager:
             assert self.samples_on_the_fly >= 0, (
                 "samples_on_the_fly should not be negative"
             )
+            if (
+                getattr(self.config, "mode", None) != "colocated"
+                and not self.config.validation.enable
+                and _dispatch_record is not _missing_dispatch
+                and _train_decrement > 0
+            ):
+                self.record_real_datafetch_acked(step, total_steps)
             # All replicas have been reduced; decide whether to weight-sync.
             # See ``need_weight_sync`` for the end-of-data rationale (the
             # final-step sync is suppressed for non-validation runs because it
             # is never consumed and races rollout teardown).
             #
-            if rollout_status_manager.all_rollouts_ended():
-                self.finish_draining_phase(rollout_status_manager)
             need_sync_weight = self.should_weight_sync_after_train_ack(
                 step, rollout_status_manager
             )
@@ -1741,8 +1817,12 @@ class PolicyStatusManager:
                         step,
                         self.total_steps,
                     )
-            # Trigger next step training if data is available
-            self.try_trigger_data_fetch_and_training()
+            # Trigger/finalize only after every policy status is normalized;
+            # otherwise a command published mid-ACK can be overwritten READY.
+            if self.job_phase == JobPhase.DRAINING:
+                self.finish_draining_phase(rollout_status_manager)
+            else:
+                self.try_trigger_data_fetch_and_training()
             if self.config.train.train_policy.on_policy:
                 # Reset on-policy rollout completed flag for next step
                 self.on_policy_rollout_completed = False
@@ -1811,6 +1891,8 @@ class PolicyStatusManager:
             return True
 
         if self.config.train.train_policy.data_dispatch_as_rank_in_mesh:
+            if not self.rollout_buffer_per_rank:
+                return False
             # In this dispatch mode, each rank has its own rollout buffer.
             return all(
                 q.qsize() >= self.config.train.train_batch_per_replica
@@ -1826,7 +1908,7 @@ class PolicyStatusManager:
         # Decide whether to save checkpoint
         # First check if we need to save checkpoint based on epoch
         do_save = False
-        if self.current_step == self.total_steps:
+        if self.current_step == self.training_horizon():
             # Always save checkpoint at the last step
             do_save = True
         elif self.config.train.ckpt.save_freq_in_epoch > 0:
@@ -1871,6 +1953,8 @@ class PolicyStatusManager:
         if self.training_finished():
             return
 
+        training_horizon = self.training_horizon()
+
         items_count = self.config.train.train_batch_per_replica
         required_rollouts = items_count * len(arrived_replicas)
         all_ready_or_reduced = (
@@ -1885,19 +1969,12 @@ class PolicyStatusManager:
             # From controller's perspective, the training step is already increased
             self.current_step += 1
 
-            # Record the actual rollout count dispatched for this step so
-            # ``train_ack`` can later decrement ``samples_on_the_fly`` by the
-            # symmetric amount.  ``required_rollouts`` is the authoritative
-            # count: ``train_batch_per_replica * len(arrived_replicas)`` on a
-            # normal step, ``0`` on the ``TrainingCompleteCommand`` step
-            # above).  Keyed by ``current_step`` which is exactly the
-            # ``global_step`` we send in DataFetchCommand below and the
-            # ``step`` the trainer echoes back via train_ack.
+            # Record the count echoed by this real command's eventual ACK set.
             self.dispatched_rollouts_by_step[self.current_step] = required_rollouts
 
             if self.config.validation.enable and (
                 self.current_step % self.config.validation.freq == 0
-                or self.current_step == self.total_steps
+                or self.current_step == training_horizon
             ):
                 self.data_fetcher.validation_activate_dataloader(self.current_step)
 
@@ -1945,7 +2022,7 @@ class PolicyStatusManager:
                     replica=replica,
                     items_count=items_count,
                     global_step=self.current_step,
-                    total_steps=self.total_steps,
+                    total_steps=training_horizon,
                     # `remain_samples_num` is just for checkpointing the training progress
                     remain_samples_num=self.remain_samples_num,
                     # do_save from `check_checkpoint_saving` indicates whether the replica should save checkpoint after this training step
@@ -2017,6 +2094,8 @@ class RolloutStatusManager:
         self.rollout_replicas = {}
         self.rollout_init_done = False
         self.replica_scaling_log = []
+        self._ended_reporters: Dict[str, set[int]] = {}
+        self._command_participant_ended_replicas: set[str] = set()
 
     def setup(
         self,
@@ -2113,6 +2192,8 @@ class RolloutStatusManager:
         )
 
         replica = self.rollout_replicas.pop(replica_name)
+        self._ended_reporters.pop(replica_name, None)
+        self._command_participant_ended_replicas.discard(replica_name)
         self.replica_scaling_log.append(ReplicaScalingLog.down(replica))
         if policy_status_manager.training_finished():
             # This policy replica is normally finished
@@ -2120,27 +2201,24 @@ class RolloutStatusManager:
             logger.info(f"[Controller] Replica {replica_name} is stopping.")
             return
 
-        # Restrict the BuildMesh recipient set to replicas that have NOT
-        # already signalled ``rollout_end`` (``status.ended``).  A
-        # replica that has POSTed its final batch is on its way out of
-        # ``main_loop`` and will stop draining its command queue, so
-        # including it in the rebuild leaves a live peer waiting on a
-        # collective that will never complete.  Also require
-        # ``len(live_survivors) >= 2`` before triggering -- a 1-member
-        # rebuild is pointless and skipping it makes the decision
-        # audible in the log.
-        live_survivors = [
-            r for r in self.get_all_atoms_arrived_replicas() if not r.status.ended
+        # Workers that promise to remain in their command loop until STOP are
+        # safe mesh members. Legacy rankless-ended workers make no such
+        # guarantee and must remain excluded.
+        safe_survivors = [
+            survivor
+            for survivor in self.get_all_atoms_arrived_replicas()
+            if not survivor.status.ended
+            or survivor.name in self._command_participant_ended_replicas
         ]
-        if replica.in_mesh and len(live_survivors) >= 2:
-            self.trigger_rebuild_mesh(live_survivors)
+        if replica.in_mesh and safe_survivors:
+            # A one-member rebuild is still required: async R2R must replace
+            # the departed replica's communicator before version bookkeeping.
+            self.trigger_rebuild_mesh(safe_survivors)
         elif replica.in_mesh:
             logger.info(
-                "[Controller] Replica %s unregistering with %d live "
-                "survivor(s); skipping mesh rebuild "
-                "(graceful end-of-data path or last-replica teardown).",
+                "[Controller] Replica %s unregistering with no safe rollout "
+                "mesh survivors; skipping rebuild.",
                 replica_name,
-                len(live_survivors),
             )
 
     def register(
@@ -2191,17 +2269,83 @@ class RolloutStatusManager:
             )
         return replica
 
-    def rollout_end(self, replica_name: str):
+    @staticmethod
+    def _expected_reporting_ranks(replica: Replica) -> set[int]:
+        return {
+            atom.global_rank
+            for atom in replica.atoms.values()
+            if atom.tp_rank() == 0
+            and atom.pp_rank() == atom.group_size[MESH_NAMES.index("pp")] - 1
+        }
+
+    def get_safe_weight_sync_replicas(
+        self, *, validation_enabled: bool
+    ) -> List[Replica]:
+        """Return an R2R recipient set that matches a valid communicator."""
+        replicas = sorted(
+            self.get_all_atoms_arrived_replicas(), key=lambda item: item.start_time
+        )
+        if validation_enabled:
+            return replicas
+        if any(
+            replica.status.ended
+            and replica.name not in self._command_participant_ended_replicas
+            for replica in replicas
+        ):
+            # A rankless legacy checkout does not promise to keep consuming
+            # commands. Publishing to it or to a subset of its communicator
+            # can deadlock, so wait for unregister/rebuild.
+            return []
+        # Command-participating ended workers remain available through STOP.
+        # Keep the complete registered topology; an R2R subset would use a
+        # stale all-replica communicator.
+        return replicas
+
+    def rollout_end(
+        self,
+        replica_name: str,
+        src_global_rank: Optional[int] = None,
+        stays_command_participant: bool = False,
+    ) -> bool:
         """
-        Rollout end event.
+        Record a local reporter checkout and return a whole-replica transition.
+
+        Rankless requests retain the legacy whole-replica meaning. They may
+        explicitly promise to remain command participants through STOP.
         """
         replica = self[replica_name]
         if replica is None:
             logger.warning(
                 f"[Controller] Rollout {replica_name} not found in RolloutStatusManager"
             )
-            return
-        replica.status.ended = True
+            return False
+        if replica.status.ended:
+            return False
+        if src_global_rank is None:
+            if stays_command_participant:
+                self._command_participant_ended_replicas.add(replica_name)
+            else:
+                self._command_participant_ended_replicas.discard(replica_name)
+            replica.status.ended = True
+            return True
+
+        expected = self._expected_reporting_ranks(replica)
+        if src_global_rank not in expected:
+            logger.warning(
+                "[Controller] Ignoring rollout end from unexpected rank %s "
+                "for %s; expected one of %s",
+                src_global_rank,
+                replica_name,
+                sorted(expected),
+            )
+            return False
+        reporters = self._ended_reporters.setdefault(replica_name, set())
+        reporters.add(src_global_rank)
+        if expected and expected.issubset(reporters):
+            self._command_participant_ended_replicas.add(replica_name)
+            replica.status.ended = True
+            return True
+        return False
 
     def all_rollouts_ended(self) -> bool:
         """

--- a/cosmos_rl/policy/trainer/base.py
+++ b/cosmos_rl/policy/trainer/base.py
@@ -184,6 +184,28 @@ class Trainer(ABC):
             "model_resume_from_checkpoint method must be implemented"
         )
 
+    def save_checkpoint(
+        self,
+        current_step: int,
+        total_steps: int,
+        remain_samples_num: int,
+        *,
+        is_final: bool,
+    ) -> None:
+        """Save trainer state for a normal or terminal checkpoint."""
+        raise NotImplementedError(
+            f"{type(self).__name__}: checkpoint saving is not supported"
+        )
+
+    def invalidate_checkpoint_completion(self, current_step: int) -> None:
+        """Invalidate this rank before a coordinated same-step final save."""
+        manager = getattr(self, "ckpt_manager", None)
+        if manager is None or not hasattr(manager, "invalidate_completion_marker"):
+            raise NotImplementedError(
+                f"{type(self).__name__}: checkpoint invalidation is not supported"
+            )
+        manager.invalidate_completion_marker(current_step)
+
     @property
     def pp_loss_fn(self):
         raise NotImplementedError("pp_loss_fn must be provided by subclass")

--- a/cosmos_rl/policy/trainer/diffusers_trainer/nft_trainer.py
+++ b/cosmos_rl/policy/trainer/diffusers_trainer/nft_trainer.py
@@ -299,6 +299,50 @@ class NFTTrainer(DiffusersTrainer):
         ]
         self.neg_pooled_prompt_embed = neg_text_embedding_dict["pooled_projections"]
 
+    def save_checkpoint(
+        self,
+        current_step: int,
+        total_steps: int,
+        remain_samples_num: int,
+        *,
+        is_final: bool,
+    ) -> None:
+        use_ema_weights = self.config.train.ema_enable and self.model.ema is not None
+        if use_ema_weights:
+            self.model.ema.copy_ema_to(self.trainable_params, store_temp=True)
+
+        try:
+            if is_final or self.config.train.ckpt.export_safetensors:
+                logger.info(
+                    f"[Policy] Saving huggingface checkpoint at step {current_step} to {self.config.train.output_dir}..."
+                )
+                self.export_safetensors(
+                    output_dir=self.config.train.output_dir,
+                    rel_path=os.path.join(
+                        "safetensors",
+                        f"step_{current_step}",
+                    ),
+                    trainable_only=False,
+                    is_final=is_final,
+                    dtype=str2torch_dtype(self.config.train.param_dtype),
+                )
+
+            logger.info(f"[Policy] Saving cosmos checkpoint at step {current_step}...")
+            model_state_dict = self.model.get_trained_model_state_dict()
+            self.ckpt_manager.save_checkpoint(
+                model=model_state_dict,
+                optimizer=self.optimizers,
+                scheduler=self.lr_schedulers,
+                step=current_step,
+                total_steps=total_steps,
+                remain_samples_num=remain_samples_num,
+                is_final=is_final,
+            )
+            self.ckpt_manager.save_check(step=current_step)
+        finally:
+            if use_ema_weights:
+                self.model.ema.copy_temp_to(self.trainable_params)
+
     def step_training(
         self,
         rollouts: List[Rollout],
@@ -790,43 +834,11 @@ class NFTTrainer(DiffusersTrainer):
 
         # Checkpointing
         if is_master_replica and (do_save_checkpoint):
-            is_last_step = current_step == total_steps
-            # Save the ema weights if ema is enabled, and restore the current weights after saving the checkpoint
-            if self.config.train.ema_enable and self.model.ema is not None:
-                self.model.ema.copy_ema_to(self.trainable_params, store_temp=True)
-
-            if is_last_step or self.config.train.ckpt.export_safetensors:
-                logger.info(
-                    f"[Policy] Saving huggingface checkpoint at step {current_step} to {self.config.train.output_dir}..."
-                )
-                self.export_safetensors(
-                    output_dir=self.config.train.output_dir,
-                    rel_path=os.path.join(
-                        "safetensors",
-                        f"step_{current_step}",
-                    ),
-                    trainable_only=False,
-                    is_final=is_last_step,
-                    dtype=str2torch_dtype(self.config.train.param_dtype),
-                )
-
-            logger.info(f"[Policy] Saving cosmos checkpoint at step {current_step}...")
-            model_state_dict = self.model.get_trained_model_state_dict()
-            self.ckpt_manager.save_checkpoint(
-                model=model_state_dict,
-                optimizer=self.optimizers,
-                scheduler=self.lr_schedulers,
-                step=current_step,
+            self.save_checkpoint(
+                current_step=current_step,
                 total_steps=total_steps,
-                **{
-                    "remain_samples_num": remain_samples_num,
-                    "is_final": is_last_step,
-                },
+                remain_samples_num=remain_samples_num,
+                is_final=current_step == total_steps,
             )
-            self.ckpt_manager.save_check(step=current_step)
-
-            # Restore current weights after saving ema weights to checkpoint
-            if self.config.train.ema_enable and self.model.ema is not None:
-                self.model.ema.copy_temp_to(self.trainable_params)
 
         return report_data

--- a/cosmos_rl/policy/trainer/llm_trainer/grpo_trainer.py
+++ b/cosmos_rl/policy/trainer/llm_trainer/grpo_trainer.py
@@ -937,6 +937,43 @@ class GRPOTrainer(LLMTrainer):
             del self.teacher_interact_results[id]
         self.fetched_teacher_uuids.clear()
 
+    def should_export_checkpoint(self, *, is_final: bool) -> bool:
+        return is_final or self.config.train.ckpt.export_safetensors
+
+    def save_checkpoint(
+        self,
+        current_step: int,
+        total_steps: int,
+        remain_samples_num: int,
+        *,
+        is_final: bool,
+    ) -> None:
+        if self.should_export_checkpoint(is_final=is_final):
+            logger.info(
+                f"[Policy] Saving huggingface checkpoint at step {current_step} to {self.config.train.output_dir}..."
+            )
+            self.export_safetensors(
+                output_dir=self.config.train.output_dir,
+                rel_path=os.path.join(
+                    "safetensors",
+                    f"step_{current_step}",
+                ),
+                trainable_only=False,
+                is_final=is_final,
+                dtype=str2torch_dtype(self.config.train.param_dtype),
+            )
+        logger.info(f"[Policy] Saving cosmos checkpoint at step {current_step}...")
+        self.ckpt_manager.save_checkpoint(
+            model=self.model,
+            optimizer=self.optimizers,
+            scheduler=self.lr_schedulers,
+            step=current_step,
+            total_steps=total_steps,
+            remain_samples_num=remain_samples_num,
+            is_final=is_final,
+        )
+        self.ckpt_manager.save_check(step=current_step)
+
     def step_training(
         self,
         rollouts: List[Rollout],
@@ -1881,34 +1918,12 @@ class GRPOTrainer(LLMTrainer):
 
         # checkpointing
         if is_master_replica and (do_save_checkpoint):
-            is_last_step = current_step == total_steps
-            if is_last_step or self.config.train.ckpt.export_safetensors:
-                logger.info(
-                    f"[Policy] Saving huggingface checkpoint at step {current_step} to {self.config.train.output_dir}..."
-                )
-                self.export_safetensors(
-                    output_dir=self.config.train.output_dir,
-                    rel_path=os.path.join(
-                        "safetensors",
-                        f"step_{current_step}",
-                    ),
-                    trainable_only=False,
-                    is_final=is_last_step,
-                    dtype=str2torch_dtype(self.config.train.param_dtype),
-                )
-            logger.info(f"[Policy] Saving cosmos checkpoint at step {current_step}...")
-            self.ckpt_manager.save_checkpoint(
-                model=self.model,
-                optimizer=self.optimizers,
-                scheduler=self.lr_schedulers,
-                step=current_step,
+            self.save_checkpoint(
+                current_step=current_step,
                 total_steps=total_steps,
-                **{
-                    "remain_samples_num": remain_samples_num,
-                    "is_final": is_last_step,
-                },
+                remain_samples_num=remain_samples_num,
+                is_final=current_step == total_steps,
             )
-            self.ckpt_manager.save_check(step=current_step)
 
         self.reference_reset(current_step)
 

--- a/cosmos_rl/policy/trainer/vla_trainer/pi_grpo_trainer.py
+++ b/cosmos_rl/policy/trainer/vla_trainer/pi_grpo_trainer.py
@@ -17,7 +17,6 @@
 
 from __future__ import annotations
 
-import os
 import time
 from typing import Any, Dict, List
 
@@ -28,13 +27,16 @@ from cosmos_rl.policy.trainer.base import TrainerRegistry
 from cosmos_rl.policy.trainer.llm_trainer.grpo_trainer import GRPOTrainer
 from cosmos_rl.utils.distributed import HighAvailabilitylNccl
 from cosmos_rl.utils.logging import logger
-from cosmos_rl.utils.util import is_master_rank, str2torch_dtype
+from cosmos_rl.utils.util import is_master_rank
 
 
 @TrainerRegistry.register(trainer_type="grpo_pi05")
 class PI05GRPOTrainer(GRPOTrainer):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
+
+    def should_export_checkpoint(self, *, is_final: bool) -> bool:
+        return self.config.train.ckpt.export_safetensors
 
     def step_training(
         self,
@@ -235,25 +237,10 @@ class PI05GRPOTrainer(GRPOTrainer):
             report_data["train_step"] = int(current_step)
 
         if is_master_replica and do_save_checkpoint:
-            if self.config.train.ckpt.export_safetensors:
-                self.export_safetensors(
-                    output_dir=self.config.train.output_dir,
-                    rel_path=os.path.join(
-                        "safetensors",
-                        f"step_{current_step}",
-                    ),
-                    trainable_only=False,
-                    is_final=current_step == total_steps,
-                    dtype=str2torch_dtype(self.config.train.param_dtype),
-                )
-            self.ckpt_manager.save_checkpoint(
-                model=self.model,
-                optimizer=self.optimizers,
-                scheduler=self.lr_schedulers,
-                step=current_step,
+            self.save_checkpoint(
+                current_step=current_step,
                 total_steps=total_steps,
                 remain_samples_num=remain_samples_num,
                 is_final=current_step == total_steps,
             )
-            self.ckpt_manager.save_check(step=current_step)
         return report_data

--- a/cosmos_rl/policy/trainer/vla_trainer/vla_trainer.py
+++ b/cosmos_rl/policy/trainer/vla_trainer/vla_trainer.py
@@ -15,9 +15,8 @@
 
 from typing import Dict, Any, List
 import torch
-import os
 
-from cosmos_rl.utils.util import is_master_rank, str2torch_dtype
+from cosmos_rl.utils.util import is_master_rank
 from cosmos_rl.policy.trainer.llm_trainer.grpo_trainer import GRPOTrainer
 from cosmos_rl.dispatcher.data.schema import Rollout
 from cosmos_rl.policy.trainer.base import TrainerRegistry
@@ -35,6 +34,9 @@ class OpenVLAGRPOTrainer(GRPOTrainer):
             **kwargs: Keyword arguments for the base GRPOTrainer.
         """
         super().__init__(*args, **kwargs)
+
+    def should_export_checkpoint(self, *, is_final: bool) -> bool:
+        return self.config.train.ckpt.export_safetensors
 
     def step_training(
         self,
@@ -183,25 +185,10 @@ class OpenVLAGRPOTrainer(GRPOTrainer):
             report_data["train_step"] = int(current_step)
 
         if is_master_replica and do_save_checkpoint:
-            if self.config.train.ckpt.export_safetensors:
-                self.export_safetensors(
-                    output_dir=self.config.train.output_dir,
-                    rel_path=os.path.join(
-                        "safetensors",
-                        f"step_{current_step}",
-                    ),
-                    trainable_only=False,
-                    is_final=current_step == total_steps,
-                    dtype=str2torch_dtype(self.config.train.param_dtype),
-                )
-            self.ckpt_manager.save_checkpoint(
-                model=self.model,
-                optimizer=self.optimizers,
-                scheduler=self.lr_schedulers,
-                step=current_step,
+            self.save_checkpoint(
+                current_step=current_step,
                 total_steps=total_steps,
                 remain_samples_num=remain_samples_num,
                 is_final=current_step == total_steps,
             )
-            self.ckpt_manager.save_check(step=current_step)
         return report_data

--- a/cosmos_rl/policy/worker/rl_worker.py
+++ b/cosmos_rl/policy/worker/rl_worker.py
@@ -600,6 +600,52 @@ class RLPolicyWorker(PolicyWorkerBase):
             f"[Policy] Training complete at global step {command.global_step}, skip training."
         )
 
+        save_requested = command.do_save and self.is_master_replica
+        if save_requested:
+
+            def all_ranks_succeeded(error: Optional[Exception]) -> bool:
+                return bool(
+                    dist_util.all_reduce_tensor_object_cpu(
+                        torch.tensor([1 if error is None else 0], dtype=torch.int32),
+                        op=dist.ReduceOp.MIN,
+                    ).item()
+                )
+
+            invalidation_error: Optional[Exception] = None
+            try:
+                self.trainer.invalidate_checkpoint_completion(command.final_step)
+            except Exception as error:
+                invalidation_error = error
+
+            if not all_ranks_succeeded(invalidation_error):
+                if invalidation_error is not None:
+                    raise invalidation_error
+                raise RuntimeError(
+                    "Final checkpoint invalidation failed on another rank in "
+                    "the policy replica"
+                )
+
+            save_error: Optional[Exception] = None
+            try:
+                self.trainer.save_checkpoint(
+                    current_step=command.final_step,
+                    total_steps=command.checkpoint_total_steps,
+                    remain_samples_num=command.remain_samples_num,
+                    is_final=True,
+                )
+            except Exception as error:
+                # Every rank must reach the agreement below even when its
+                # local shard/future fails, or rank 0 could ACK an incomplete
+                # distributed checkpoint.
+                save_error = error
+
+            if not all_ranks_succeeded(save_error):
+                if save_error is not None:
+                    raise save_error
+                raise RuntimeError(
+                    "Final checkpoint failed on another rank in the policy replica"
+                )
+
         self.profiler.step()
 
         if is_master_rank(self.parallel_dims, self.global_rank):

--- a/cosmos_rl/rollout/trtllm_rollout/trtllm_rollout_wrapper.py
+++ b/cosmos_rl/rollout/trtllm_rollout/trtllm_rollout_wrapper.py
@@ -16,6 +16,7 @@
 import torch
 import atexit
 import threading
+import time
 from queue import Queue
 from typing import List, Tuple, Optional, Any, Callable, Union
 from torch.utils.data import Dataset
@@ -257,17 +258,26 @@ class TRTLLMRolloutWrapper(TRTLLMRolloutWorkerBase):
         Send end signal to the controller.
         This is used to notify the controller that the rollout worker has finished processing all prompts.
         """
+        if getattr(self, "_rollout_end_acknowledged", False):
+            return True
+
         payloads, is_validation, _, empty = self.report_rollouts(block=True)
         assert not is_validation and payloads is None and empty, (
             f"Payloads must be empty and not for validation when sending end signal {is_validation}, {payloads}, {empty}"
         )
         response = RolloutRequest(
             src_replica_name=self.replica_name,
+            # This wrapper aggregates the TRT-LLM executor replica. Its inner
+            # ranks keep polling commands until explicit STOP.
+            stays_command_participant=True,
             payloads=[],
             is_end=True,
         )
         logger.info(f"[Rollout] Posting rollout end signal to controller: {response}")
-        self.api_client.post_rollout_completion(response)
+        self._rollout_end_acknowledged = bool(
+            self.api_client.post_rollout_completion(response)
+        )
+        return self._rollout_end_acknowledged
 
     @torch.no_grad()
     def main_loop(self):
@@ -378,6 +388,8 @@ class TRTLLMRolloutWrapper(TRTLLMRolloutWorkerBase):
                 assert self._prompt_queue.empty() and self.state.prompt_fetch_end(), (
                     "[Rollout] If prompt are all consumed, prompt queue should be empty and prompt end event should be set."
                 )
+                if not self.send_end_signal():
+                    time.sleep(0.1)
                 continue
             elif self._prompt_queue.empty():
                 continue

--- a/cosmos_rl/rollout/trtllm_rollout/trtllm_worker.py
+++ b/cosmos_rl/rollout/trtllm_rollout/trtllm_worker.py
@@ -34,6 +34,7 @@ from cosmos_rl.dispatcher.command import (
     BuildMeshCommand,
     PolicyToRolloutUnicastCommand,
     RolloutToRolloutBroadcastCommand,
+    StopCommand,
     Command,
 )
 from cosmos_rl.utils.pynccl import (
@@ -559,6 +560,16 @@ class CosmosTRTLLMWorker(TrtLLMRolloutWorker, PyExecutor):
             self.cosmos_weight_sync_queue.put(ShutdownInstruction())
             self.shutdown_signal.set()
             self.shutdown_mp_signal.set()
+
+    @TRTLLMRolloutWorkerBase.register_rollout_command_handler(
+        StopCommand, backend="trtllm"
+    )
+    def handle_stop(self, command: StopCommand) -> None:
+        """Stop the executor ranks and notify the single-process wrapper."""
+        if self.global_rank == 0:
+            self.cosmos_weight_sync_queue.put(ShutdownInstruction())
+        self.shutdown_signal.set()
+        self.shutdown_mp_signal.set()
 
     def query_command_from_controller(self):
         """Background task to check commands from the controller"""

--- a/cosmos_rl/rollout/worker/rollout_control.py
+++ b/cosmos_rl/rollout/worker/rollout_control.py
@@ -184,6 +184,7 @@ class DisaggregatedRolloutControlWorker(RolloutWorkerBase):
         self._prompt_fetch_lock = threading.Lock()
         self.prefetch_thread: Optional[threading.Thread] = None
         self.current_weight_version = 0
+        self._rollout_end_acknowledged = False
 
         # determine the quantization type
         self.quantization_type = None
@@ -526,6 +527,15 @@ class DisaggregatedRolloutControlWorker(RolloutWorkerBase):
         could not reach).  No NCCL collective is involved, and teardown's
         bounded ``cleanup_ucxx`` still lets any in-flight output read drain.
         """
+        wst = getattr(self, "_weight_sync_thread", None)
+        if wst is not None:
+            fenced = wst.fence()
+            if not fenced:
+                logger.error(
+                    "[ABNORMAL teardown] WeightSyncThread fence failed for %s; "
+                    "continuing shutdown after the bounded abort path",
+                    self.replica_name,
+                )
         logger.info(
             "[Rollout] Received STOP from controller for %s; setting shutdown signal.",
             self.replica_name,
@@ -535,19 +545,30 @@ class DisaggregatedRolloutControlWorker(RolloutWorkerBase):
 
     @RolloutWorkerBase.register_rollout_command_handler(BuildMeshCommand)
     def build_global_mesh(self, build_mesh_command: BuildMeshCommand):
-        # If this replica is already draining (prompt source exhausted),
-        # skip the NCCL mesh rebuild -- entering the collective would
-        # deadlock the peers that join while we exit shortly without
-        # them.  The controller-side filter on ``status.ended`` is the
-        # primary defence; this guard handles the race where a
-        # BuildMeshCommand was queued before that filter took effect.
-        if self.state.prompt_consume_end():
+        # Ranked-ended disaggregated workers remain command participants until
+        # STOP, so every rank in such a replica must accept topology rebuilds.
+        # Keep only the single-process delivery-failure escape: that worker is
+        # already shutting down and the controller never acknowledged it.
+        if (
+            self.state.prompt_consume_end()
+            and getattr(self.parallel_dims, "world_size", 1) == 1
+            and not getattr(self, "_rollout_end_acknowledged", False)
+        ):
             logger.info(
                 "[Rollout] Skipping BuildMeshCommand for %s: prompt "
-                "source exhausted, this replica is draining.",
+                "source exhausted without an acknowledged checkout.",
                 self.replica_name,
             )
+            mesh_ready = getattr(self, "_mesh_rebuild_ready", None)
+            if mesh_ready is not None:
+                mesh_ready.set()
             return
+
+        wst = getattr(self, "_weight_sync_thread", None)
+        if wst is not None and not wst.fence():
+            raise RuntimeError(
+                "Weight-sync work did not drain before rollout mesh rebuild"
+            )
         logger.info(f"[Rollout] Building global mesh for {self.replica_name}")
 
         replica_name_to_rank = build_mesh_command.replica_name_to_rank
@@ -561,6 +582,9 @@ class DisaggregatedRolloutControlWorker(RolloutWorkerBase):
 
         if len(replica_name_to_rank) == 1:
             # only one rollout replica now, no need to build mesh.
+            mesh_ready = getattr(self, "_mesh_rebuild_ready", None)
+            if mesh_ready is not None:
+                mesh_ready.set()
             return
         # generate key for storing the NCCL group id.
         # group_0: [rank 0 in replica 0, rank 0 in replica 1, ..., rank 0 in replica n-1]
@@ -596,6 +620,9 @@ class DisaggregatedRolloutControlWorker(RolloutWorkerBase):
         self.global_commnicator_idex = create_nccl_comm(
             nccl_group_id, self.rank_in_rollout_repicas, len(replica_name_to_rank)
         )
+        mesh_ready = getattr(self, "_mesh_rebuild_ready", None)
+        if mesh_ready is not None:
+            mesh_ready.set()
 
     def query_nccl_unique_id_from_controller(self, unique_id_key: str):
         # We don't have something like dist.barrier(), so just use while True loop to query it like synchronize.
@@ -1605,6 +1632,15 @@ class DisaggregatedRolloutControlWorker(RolloutWorkerBase):
                 command = Command.depack(instruction)
                 logger.debug(f"[Rollout] Received command: {command.command_type}")
 
+                if isinstance(command, BuildMeshCommand):
+                    mesh_ready = threading.Event()
+                    self._mesh_rebuild_ready = mesh_ready
+                    self._command_queue.put(command)
+                    while not mesh_ready.wait(timeout=0.1):
+                        if self.shutdown_signal.is_set():
+                            return
+                    continue
+
                 wst = getattr(self, "_weight_sync_thread", None)
                 if wst is not None and isinstance(
                     command, PolicyToRolloutUnicastCommand
@@ -1831,17 +1867,35 @@ class DisaggregatedRolloutControlWorker(RolloutWorkerBase):
         Send end signal to the controller.
         This is used to notify the controller that the rollout worker has finished processing all prompts.
         """
+        if self._rollout_end_acknowledged:
+            return True
+
         payloads, is_validation, _, empty = self.report_rollouts(block=True)
         assert not is_validation and payloads is None and empty, (
             f"Payloads must be empty and not for validation when sending end signal {is_validation}, {payloads}, {empty}"
         )
         response = RolloutRequest(
             src_replica_name=self.replica_name,
+            src_global_rank=self.global_rank,
             payloads=[],
             is_end=True,
         )
         logger.info(f"[Rollout] Posting rollout end signal to controller: {response}")
-        self.api_client.post_rollout_completion(response)
+        self._rollout_end_acknowledged = bool(
+            self.api_client.post_rollout_completion(response)
+        )
+
+        # Disaggregated workers whose end POST was acknowledged stay in the
+        # command loop until the controller's explicit StopCommand.  Preserve
+        # the existing local escape only when a single-process worker cannot
+        # reach the controller, and for colocated mode, which has no separate
+        # rollout StopCommand channel.
+        if self.parallel_dims.world_size == 1 and (
+            self.config.mode == "colocated" or not self._rollout_end_acknowledged
+        ):
+            self.shutdown_signal.set()
+
+        return self._rollout_end_acknowledged
 
     def dynamic_sampling(self, payloads: List[RLPayload]):
         """
@@ -2160,7 +2214,7 @@ class DisaggregatedRolloutControlWorker(RolloutWorkerBase):
                         self.state.set_prompt_fetch_end()
                         if self._prompt_queue.empty():
                             self.state.set_prompt_consume_end()
-                            if self.global_rank == 0:
+                            if self.should_report:
                                 self.send_end_signal()
                         break
                     # Controller had nothing to hand out right now: stop
@@ -2174,31 +2228,8 @@ class DisaggregatedRolloutControlWorker(RolloutWorkerBase):
                     "[Rollout] If prompt are all consumed, prompt queue should be empty and prompt end event should be set."
                 )
                 self._mainloop_branch_counts["consume_end"] += 1
-                # Mirror the async-rollout generation path
-                # (``stream_generation_step``, used when
-                # ``config.rollout.mode == "async"`` and the backend is
-                # in ``SUPPORT_ASYNC_BACKEND``): that method already
-                # calls ``self.shutdown_signal.set()`` at the analogous
-                # ``prompt_consume_end()`` site.  Without setting it
-                # here too, the default sync path leaves worker threads
-                # spinning on this branch waiting for an external
-                # ``shutdown`` broadcast that may never arrive (e.g.
-                # when the controller has already crashed).
-                #
-                # Scope the self-terminate to single-process workers
-                # (``world_size == 1``).  In a multi-rank worker the
-                # final prompt batch is scattered round-robin and
-                # *unevenly* across DP ranks, so ranks reach
-                # ``consume_end`` on different iterations.  If the first
-                # rank to drain set ``shutdown_signal`` and left
-                # ``main_loop`` here, it would strand its peers in the
-                # next cross-rank collective -> deadlock.  Multi-rank
-                # workers therefore keep the proven controller-broadcast
-                # lockstep shutdown; only single-process workers (the
-                # prefetch / bench regime that motivated this) take the
-                # self-terminate fast path.
-                if self.parallel_dims.world_size == 1:
-                    self.shutdown_signal.set()
+                if self.should_report:
+                    self.send_end_signal()
                 continue
             elif self._prompt_queue.empty():
                 # In single-producer mode the queue draining + a
@@ -2214,7 +2245,7 @@ class DisaggregatedRolloutControlWorker(RolloutWorkerBase):
                 if self._single_producer_mode:
                     if self.state.prompt_fetch_end():
                         self.state.set_prompt_consume_end()
-                        if self.global_rank == 0:
+                        if self.should_report:
                             self.send_end_signal()
                     else:
                         time.sleep(0.05)
@@ -2266,7 +2297,7 @@ class DisaggregatedRolloutControlWorker(RolloutWorkerBase):
 
                 if self.state.prompt_fetch_end() and self._prompt_queue.empty():
                     self.state.set_prompt_consume_end()
-                    if self.global_rank == 0:
+                    if self.should_report:
                         self.send_end_signal()
         logger.info(f"[Rollout] Main loop of {self.replica_name} finished")
 
@@ -2554,20 +2585,9 @@ class DisaggregatedRolloutControlWorker(RolloutWorkerBase):
 
         # Check if all prompts are consumed, if so, send end signal to the controller.
         if self.state.prompt_consume_end():
-            # Send end signal to the controller
-            # Because we first report_rollouts() to the controller, so we don't need to check the reward_dispatcher queue here.
-            #
-            # Scope the self-terminate to single-process workers
-            # (``world_size == 1``); see the matching guard in the
-            # synchronous ``_main_loop_impl`` consume-end branch.  A
-            # multi-rank async worker would otherwise strand its peers
-            # in the next cross-rank collective when the first rank to
-            # exhaust its (unevenly scattered) prompt share leaves
-            # ahead of the others.  Multi-rank workers shut down via
-            # the controller stop-broadcast instead.
-            if self.parallel_dims.world_size == 1:
-                self.shutdown_signal.set()
-            if self.global_rank == 0:
+            # Each reporting rank owns an independent reward dispatcher;
+            # flush it and report that rank's local drain exactly once.
+            if self.should_report:
                 self.send_end_signal()
 
     def enqueue_teacher_calculation(self, payloads: List[RLPayload]) -> List[RLPayload]:

--- a/cosmos_rl/rollout/worker/weight_sync.py
+++ b/cosmos_rl/rollout/worker/weight_sync.py
@@ -64,6 +64,7 @@ from torch.distributed.tensor import DTensor
 from cosmos_rl.utils.logging import logger
 from cosmos_rl.utils.pynccl import (
     bounded_drain_or_abort,
+    nccl_abort_all,
     nccl_broadcast,
     nccl_group_end,
     nccl_group_start,
@@ -76,6 +77,9 @@ from cosmos_rl.utils.pynccl import (
 # ``stop()`` (and in turn ``destroy_distributed``) cannot wedge.
 _WST_STREAM_DRAIN_TIMEOUT_S = float(
     os.getenv("COSMOS_WST_STREAM_DRAIN_TIMEOUT_S", "10.0")
+)
+_WST_QUEUE_DRAIN_TIMEOUT_S = float(
+    os.getenv("COSMOS_WST_QUEUE_DRAIN_TIMEOUT_S", "120.0")
 )
 
 if TYPE_CHECKING:
@@ -383,6 +387,9 @@ class WeightSyncThread:
         self._idle = threading.Event()
         self._idle.set()
         self._last_event: torch.cuda.Event | None = None
+        self._fence_failed = False
+        self._fenced_seq = -1
+        self._task_failed = False
         # Backlog observability (see weight-sync coalescing plan): high-water
         # queue depth and total executed transfers.  A healthy (coalesced) run
         # keeps ``_max_qdepth`` ~1; a piled-up run shows it climbing while most
@@ -436,10 +443,30 @@ class WeightSyncThread:
             self._max_qdepth,
         )
 
-    def drain(self, timeout: float = 120.0) -> None:
-        """Block until the queue is empty and no operation is in-flight."""
-        if not self._thread.is_alive():
-            return
+    def fence(
+        self,
+        queue_timeout: float = _WST_QUEUE_DRAIN_TIMEOUT_S,
+        stream_timeout: float = _WST_STREAM_DRAIN_TIMEOUT_S,
+    ) -> bool:
+        """Fence every command received before STOP.
+
+        Queue completion only proves that the background thread has enqueued
+        the CUDA work.  The stream fence is therefore ordered strictly after
+        ``queue.join()``.  A queue timeout is an abnormal teardown path: abort
+        NCCL, attempt the bounded stream drain, and report failure instead of
+        allowing the caller to treat a warning as successful synchronization.
+        """
+        if getattr(self, "_fence_failed", False):
+            return False
+
+        current_seq = getattr(self, "_seq", None)
+        if (
+            current_seq is not None
+            and getattr(self, "_fenced_seq", None) == current_seq
+            and getattr(self._queue, "unfinished_tasks", 1) == 0
+        ):
+            return True
+
         done = threading.Event()
 
         def _join_with_timeout():
@@ -448,36 +475,75 @@ class WeightSyncThread:
 
         t = threading.Thread(target=_join_with_timeout, daemon=True)
         t.start()
-        if not done.wait(timeout=timeout):
-            logger.warning(
-                "[WeightSyncThread] drain() timed out after %.1fs",
-                timeout,
+        queue_drained = done.wait(timeout=queue_timeout)
+        if not queue_drained:
+            logger.error(
+                "[ABNORMAL teardown] WeightSyncThread[%s] queue did not "
+                "drain within %.1fs; aborting NCCL before shutdown",
+                self._worker.replica_name,
+                queue_timeout,
             )
+            try:
+                nccl_abort_all()
+            except Exception:
+                logger.exception(
+                    "[WeightSyncThread] NCCL abort failed after queue timeout"
+                )
 
-    def stop(self) -> None:
+        stream_drained = bounded_drain_or_abort(
+            self._stream,
+            stream_timeout,
+            f"WeightSyncThread[{self._worker.replica_name}]",
+        )
+        result = (
+            queue_drained
+            and stream_drained
+            and not getattr(self, "_task_failed", False)
+        )
+        self._fence_failed = not result
+        self._fenced_seq = current_seq
+        return result
+
+    def drain(self, timeout: float = _WST_QUEUE_DRAIN_TIMEOUT_S) -> bool:
+        """Compatibility wrapper for the full queue-and-stream fence."""
+        return self.fence(queue_timeout=timeout)
+
+    def stop(self) -> bool:
         """Signal the thread to stop and wait for it to finish.
 
-        The Python thread joining is not sufficient: a grouped R2R broadcast
+        A Python thread join is not sufficient: a grouped R2R broadcast
         enqueued on ``self._stream`` runs asynchronously on the GPU, and pynccl
         only bounds the *enqueue* phase (``run_task`` stops polling after
-        ``ncclSuccess``).  If a peer already departed, that broadcast kernel can
-        hang on the device while this thread reports ``thread_alive=False`` --
-        which later wedges any device sync (``inference_stream.synchronize()``)
-        and ``destroy_distributed``.  After joining we therefore bounded-drain
-        the stream and, on timeout, abort all NCCL communicators.
+        ``ncclSuccess``).  Fence the queue and stream before asking the thread
+        to exit so no accepted task is dropped; timeout paths abort NCCL and
+        report failure.
         """
+        fenced = self.fence()
         self._stop.set()
         if self._thread.is_alive():
             self._thread.join(timeout=10.0)
-        # Backstop for an orphaned in-flight R2R broadcast on our stream (peer
-        # departed mid-collective).  Should never fire once the controller waits
-        # for all rollouts to check out before shutting down; logs loudly if it
-        # does.  See ``bounded_drain_or_abort``.
-        bounded_drain_or_abort(
+        if self._thread.is_alive():
+            logger.error(
+                "[ABNORMAL teardown] WeightSyncThread[%s] did not stop "
+                "within 10s; aborting NCCL",
+                self._worker.replica_name,
+            )
+            try:
+                nccl_abort_all()
+            except Exception:
+                logger.exception(
+                    "[WeightSyncThread] NCCL abort failed after thread timeout"
+                )
+            fenced = False
+        # A timed-out task can leave its barrier only after _stop is set. Drain
+        # once more after the thread exits so no CUDA work can appear behind
+        # the earlier timeout-path drain.
+        post_stop_drained = bounded_drain_or_abort(
             self._stream,
             _WST_STREAM_DRAIN_TIMEOUT_S,
-            f"WeightSyncThread[{self._worker.replica_name}]",
+            f"WeightSyncThread[{self._worker.replica_name}] post-stop",
         )
+        return fenced and post_stop_drained
 
     def _run(self) -> None:
         torch.cuda.set_device(self._worker.device)
@@ -497,6 +563,7 @@ class WeightSyncThread:
                 elif cmd_type == "r2r":
                     self._execute_r2r(command)
             except Exception:
+                self._task_failed = True
                 logger.exception(
                     "[WeightSyncThread] Error executing %s command",
                     cmd_type,
@@ -546,13 +613,26 @@ class WeightSyncThread:
         # Use the controller's authoritative recipient set for this round as the
         # barrier participant count so it stays in lockstep as replicas finish.
         expected_world_size = len(getattr(command, "dst_replica_names", None) or [])
-        r2r_barrier(worker, weight_step, expected_world_size=expected_world_size)
+        if expected_world_size > 1 and not r2r_barrier(
+            worker, weight_step, expected_world_size=expected_world_size
+        ):
+            logger.info(
+                "[WeightSyncThread] R2R cancelled during teardown (step=%s)",
+                weight_step,
+            )
+            return
         t0 = time.monotonic()
-        transferred_cnt, bytes_broadcast = do_nccl_broadcast_grouped(
-            worker,
-            command.src_replica_name,
-            self._stream,
-        )
+        if expected_world_size <= 1:
+            # BuildMesh intentionally creates no NCCL communicator for one
+            # replica. P2R already populated its buffer; retain R2R's version
+            # and validation bookkeeping without touching a stale communicator.
+            transferred_cnt, bytes_broadcast = 0, 0
+        else:
+            transferred_cnt, bytes_broadcast = do_nccl_broadcast_grouped(
+                worker,
+                command.src_replica_name,
+                self._stream,
+            )
         self._last_event = torch.cuda.Event()
         self._last_event.record(self._stream)
         worker._buffer_version += 1
@@ -669,7 +749,7 @@ def setup_redis_barrier(worker) -> None:
 
 def r2r_barrier(
     worker, weight_step: int, expected_world_size: Optional[int] = None
-) -> None:
+) -> bool:
     """Redis-based barrier so all rollout workers start R2R broadcast together.
 
     Uses an atomic INCR counter per weight step.  The last worker to arrive
@@ -694,7 +774,7 @@ def r2r_barrier(
             worker, "_r2r_world_size", 0
         )
     if r2r_redis is None or world_size <= 1:
-        return
+        return True
 
     prefix = worker._r2r_barrier_prefix
     barrier_key = f"{prefix}:barrier:{weight_step}"
@@ -713,7 +793,7 @@ def r2r_barrier(
                 world_size,
                 weight_step,
             )
-            return
+            return True
 
         logger.info(
             "[R2R Barrier] Waiting for other workers (count=%d/%d, step=%d)...",
@@ -736,7 +816,7 @@ def r2r_barrier(
                     world_size,
                     elapsed_ms,
                 )
-                return
+                return True
 
             # Allow teardown to interrupt the wait: if the WeightSyncThread is
             # asked to stop, abort the barrier rather than blocking ``wst.stop()``
@@ -751,7 +831,7 @@ def r2r_barrier(
                         "aborting barrier.",
                         weight_step,
                     )
-                    return
+                    return False
                 msg = pubsub.get_message(timeout=1.0)
                 if msg is not None and msg.get("type") == "message":
                     break
@@ -772,8 +852,10 @@ def r2r_barrier(
             weight_step,
             elapsed_ms,
         )
+        return True
     except Exception as exc:
         logger.warning("[R2R Barrier] Redis error (%s); skipping barrier.", exc)
+        return True
 
 
 # ---------------------------------------------------------------------------

--- a/cosmos_rl/utils/checkpoint.py
+++ b/cosmos_rl/utils/checkpoint.py
@@ -415,6 +415,29 @@ class CheckpointMananger:
                 state_dict_cpu[key] = value
         return state_dict_cpu
 
+    def _wait_for_pending_async_saves(self) -> None:
+        """Wait for pending saves and propagate any background failure."""
+        if not self.pre_save_futures:
+            return
+        futures.wait(self.pre_save_futures)
+        for future in self.pre_save_futures:
+            future.result()
+        self.pre_save_futures = []
+
+    def invalidate_completion_marker(self, step: int) -> None:
+        """Remove this rank's marker before a same-step checkpoint rewrite."""
+        if self.save_mode == "async" and self.pre_save_futures:
+            self._wait_for_pending_async_saves()
+
+        marker_path = os.path.join(
+            self.ckpt_output_dir,
+            f"step_{step}",
+            "policy",
+            f".rank_{self.global_rank}_complete",
+        )
+        if os.path.exists(marker_path):
+            os.remove(marker_path)
+
     def finalize(self) -> None:
         """Wait for any pending async checkpoint saves/uploads to finish.
         This should be called before process exit to avoid losing uploads when
@@ -469,6 +492,14 @@ class CheckpointMananger:
 
         is_final = kwargs.get("is_final", False)
         cur_step_ckpt_dir = os.path.join(f"step_{step}", "policy")
+
+        complete_marker_path = os.path.join(
+            self.ckpt_output_dir,
+            cur_step_ckpt_dir,
+            f".rank_{self.global_rank}_complete",
+        )
+        self.invalidate_completion_marker(step)
+
         os.makedirs(
             os.path.join(self.ckpt_output_dir, cur_step_ckpt_dir), exist_ok=True
         )
@@ -512,13 +543,6 @@ class CheckpointMananger:
                 "Unsupport model type, should either be a torch.nn.Module or dict"
             )
 
-        # Path for the complete marker file
-        complete_marker_path = os.path.join(
-            self.ckpt_output_dir,
-            cur_step_ckpt_dir,
-            f".rank_{self.global_rank}_complete",
-        )
-
         if self.save_mode == "async":
 
             def _write_complete_marker_after_saves(futures_to_wait, marker_path):
@@ -528,12 +552,6 @@ class CheckpointMananger:
                 # All saves completed, write the complete marker
                 with open(marker_path, "w") as f:
                     f.write("")
-
-            # wait for the previous save to finish
-            if len(self.pre_save_futures) > 0:
-                for future in futures.as_completed(self.pre_save_futures):
-                    future.result()
-                self.pre_save_futures = []
 
             # offload the state dict to CPU
             model_state_dict_cpu = self.offload_state_dict_cpu(state_dict)
@@ -586,9 +604,7 @@ class CheckpointMananger:
             self.pre_save_futures = save_futures + [complete_marker_future]
 
             if is_final:
-                # wait for all futures to complete before returning for final save
-                futures.wait(self.pre_save_futures)
-                self.pre_save_futures = []
+                self._wait_for_pending_async_saves()
         else:  # sync
             _save_upload(state_dict, model_ckpt_path, is_final)
             _save_upload(optimizer.state_dict(), optimizer_ckpt_path, is_final)
@@ -759,33 +775,33 @@ class CheckpointMananger:
     def save_check(self, step: int, **kwargs):
         if self._is_master_rank():
             step_ckpt_path = os.path.join(self.ckpt_output_dir, f"step_{step}")
+            step_ckpt_abs_path = os.path.abspath(step_ckpt_path)
+            self.saved_ckpt_step_dirs = [
+                saved_dir
+                for saved_dir in self.saved_ckpt_step_dirs
+                if os.path.abspath(saved_dir) != step_ckpt_abs_path
+            ]
             self.saved_ckpt_step_dirs.append(step_ckpt_path)
             # remove the old checkpoints
             # expected behavior:
             # Keep the best checkpoint, and delete the oldest checkpoint if the number of
             # checkpoints exceeds the max_keep.
-            # If the best checkpoint is the oldest checkpoint, delete the second oldest checkpoint.
+            # Never delete the checkpoint that was just saved. If all older checkpoints
+            # are protected as best, temporarily exceed max_keep.
             if len(self.saved_ckpt_step_dirs) > self.max_keep and self.max_keep != -1:
-                oldest_dir = self.saved_ckpt_step_dirs[0]  # peek
-                step_to_delete = None
-
-                if (
-                    self._is_ckpt_dir_linked_as_best(oldest_dir)
-                    and len(self.saved_ckpt_step_dirs) > 1
-                ):
-                    # Best is oldest, delete second oldest instead
-                    self.saved_ckpt_step_dirs.pop(0)  # remove best temporarily
-                    step_to_delete = self.saved_ckpt_step_dirs.pop(0)
-                    self.saved_ckpt_step_dirs.insert(0, oldest_dir)  # put best back
-                    logger.info(
-                        f"Best checkpoint is at {oldest_dir}, "
-                        f"deleting {step_to_delete} instead"
-                    )
-                else:
-                    step_to_delete = self.saved_ckpt_step_dirs.pop(0)
-                    logger.info(f"Deleting {step_to_delete}")
+                step_to_delete = next(
+                    (
+                        saved_dir
+                        for saved_dir in self.saved_ckpt_step_dirs
+                        if os.path.abspath(saved_dir) != step_ckpt_abs_path
+                        and not self._is_ckpt_dir_linked_as_best(saved_dir)
+                    ),
+                    None,
+                )
 
                 if step_to_delete is not None:
+                    self.saved_ckpt_step_dirs.remove(step_to_delete)
+                    logger.info(f"Deleting {step_to_delete}")
                     if self.save_mode == "async" and hasattr(self, "executor"):
                         self.pre_save_futures.append(
                             self.executor.submit(
@@ -794,6 +810,11 @@ class CheckpointMananger:
                         )
                     else:
                         self._delete_checkpoint(step_to_delete)
+                else:
+                    logger.info(
+                        "Keeping both the current and best checkpoints; "
+                        "checkpoint count temporarily exceeds max_keep"
+                    )
 
             val_score = kwargs.get("val_score", None)
             if val_score is not None:

--- a/tests/run_test.sh
+++ b/tests/run_test.sh
@@ -78,8 +78,8 @@ run python tests/test_dataset_signature.py
 run python tests/test_put_rollouts.py
 run python tests/test_trajectory_iteration.py
 run python tests/test_gym_example.py
-# pytest-style suite (CPU-only); install pytest in case the image lacks it.
-run /bin/bash -c "python -m pip install --quiet pytest && python -m pytest -q tests/test_weight_sync.py"
+# Pytest-style CPU suites; install pytest in case the image lacks it.
+run /bin/bash -c "python -m pip install --quiet pytest && python -m pytest -q tests/test_weight_sync.py tests/test_checkpoint.py tests/test_ranked_rollout_end_and_wst_fence.py tests/test_terminal_checkpoint_trainer_hooks.py tests/test_terminal_drain_protocol.py tests/test_training_complete_checkpoint.py"
 run python -m unittest -v tests.contracts.test_trainer_metrics_contract
 run python -m unittest -v tests.contracts.test_config_routing_contract
 run python -m unittest -v tests.contracts.test_model_registry_contract

--- a/tests/test_checkpoint.py
+++ b/tests/test_checkpoint.py
@@ -18,7 +18,9 @@ import json
 import os
 import shutil
 import tempfile
+import threading
 import unittest
+from concurrent import futures
 
 import torch
 import torch.distributed as dist
@@ -360,6 +362,214 @@ class TestCheckpointManager(unittest.TestCase):
         self.assertFalse(os.path.exists(os.path.join(ckpt_dir, "step_100")))
         self.assertTrue(os.path.exists(os.path.join(ckpt_dir, "step_200")))
         self.assertTrue(os.path.exists(os.path.join(ckpt_dir, "step_300")))
+
+    def test_final_async_save_propagates_background_failure(self):
+        """A final save must not report success when an async write fails."""
+        output_dir = os.path.join(self.test_dir, self.timestamp1)
+        config = create_test_config(
+            output_dir=output_dir, resume=False, save_mode="async"
+        )
+        manager = CheckpointMananger(
+            config,
+            parallel_dims=create_test_parallel_dims(),
+            global_rank=0,
+        )
+
+        model = {"unpicklable": (item for item in ())}
+        parameter = torch.nn.Parameter(torch.zeros(1))
+        optimizer = torch.optim.Adam([parameter], lr=0.001)
+
+        try:
+            with self.assertRaises(Exception):
+                manager.save_checkpoint(
+                    model,
+                    optimizer,
+                    SimpleScheduler(),
+                    step=100,
+                    total_steps=100,
+                    is_final=True,
+                )
+        finally:
+            manager.finalize()
+
+    def test_async_rewrite_waits_for_prior_failure_before_writing(self):
+        """A failed prior save must abort a rewrite before files are replaced."""
+        output_dir = os.path.join(self.test_dir, self.timestamp1)
+        config = create_test_config(
+            output_dir=output_dir, resume=False, save_mode="async"
+        )
+        manager = CheckpointMananger(
+            config,
+            parallel_dims=create_test_parallel_dims(),
+            global_rank=0,
+        )
+        parameter = torch.nn.Parameter(torch.zeros(1))
+        optimizer = torch.optim.Adam([parameter], lr=0.001)
+
+        manager.save_checkpoint(
+            {"unpicklable": (item for item in ())},
+            optimizer,
+            SimpleScheduler(),
+            step=100,
+            total_steps=100,
+        )
+        config_path = os.path.join(
+            output_dir, "checkpoints", "step_100", "policy", "cosmos_config"
+        )
+        sentinel = "prior save failed"
+        with open(config_path, "w") as config_file:
+            config_file.write(sentinel)
+
+        try:
+            with self.assertRaises(Exception):
+                manager.save_checkpoint(
+                    SimpleModel(),
+                    optimizer,
+                    SimpleScheduler(),
+                    step=100,
+                    total_steps=100,
+                    is_final=True,
+                )
+            with open(config_path, "r") as config_file:
+                self.assertEqual(config_file.read(), sentinel)
+        finally:
+            manager.finalize()
+
+    def test_invalidation_waits_for_prior_async_marker(self):
+        """Invalidation must remove a marker written by an older async save."""
+        output_dir = os.path.join(self.test_dir, self.timestamp1)
+        config = create_test_config(
+            output_dir=output_dir, resume=False, save_mode="async"
+        )
+        manager = CheckpointMananger(
+            config,
+            parallel_dims=create_test_parallel_dims(),
+            global_rank=0,
+        )
+        marker_path = os.path.join(
+            output_dir,
+            "checkpoints",
+            "step_100",
+            "policy",
+            ".rank_0_complete",
+        )
+        os.makedirs(os.path.dirname(marker_path), exist_ok=True)
+        marker_future_started = threading.Event()
+        release_marker_future = threading.Event()
+
+        def write_delayed_marker():
+            marker_future_started.set()
+            release_marker_future.wait()
+            with open(marker_path, "w") as marker_file:
+                marker_file.write("")
+
+        manager.pre_save_futures = [manager.executor.submit(write_delayed_marker)]
+        with futures.ThreadPoolExecutor(max_workers=1) as executor:
+            invalidation = executor.submit(manager.invalidate_completion_marker, 100)
+            self.assertTrue(marker_future_started.wait(timeout=5))
+            self.assertFalse(invalidation.done())
+            release_marker_future.set()
+            invalidation.result(timeout=5)
+
+        self.assertFalse(os.path.exists(marker_path))
+        manager.finalize()
+
+    def test_same_step_rewrite_removes_only_its_stale_completion_marker(self):
+        """A failed rewrite must not leave this rank looking complete."""
+        output_dir = os.path.join(self.test_dir, self.timestamp1)
+        config = create_test_config(output_dir=output_dir, resume=False)
+        manager = CheckpointMananger(
+            config,
+            parallel_dims=create_test_parallel_dims(),
+            global_rank=0,
+        )
+        model = SimpleModel()
+        optimizer = torch.optim.Adam(model.parameters(), lr=0.001)
+        scheduler = SimpleScheduler()
+        manager.save_checkpoint(model, optimizer, scheduler, step=100, total_steps=100)
+
+        policy_dir = os.path.join(output_dir, "checkpoints", "step_100", "policy")
+        rank_zero_marker = os.path.join(policy_dir, ".rank_0_complete")
+        rank_one_marker = os.path.join(policy_dir, ".rank_1_complete")
+        with open(rank_one_marker, "w") as marker_file:
+            marker_file.write("")
+
+        with self.assertRaises(ValueError):
+            manager.save_checkpoint(
+                object(),
+                optimizer,
+                scheduler,
+                step=100,
+                total_steps=100,
+                is_final=True,
+            )
+
+        self.assertFalse(os.path.exists(rank_zero_marker))
+        self.assertTrue(os.path.exists(rank_one_marker))
+
+    def test_same_step_final_promotion_is_retained_with_max_keep_one(self):
+        """Promoting a retained step must not prune that same checkpoint."""
+        output_dir = os.path.join(self.test_dir, self.timestamp1)
+        config = create_test_config(output_dir=output_dir, resume=False, max_keep=1)
+        manager = CheckpointMananger(
+            config,
+            parallel_dims=create_test_parallel_dims(),
+            global_rank=0,
+        )
+        model = SimpleModel()
+        optimizer = torch.optim.Adam(model.parameters(), lr=0.001)
+        scheduler = SimpleScheduler()
+
+        manager.save_checkpoint(model, optimizer, scheduler, step=100, total_steps=100)
+        manager.save_check(100)
+        manager.save_checkpoint(
+            model,
+            optimizer,
+            scheduler,
+            step=100,
+            total_steps=100,
+            is_final=True,
+        )
+        manager.save_check(100)
+
+        step_path = os.path.join(output_dir, "checkpoints", "step_100")
+        self.assertTrue(os.path.isdir(step_path))
+        self.assertEqual(manager.saved_ckpt_step_dirs, [step_path])
+
+    def test_final_promotion_is_not_deleted_when_only_other_checkpoint_is_best(self):
+        """Retention must preserve both the best and just-promoted checkpoints."""
+        output_dir = os.path.join(self.test_dir, self.timestamp1)
+        config = create_test_config(output_dir=output_dir, resume=False, max_keep=1)
+        manager = CheckpointMananger(
+            config,
+            parallel_dims=create_test_parallel_dims(),
+            global_rank=0,
+            metric="val_loss",
+        )
+        model = SimpleModel()
+        optimizer = torch.optim.Adam(model.parameters(), lr=0.001)
+        scheduler = SimpleScheduler()
+
+        manager.save_checkpoint(model, optimizer, scheduler, step=50, total_steps=100)
+        manager.save_check(50, val_score=0.1)
+        manager.save_checkpoint(model, optimizer, scheduler, step=100, total_steps=100)
+        manager.save_check(100, val_score=0.2)
+
+        manager.save_checkpoint(
+            model,
+            optimizer,
+            scheduler,
+            step=100,
+            total_steps=100,
+            is_final=True,
+        )
+        manager.save_check(100)
+
+        best_path = os.path.join(output_dir, "checkpoints", "step_50")
+        final_path = os.path.join(output_dir, "checkpoints", "step_100")
+        self.assertTrue(os.path.isdir(best_path))
+        self.assertTrue(os.path.isdir(final_path))
+        self.assertEqual(manager.saved_ckpt_step_dirs, [best_path, final_path])
 
     def _state_dicts_equal(self, sd1, sd2):
         """Helper to compare two state dicts."""

--- a/tests/test_multirank_shutdown.py
+++ b/tests/test_multirank_shutdown.py
@@ -381,21 +381,21 @@ def _replica(name, ended, start_time):
 
 
 class _RolloutMgrStub:
-    def __init__(self, replicas):
+    def __init__(self, replicas, ranked_ended=()):
         self._replicas = replicas
+        self._command_participant_ended_replicas = set(ranked_ended)
         self.rollout_atoms_in_replica = 1
 
     def get_all_atoms_arrived_replicas(self):
         return list(self._replicas)
 
+    get_safe_weight_sync_replicas = RolloutStatusManager.get_safe_weight_sync_replicas
 
-class TestTriggerWeightSyncExcludesEnded(unittest.TestCase):
-    """Corners 1-3: the controller must not issue P2R/R2R to a rollout
-    that has already POSTed ``is_end`` (and is self-terminating), unless
-    validation is enabled (then the rollout stays for the final
-    validation and must keep receiving the sync)."""
 
-    def _run(self, replicas, validation_enabled):
+class TestTriggerWeightSyncTopology(unittest.TestCase):
+    """R2R recipients must match a communicator whose members stay alive."""
+
+    def _run(self, replicas, validation_enabled, ranked_ended=()):
         mgr = PolicyStatusManager()
         mgr.config = SimpleNamespace(
             validation=SimpleNamespace(enable=validation_enabled)
@@ -403,7 +403,7 @@ class TestTriggerWeightSyncExcludesEnded(unittest.TestCase):
         mgr.policy_atoms_in_replica = 1
         mgr.redis_handler = object()
         policy_replica = _replica("policy-0", ended=False, start_time=0)
-        rollout_mgr = _RolloutMgrStub(replicas)
+        rollout_mgr = _RolloutMgrStub(replicas, ranked_ended)
 
         with (
             patch(
@@ -431,19 +431,19 @@ class TestTriggerWeightSyncExcludesEnded(unittest.TestCase):
         p2r.assert_not_called()
         r2r.assert_not_called()
 
-    def test_mixed_excludes_only_ended(self):
-        """Live + ended replicas, validation off -> sync targets only the
-        live replica (ended dropped from P2R target and R2R recipients)."""
+    def test_ranked_ended_replica_keeps_full_topology(self):
         live = _replica("r-live", ended=False, start_time=1)
         ended = _replica("r-ended", ended=True, start_time=0)
-        p2r, r2r = self._run([live, ended], validation_enabled=False)
+        p2r, r2r = self._run(
+            [live, ended],
+            validation_enabled=False,
+            ranked_ended={"r-ended"},
+        )
         p2r.assert_called_once()
         r2r.assert_called_once()
-        # P2R unicast target is the (only) live replica.
-        self.assertIs(p2r.call_args.kwargs["dst_replica"], live)
-        # R2R recipient list excludes the ended replica.
+        self.assertIs(p2r.call_args.kwargs["dst_replica"], ended)
         dst_replicas = r2r.call_args.kwargs["dst_replicas"]
-        self.assertEqual(dst_replicas, [live])
+        self.assertEqual(dst_replicas, [ended, live])
 
     def test_ended_included_when_validation_enabled(self):
         """Validation on -> exclusion disabled; ended replica still synced
@@ -961,7 +961,7 @@ class TestQueryCommandStopsAfterStop(unittest.TestCase):
 # Controller -- JobPhase end-of-data model
 # ---------------------------------------------------------------------------
 class TestJobPhaseEnterDraining(unittest.TestCase):
-    def test_first_is_end_enters_draining_and_recomputes(self):
+    def test_last_is_end_enters_draining_and_freezes_horizon(self):
         recompute_args = []
 
         def _recompute(explicit_num_remaining_samples=None):
@@ -969,13 +969,17 @@ class TestJobPhaseEnterDraining(unittest.TestCase):
 
         psm = SimpleNamespace(
             job_phase=JobPhase.RUNNING,
-            total_pending_rollouts=lambda: 8,
+            total_steps=10,
+            draining_total_steps=None,
             recompute_total_steps=_recompute,
         )
         psm.enter_draining_phase = PolicyStatusManager.enter_draining_phase.__get__(psm)
         psm.enter_draining_phase()
         self.assertEqual(psm.job_phase, JobPhase.DRAINING)
-        self.assertEqual(recompute_args, [8])
+        self.assertEqual(psm.draining_total_steps, 10)
+        psm.total_steps = 99
+        self.assertEqual(psm.draining_total_steps, 10)
+        self.assertEqual(recompute_args, [])
 
     def test_second_enter_stays_draining(self):
         recompute_args = []
@@ -985,7 +989,8 @@ class TestJobPhaseEnterDraining(unittest.TestCase):
 
         psm = SimpleNamespace(
             job_phase=JobPhase.DRAINING,
-            total_pending_rollouts=lambda: 4,
+            total_steps=10,
+            draining_total_steps=10,
             recompute_total_steps=_recompute,
         )
         psm.enter_draining_phase = PolicyStatusManager.enter_draining_phase.__get__(psm)
@@ -1028,6 +1033,7 @@ class TestJobPhaseWeightSync(unittest.TestCase):
             all_rollouts_ended=lambda: False,
             rollout_replicas={"r0": ended, "r1": live},
             get_all_atoms_arrived_replicas=lambda: [ended, live],
+            get_safe_weight_sync_replicas=lambda **_kwargs: [ended, live],
         )
         psm.should_weight_sync_after_train_ack = (
             PolicyStatusManager.should_weight_sync_after_train_ack.__get__(psm)
@@ -1052,6 +1058,7 @@ class TestJobPhaseWeightSync(unittest.TestCase):
             all_rollouts_ended=lambda: True,
             rollout_replicas={"r0": ended},
             get_all_atoms_arrived_replicas=lambda: [ended],
+            get_safe_weight_sync_replicas=lambda **_kwargs: [ended],
         )
         psm.should_weight_sync_after_train_ack = (
             PolicyStatusManager.should_weight_sync_after_train_ack.__get__(psm)
@@ -1082,118 +1089,6 @@ class TestJobPhaseWeightSync(unittest.TestCase):
         self.assertFalse(psm.should_weight_sync_after_train_ack(1, rsm))
 
 
-class TestJobPhaseFinishDraining(unittest.TestCase):
-    def test_finish_triggers_training_complete_when_buffer_empty(self):
-        training_complete = []
-        recompute_calls = []
-
-        def _recompute(explicit_num_remaining_samples=None):
-            recompute_calls.append(explicit_num_remaining_samples)
-            psm.total_steps = psm.current_step
-
-        def _trigger_training_complete():
-            training_complete.append(True)
-
-        psm = SimpleNamespace(
-            total_steps=10,
-            current_step=9,
-            policy_replicas={},
-            total_pending_rollouts=lambda: 0,
-            all_ready_or_reduced=lambda: True,
-            recompute_total_steps=_recompute,
-            trigger_training_complete=_trigger_training_complete,
-            rollout_buffer=SimpleNamespace(queue=SimpleNamespace(clear=lambda: None)),
-            config=SimpleNamespace(train=SimpleNamespace(train_batch_per_replica=8)),
-            get_all_atoms_arrived_replicas=lambda: [object()],
-        )
-        psm.finish_draining_phase = PolicyStatusManager.finish_draining_phase.__get__(
-            psm
-        )
-        rsm = SimpleNamespace(all_rollouts_ended=lambda: True)
-        psm.finish_draining_phase(rsm)
-        self.assertEqual(recompute_calls, [0])
-        self.assertEqual(psm.total_steps, 10)
-        self.assertEqual(training_complete, [True])
-
-    def test_finish_happen_to_finish_skips_when_buffer_empty(self):
-        """When the buffer is already drained, no TrainingComplete is needed."""
-        training_complete = []
-
-        psm = SimpleNamespace(
-            total_steps=3,
-            current_step=3,
-            total_pending_rollouts=lambda: 0,
-            recompute_total_steps=lambda **kw: None,
-            trigger_training_complete=lambda: training_complete.append(True),
-            rollout_buffer=SimpleNamespace(queue=SimpleNamespace(clear=lambda: None)),
-            config=SimpleNamespace(train=SimpleNamespace(train_batch_per_replica=8)),
-            get_all_atoms_arrived_replicas=lambda: [object()],
-        )
-        psm.finish_draining_phase = PolicyStatusManager.finish_draining_phase.__get__(
-            psm
-        )
-        psm.finish_draining_phase(SimpleNamespace(all_rollouts_ended=lambda: True))
-        self.assertEqual(training_complete, [])
-
-    def test_finish_buffered_rollouts_triggers_training_complete(self):
-        """Regression: buffered rollouts at the final step must still dispatch."""
-        cleared = []
-        training_complete = []
-        queue = SimpleNamespace(clear=lambda: cleared.append(True))
-
-        psm = SimpleNamespace(
-            total_steps=3,
-            current_step=3,
-            policy_replicas={},
-            total_pending_rollouts=lambda: 8,
-            all_ready_or_reduced=lambda: True,
-            recompute_total_steps=lambda **kw: None,
-            trigger_training_complete=lambda: training_complete.append(True),
-            rollout_buffer=SimpleNamespace(queue=queue),
-            config=SimpleNamespace(train=SimpleNamespace(train_batch_per_replica=8)),
-            get_all_atoms_arrived_replicas=lambda: [object()],
-        )
-        psm.finish_draining_phase = PolicyStatusManager.finish_draining_phase.__get__(
-            psm
-        )
-        psm.finish_draining_phase(SimpleNamespace(all_rollouts_ended=lambda: True))
-        self.assertEqual(cleared, [True])
-        self.assertEqual(psm.total_steps, 4)
-        self.assertEqual(training_complete, [True])
-
-    def test_finish_defers_when_buffer_can_fill_remaining_steps(self):
-        """Do not fire TrainingComplete while a full step of rollouts waits."""
-        training_complete = []
-
-        psm = SimpleNamespace(
-            total_steps=3,
-            current_step=2,
-            policy_replicas={},
-            total_pending_rollouts=lambda: 16,
-            all_ready_or_reduced=lambda: True,
-            trigger_training_complete=lambda: training_complete.append(True),
-            rollout_buffer=SimpleNamespace(
-                queue=SimpleNamespace(
-                    clear=lambda: (_ for _ in ()).throw(
-                        AssertionError("buffer should not be cleared")
-                    )
-                )
-            ),
-            config=SimpleNamespace(train=SimpleNamespace(train_batch_per_replica=8)),
-            get_all_atoms_arrived_replicas=lambda: [object()],
-        )
-
-        def _recompute(**_kw):
-            psm.total_steps = 2
-
-        psm.recompute_total_steps = _recompute
-        psm.finish_draining_phase = PolicyStatusManager.finish_draining_phase.__get__(
-            psm
-        )
-        psm.finish_draining_phase(SimpleNamespace(all_rollouts_ended=lambda: True))
-        self.assertEqual(training_complete, [])
-
-
 class TestJobPhaseValidationBypass(unittest.TestCase):
     def test_on_rollout_is_end_noop_when_validation_enabled(self):
         psm = SimpleNamespace(
@@ -1217,6 +1112,8 @@ class TestTrainingCompleteCommand(unittest.TestCase):
             "policy-0",
             global_step=3,
             total_steps=3,
+            final_step=2,
+            checkpoint_total_steps=7,
             remain_samples_num=0,
         )
         restored = Command.depack(cmd.pack())
@@ -1224,107 +1121,13 @@ class TestTrainingCompleteCommand(unittest.TestCase):
         self.assertEqual(restored.replica_name, "policy-0")
         self.assertEqual(restored.global_step, 3)
         self.assertEqual(restored.total_steps, 3)
+        self.assertEqual(restored.final_step, 2)
+        self.assertEqual(restored.checkpoint_total_steps, 7)
         self.assertEqual(restored.command_type, "TRAINING_COMPLETE")
-
-    def test_trigger_training_complete_dispatch(self):
-        triggered = []
-        replica = SimpleNamespace(
-            name="policy-0",
-            sub_profiler_config=SimpleNamespace(
-                do_profile=False,
-                active_steps=None,
-                rank_filter=None,
-                record_shape=None,
-                profile_memory=None,
-                with_stack=None,
-                with_modules=None,
-            ),
-        )
-
-        def fake_trigger(**kwargs):
-            triggered.append(kwargs)
-
-        psm = SimpleNamespace(
-            data_fetcher=SimpleNamespace(activated_val_iter=None),
-            current_step=2,
-            total_steps=3,
-            remain_samples_num=0,
-            dispatched_rollouts_by_step={},
-            config=SimpleNamespace(
-                validation=SimpleNamespace(enable=False, freq=1),
-                train=SimpleNamespace(
-                    ckpt=SimpleNamespace(
-                        enable_checkpoint=False, save_freq=1, save_freq_in_epoch=None
-                    ),
-                    epoch=1,
-                ),
-            ),
-            redis_handler=object(),
-            get_all_atoms_arrived_replicas=lambda: [replica],
-            training_finished=lambda: False,
-            check_checkpoint_saving=lambda n: False,
-            set_status=lambda name, status: None,
-        )
-        psm.trigger_training_complete = (
-            PolicyStatusManager.trigger_training_complete.__get__(psm)
-        )
-        with patch.object(TrainingCompleteCommand, "trigger", fake_trigger):
-            psm.trigger_training_complete()
-        self.assertEqual(psm.current_step, 3)
-        self.assertEqual(psm.dispatched_rollouts_by_step[3], 0)
-        self.assertEqual(len(triggered), 1)
-        self.assertEqual(triggered[0]["global_step"], 3)
-
-    def test_finish_draining_calls_training_complete(self):
-        calls = []
-
-        def _trigger():
-            calls.append(True)
-
-        psm = SimpleNamespace(
-            total_steps=10,
-            current_step=9,
-            policy_replicas={},
-            total_pending_rollouts=lambda: 0,
-            all_ready_or_reduced=lambda: True,
-            recompute_total_steps=lambda **kw: setattr(
-                psm, "total_steps", psm.current_step
-            ),
-            trigger_training_complete=_trigger,
-            rollout_buffer=SimpleNamespace(queue=SimpleNamespace(clear=lambda: None)),
-            config=SimpleNamespace(train=SimpleNamespace(train_batch_per_replica=8)),
-            get_all_atoms_arrived_replicas=lambda: [object()],
-        )
-        psm.finish_draining_phase = PolicyStatusManager.finish_draining_phase.__get__(
-            psm
-        )
-        psm.finish_draining_phase(SimpleNamespace(all_rollouts_ended=lambda: True))
-        self.assertEqual(calls, [True])
-
-    def test_finish_draining_defers_while_policy_in_flight(self):
-        calls = []
-
-        psm = SimpleNamespace(
-            total_steps=1,
-            current_step=1,
-            policy_replicas={"p0": SimpleNamespace(status="running")},
-            total_pending_rollouts=lambda: 8,
-            all_ready_or_reduced=lambda: False,
-            recompute_total_steps=lambda **kw: None,
-            trigger_training_complete=lambda: calls.append(True),
-            rollout_buffer=SimpleNamespace(queue=SimpleNamespace(clear=lambda: None)),
-            config=SimpleNamespace(train=SimpleNamespace(train_batch_per_replica=8)),
-            get_all_atoms_arrived_replicas=lambda: [object()],
-        )
-        psm.finish_draining_phase = PolicyStatusManager.finish_draining_phase.__get__(
-            psm
-        )
-        psm.finish_draining_phase(SimpleNamespace(all_rollouts_ended=lambda: True))
-        self.assertEqual(calls, [])
 
 
 class TestOnRolloutIsEndSequence(unittest.TestCase):
-    def test_enter_once_finish_only_when_all_ended(self):
+    def test_finish_only_when_all_ended(self):
         enter_count = []
         finish_count = []
 
@@ -1343,14 +1146,14 @@ class TestOnRolloutIsEndSequence(unittest.TestCase):
 
         rsm_partial = SimpleNamespace(all_rollouts_ended=lambda: False)
         psm.on_rollout_is_end(rsm_partial)
-        self.assertEqual(enter_count, [1])
-        self.assertEqual(finish_count, [False])
-        self.assertEqual(psm.job_phase, JobPhase.DRAINING)
+        self.assertEqual(enter_count, [])
+        self.assertEqual(finish_count, [])
+        self.assertEqual(psm.job_phase, JobPhase.RUNNING)
 
         rsm_all = SimpleNamespace(all_rollouts_ended=lambda: True)
         psm.on_rollout_is_end(rsm_all)
-        self.assertEqual(enter_count, [1])
-        self.assertEqual(finish_count, [False, True])
+        self.assertEqual(enter_count, [])
+        self.assertEqual(finish_count, [True])
 
 
 class TestTrainAckDuringPartialDrain(unittest.TestCase):
@@ -1374,45 +1177,6 @@ class TestTrainAckDuringPartialDrain(unittest.TestCase):
             PolicyStatusManager.should_weight_sync_after_train_ack.__get__(psm)
         )
         self.assertFalse(psm.should_weight_sync_after_train_ack(2, rsm))
-
-
-class TestEndOfDataRecomputeUsesBufferOnly(unittest.TestCase):
-    """Regression: ``enter_draining_phase`` uses ``total_pending_rollouts`` only."""
-
-    def test_recompute_uses_buffer_count_on_first_is_end(self):
-        from cosmos_rl.dispatcher import run_web_panel
-
-        recompute_args = []
-
-        def _recompute(explicit_num_remaining_samples=None):
-            recompute_args.append(explicit_num_remaining_samples)
-
-        psm = SimpleNamespace(
-            job_phase=JobPhase.RUNNING,
-            config=SimpleNamespace(validation=SimpleNamespace(enable=False)),
-            total_steps=10,
-            current_step=10,
-            total_pending_rollouts=lambda: 8,
-            recompute_total_steps=_recompute,
-            finish_draining_phase=lambda rsm: None,
-        )
-        psm.enter_draining_phase = PolicyStatusManager.enter_draining_phase.__get__(psm)
-        psm.on_rollout_is_end = PolicyStatusManager.on_rollout_is_end.__get__(psm)
-        rsm = SimpleNamespace(
-            rollout_end=lambda name: None,
-            all_rollouts_ended=lambda: False,
-        )
-        fake_controller = SimpleNamespace(
-            rollout_status_manager=rsm,
-            policy_status_manager=psm,
-        )
-        req = SimpleNamespace(
-            is_end=True, src_replica_name="r0", payloads=[], metrics={}
-        )
-        with patch.object(run_web_panel, "controller", fake_controller):
-            asyncio.run(run_web_panel.put_rollout_group(req))
-        self.assertEqual(recompute_args, [8])
-        self.assertEqual(psm.job_phase, JobPhase.DRAINING)
 
 
 if __name__ == "__main__":

--- a/tests/test_ranked_rollout_end_and_wst_fence.py
+++ b/tests/test_ranked_rollout_end_and_wst_fence.py
@@ -1,0 +1,444 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-License-Identifier: Apache-2.0
+
+import threading
+import time
+from queue import Queue
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from cosmos_rl.colocated.api_client import ColocatedAPIClient
+from cosmos_rl.dispatcher.api.client import APIClient
+from cosmos_rl.dispatcher.command import (
+    BuildMeshCommand,
+    Command,
+    RolloutToRolloutBroadcastCommand,
+    StopCommand,
+)
+from cosmos_rl.dispatcher.protocol import RolloutRequest
+from cosmos_rl.rollout.worker.rollout_control import DisaggregatedRolloutControlWorker
+from cosmos_rl.rollout.worker import weight_sync
+from cosmos_rl.rollout.worker.weight_sync import WeightSyncThread
+
+
+def test_rollout_end_request_supports_ranked_and_legacy_reporters():
+    ranked = RolloutRequest(
+        src_replica_name="rollout-0",
+        src_global_rank=7,
+        payloads=[],
+        is_end=True,
+    )
+    legacy = RolloutRequest(
+        src_replica_name="rollout-0",
+        payloads=[],
+        is_end=True,
+    )
+
+    assert ranked.src_global_rank == 7
+    assert legacy.src_global_rank is None
+
+
+def test_http_rollout_end_reports_controller_acknowledgement():
+    client = object.__new__(APIClient)
+    client.max_retries = 1
+    client.get_alternative_urls = lambda _suffix: ["http://controller/rollout"]
+    request = RolloutRequest(
+        src_replica_name="rollout-0",
+        src_global_rank=7,
+        payloads=[],
+        is_end=True,
+    )
+
+    with patch(
+        "cosmos_rl.dispatcher.api.client.make_request_with_retry"
+    ) as make_request:
+        acknowledged = client.post_rollout_completion(request)
+
+    assert acknowledged is True
+    assert make_request.call_count == 1
+
+
+def test_http_rollout_end_reports_failed_delivery():
+    client = object.__new__(APIClient)
+    client.max_retries = 1
+    client.get_alternative_urls = lambda _suffix: ["http://controller/rollout"]
+    request = RolloutRequest(
+        src_replica_name="rollout-0",
+        src_global_rank=7,
+        payloads=[],
+        is_end=True,
+    )
+
+    with patch(
+        "cosmos_rl.dispatcher.api.client.make_request_with_retry",
+        side_effect=RuntimeError("controller unavailable"),
+    ):
+        acknowledged = client.post_rollout_completion(request)
+
+    assert acknowledged is False
+
+
+def test_colocated_rollout_end_reports_synchronous_acknowledgement():
+    client = object.__new__(ColocatedAPIClient)
+    client.controller = MagicMock()
+    request = RolloutRequest(
+        src_replica_name="rollout-0",
+        src_global_rank=7,
+        payloads=[],
+        is_end=True,
+    )
+
+    acknowledged = client.post_rollout_completion(request)
+
+    assert acknowledged is True
+    client.controller.put_rollouts.assert_called_once_with(request)
+
+
+def _rollout_end_worker(
+    *,
+    acknowledged: bool | list[bool],
+    mode: str = "disaggregated",
+    world_size: int = 1,
+):
+    calls = []
+    requests = []
+    acknowledgements = iter(acknowledged) if isinstance(acknowledged, list) else None
+
+    def report_rollouts(*, block):
+        calls.append(("flush", block))
+        return None, False, None, True
+
+    def post_rollout_completion(request):
+        calls.append(("post", request.src_global_rank))
+        requests.append(request)
+        if acknowledgements is not None:
+            return next(acknowledgements)
+        return acknowledged
+
+    worker = SimpleNamespace(
+        api_client=SimpleNamespace(
+            post_rollout_completion=post_rollout_completion,
+        ),
+        config=SimpleNamespace(mode=mode),
+        global_rank=7,
+        parallel_dims=SimpleNamespace(world_size=world_size),
+        replica_name="rollout-0",
+        report_rollouts=report_rollouts,
+        should_report=True,
+        shutdown_signal=threading.Event(),
+        _rollout_end_acknowledged=False,
+    )
+    return worker, calls, requests
+
+
+def test_ranked_rollout_end_flushes_once_and_waits_for_stop_after_ack():
+    worker, calls, requests = _rollout_end_worker(acknowledged=True)
+
+    first = DisaggregatedRolloutControlWorker.send_end_signal(worker)
+    second = DisaggregatedRolloutControlWorker.send_end_signal(worker)
+
+    assert first is True
+    assert second is True
+    assert calls == [("flush", True), ("post", 7)]
+    assert requests[0].src_replica_name == "rollout-0"
+    assert requests[0].src_global_rank == 7
+    assert requests[0].is_end is True
+    assert not worker.shutdown_signal.is_set()
+
+
+def test_failed_disaggregated_end_preserves_single_process_escape():
+    worker, _, _ = _rollout_end_worker(acknowledged=False)
+
+    acknowledged = DisaggregatedRolloutControlWorker.send_end_signal(worker)
+
+    assert acknowledged is False
+    assert worker.shutdown_signal.is_set()
+
+
+def test_failed_multirank_end_retries_until_acknowledged():
+    worker, calls, requests = _rollout_end_worker(
+        acknowledged=[False, True],
+        world_size=2,
+    )
+
+    first = DisaggregatedRolloutControlWorker.send_end_signal(worker)
+    assert first is False
+    assert worker._rollout_end_acknowledged is False
+    assert not worker.shutdown_signal.is_set()
+
+    second = DisaggregatedRolloutControlWorker.send_end_signal(worker)
+    third = DisaggregatedRolloutControlWorker.send_end_signal(worker)
+
+    assert second is True
+    assert third is True
+    assert worker._rollout_end_acknowledged is True
+    assert calls == [
+        ("flush", True),
+        ("post", 7),
+        ("flush", True),
+        ("post", 7),
+    ]
+    assert len(requests) == 2
+    assert not worker.shutdown_signal.is_set()
+
+
+def test_colocated_end_preserves_local_exit_after_ack():
+    worker, _, _ = _rollout_end_worker(acknowledged=True, mode="colocated")
+
+    acknowledged = DisaggregatedRolloutControlWorker.send_end_signal(worker)
+
+    assert acknowledged is True
+    assert worker.shutdown_signal.is_set()
+
+
+def test_drained_nonreporting_rank_accepts_one_member_mesh_rebuild():
+    worker = SimpleNamespace(
+        state=SimpleNamespace(prompt_consume_end=lambda: True),
+        parallel_dims=SimpleNamespace(world_size=2),
+        replica_name="rollout-0",
+    )
+    command = SimpleNamespace(replica_name_to_rank={"rollout-0": 0})
+
+    DisaggregatedRolloutControlWorker.build_global_mesh(worker, command)
+
+    assert worker.rank_in_rollout_repicas == 0
+    assert worker.replica_name_to_rank == {"rollout-0": 0}
+
+
+def test_mesh_rebuild_fences_weight_sync_and_releases_command_router():
+    mesh_ready = threading.Event()
+    wst = SimpleNamespace(fence=MagicMock(return_value=True))
+    worker = SimpleNamespace(
+        state=SimpleNamespace(prompt_consume_end=lambda: False),
+        parallel_dims=SimpleNamespace(world_size=1),
+        replica_name="rollout-0",
+        _weight_sync_thread=wst,
+        _mesh_rebuild_ready=mesh_ready,
+    )
+    command = BuildMeshCommand({"rollout-0": 0})
+
+    DisaggregatedRolloutControlWorker.build_global_mesh(worker, command)
+
+    wst.fence.assert_called_once_with()
+    assert mesh_ready.is_set()
+
+
+def test_command_router_does_not_overtake_mesh_rebuild():
+    mesh = BuildMeshCommand({"rollout-0": 0})
+    r2r = RolloutToRolloutBroadcastCommand(
+        "rollout-0",
+        ["rollout-0"],
+        weight_step=1,
+        total_steps=2,
+        trainable_only=False,
+    )
+    shutdown_signal = threading.Event()
+    wst = SimpleNamespace(
+        enqueue_p2r=MagicMock(),
+        enqueue_r2r=MagicMock(side_effect=lambda _command: shutdown_signal.set()),
+    )
+    command_queue = Queue()
+    worker = SimpleNamespace(
+        replica_name="rollout-0",
+        shutdown_signal=shutdown_signal,
+        redis_controller=SimpleNamespace(
+            subscribe_command=MagicMock(return_value=[b"mesh", b"r2r"])
+        ),
+        _command_queue=command_queue,
+        _weight_sync_thread=wst,
+    )
+
+    with patch.object(Command, "depack", side_effect=[mesh, r2r]):
+        router = threading.Thread(
+            target=DisaggregatedRolloutControlWorker.query_command_from_controller,
+            args=(worker,),
+        )
+        router.start()
+        assert command_queue.get(timeout=1) is mesh
+        wst.enqueue_r2r.assert_not_called()
+        worker._mesh_rebuild_ready.set()
+        router.join(timeout=1)
+
+    assert not router.is_alive()
+    wst.enqueue_r2r.assert_called_once_with(r2r)
+
+
+class _JoinQueue:
+    def __init__(self, join):
+        self.join = join
+
+
+def _weight_sync_thread(queue):
+    wst = object.__new__(WeightSyncThread)
+    wst._queue = queue
+    wst._stream = object()
+    wst._worker = SimpleNamespace(replica_name="rollout-0")
+    return wst
+
+
+def test_weight_sync_fence_waits_for_queue_before_cuda_stream():
+    order = []
+
+    def join_queue():
+        order.append("queue")
+
+    def drain_stream(_stream, _timeout, _context):
+        order.append("stream")
+        return True
+
+    wst = _weight_sync_thread(_JoinQueue(join_queue))
+    with patch.object(
+        weight_sync,
+        "bounded_drain_or_abort",
+        side_effect=drain_stream,
+    ):
+        fenced = wst.fence(queue_timeout=0.1, stream_timeout=0.1)
+
+    assert fenced is True
+    assert order == ["queue", "stream"]
+
+
+def test_weight_sync_queue_timeout_aborts_and_reports_failure():
+    order = []
+
+    def slow_join_queue():
+        order.append("queue")
+        time.sleep(0.1)
+
+    def abort_nccl():
+        order.append("abort")
+
+    def drain_stream(_stream, _timeout, _context):
+        order.append("stream")
+        return True
+
+    wst = _weight_sync_thread(_JoinQueue(slow_join_queue))
+    with (
+        patch.object(weight_sync, "nccl_abort_all", side_effect=abort_nccl),
+        patch.object(
+            weight_sync,
+            "bounded_drain_or_abort",
+            side_effect=drain_stream,
+        ),
+    ):
+        fenced = wst.fence(queue_timeout=0.01, stream_timeout=0.1)
+
+    assert fenced is False
+    assert order == ["queue", "abort", "stream"]
+
+
+def test_weight_sync_task_failure_makes_fence_fail():
+    wst = _weight_sync_thread(_JoinQueue(lambda: None))
+    wst._task_failed = True
+    with patch.object(
+        weight_sync,
+        "bounded_drain_or_abort",
+        return_value=True,
+    ):
+        assert wst.fence(queue_timeout=0.1, stream_timeout=0.1) is False
+
+
+def test_weight_sync_stop_always_performs_post_stop_stream_drain():
+    wst = object.__new__(WeightSyncThread)
+    wst.fence = MagicMock(return_value=False)
+    wst._stop = threading.Event()
+    wst._thread = SimpleNamespace(is_alive=lambda: False)
+    wst._stream = object()
+    wst._worker = SimpleNamespace(replica_name="rollout-0")
+
+    with patch.object(
+        weight_sync,
+        "bounded_drain_or_abort",
+        return_value=True,
+    ) as drain:
+        assert wst.stop() is False
+
+    drain.assert_called_once()
+    assert wst._stop.is_set()
+
+
+def test_cancelled_r2r_barrier_never_enqueues_nccl_work():
+    wst = object.__new__(WeightSyncThread)
+    wst._worker = SimpleNamespace(replica_name="rollout-0")
+    command = SimpleNamespace(
+        weight_step=3,
+        dst_replica_names=["rollout-0", "rollout-1"],
+    )
+
+    with (
+        patch.object(weight_sync, "r2r_barrier", return_value=False),
+        patch.object(weight_sync, "do_nccl_broadcast_grouped") as broadcast,
+    ):
+        wst._execute_r2r(command)
+
+    broadcast.assert_not_called()
+
+
+def test_one_member_async_r2r_updates_version_without_nccl():
+    state = SimpleNamespace(
+        weight_synced=lambda: False,
+        set_weight_synced=MagicMock(),
+    )
+    worker = SimpleNamespace(
+        replica_name="rollout-0",
+        _buffer_version=0,
+        current_weight_version=0,
+        state=state,
+        config=SimpleNamespace(
+            validation=SimpleNamespace(
+                enable=False,
+                val_before_train=False,
+                freq=1,
+            )
+        ),
+    )
+    wst = object.__new__(WeightSyncThread)
+    wst._worker = worker
+    wst._stream = object()
+    wst._queue = SimpleNamespace(qsize=lambda: 0)
+    wst._executed = 0
+    command = SimpleNamespace(
+        weight_step=3,
+        total_steps=5,
+        src_replica_name="rollout-0",
+        dst_replica_names=["rollout-0"],
+        replica_should_stop=lambda: False,
+    )
+
+    with (
+        patch.object(weight_sync, "do_nccl_broadcast_grouped") as broadcast,
+        patch.object(weight_sync.torch.cuda, "Event") as event,
+    ):
+        wst._execute_r2r(command)
+
+    broadcast.assert_not_called()
+    event.return_value.record.assert_called_once_with(wst._stream)
+    assert worker.current_weight_version == 3
+    state.set_weight_synced.assert_called_once_with()
+
+
+def test_stop_fences_weight_sync_before_setting_shutdown():
+    shutdown_signal = threading.Event()
+    shutdown_mp_signal = threading.Event()
+
+    def fence():
+        assert not shutdown_signal.is_set()
+        assert not shutdown_mp_signal.is_set()
+        return True
+
+    wst = SimpleNamespace(fence=MagicMock(side_effect=fence))
+    worker = SimpleNamespace(
+        _weight_sync_thread=wst,
+        replica_name="rollout-0",
+        shutdown_signal=shutdown_signal,
+        shutdown_mp_signal=shutdown_mp_signal,
+    )
+
+    DisaggregatedRolloutControlWorker.handle_stop(
+        worker,
+        StopCommand("rollout-0"),
+    )
+
+    wst.fence.assert_called_once_with()
+    assert shutdown_signal.is_set()
+    assert shutdown_mp_signal.is_set()

--- a/tests/test_terminal_checkpoint_trainer_hooks.py
+++ b/tests/test_terminal_checkpoint_trainer_hooks.py
@@ -1,0 +1,195 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import torch
+from types import SimpleNamespace
+
+from cosmos_rl.policy.trainer.base import Trainer
+from cosmos_rl.policy.trainer.diffusers_trainer.nft_trainer import NFTTrainer
+from cosmos_rl.policy.trainer.llm_trainer.grpo_trainer import GRPOTrainer
+from cosmos_rl.policy.trainer.vla_trainer.pi_grpo_trainer import PI05GRPOTrainer
+from cosmos_rl.policy.trainer.vla_trainer.vla_trainer import OpenVLAGRPOTrainer
+
+
+class _RecordingCheckpointManager:
+    def __init__(self):
+        self.checkpoints = []
+        self.completed_steps = []
+
+    def save_checkpoint(self, **kwargs):
+        self.checkpoints.append(kwargs)
+
+    def save_check(self, *, step):
+        self.completed_steps.append(step)
+
+
+class _FailingCheckpointManager(_RecordingCheckpointManager):
+    def save_checkpoint(self, **kwargs):
+        raise RuntimeError("checkpoint failed")
+
+
+class _RecordingEMA:
+    def __init__(self):
+        self.events = []
+
+    def copy_ema_to(self, params, *, store_temp):
+        self.events.append(("copy_ema_to", params, store_temp))
+
+    def copy_temp_to(self, params):
+        self.events.append(("copy_temp_to", params))
+
+
+class _NFTModel:
+    def __init__(self):
+        self.ema = _RecordingEMA()
+        self.state = object()
+
+    def get_trained_model_state_dict(self):
+        return self.state
+
+
+def _checkpoint_config(*, export_safetensors: bool):
+    return SimpleNamespace(
+        train=SimpleNamespace(
+            output_dir="/output",
+            param_dtype="float32",
+            ckpt=SimpleNamespace(export_safetensors=export_safetensors),
+        )
+    )
+
+
+class _TrainerWithoutCheckpointSupport(Trainer):
+    def build_optimizers(self):
+        pass
+
+    def build_lr_schedulers(self):
+        pass
+
+    def step_training(self):
+        pass
+
+    def step_validation(self):
+        pass
+
+    def export_safetensors(self, *args, **kwargs):
+        pass
+
+    def model_load_from_hf(self):
+        pass
+
+    def model_resume_from_checkpoint(self):
+        pass
+
+    @property
+    def pp_loss_fn(self):
+        return None
+
+
+def test_base_checkpoint_hook_raises_only_when_invoked():
+    trainer = object.__new__(_TrainerWithoutCheckpointSupport)
+
+    with pytest.raises(NotImplementedError, match="checkpoint saving is not supported"):
+        trainer.save_checkpoint(
+            current_step=3,
+            total_steps=8,
+            remain_samples_num=21,
+            is_final=True,
+        )
+
+
+def test_grpo_checkpoint_hook_preserves_final_checkpoint_behavior():
+    trainer = object.__new__(GRPOTrainer)
+    trainer.config = _checkpoint_config(export_safetensors=False)
+    trainer.model = object()
+    trainer.optimizers = object()
+    trainer.lr_schedulers = object()
+    trainer.ckpt_manager = _RecordingCheckpointManager()
+    exports = []
+    trainer.export_safetensors = lambda **kwargs: exports.append(kwargs)
+
+    trainer.save_checkpoint(
+        current_step=3,
+        total_steps=8,
+        remain_samples_num=21,
+        is_final=True,
+    )
+
+    assert exports == [
+        {
+            "output_dir": "/output",
+            "rel_path": "safetensors/step_3",
+            "trainable_only": False,
+            "is_final": True,
+            "dtype": torch.float32,
+        }
+    ]
+    assert trainer.ckpt_manager.checkpoints == [
+        {
+            "model": trainer.model,
+            "optimizer": trainer.optimizers,
+            "scheduler": trainer.lr_schedulers,
+            "step": 3,
+            "total_steps": 8,
+            "remain_samples_num": 21,
+            "is_final": True,
+        }
+    ]
+    assert trainer.ckpt_manager.completed_steps == [3]
+
+
+def test_nft_checkpoint_hook_restores_temporary_ema_weights_after_failure():
+    trainer = object.__new__(NFTTrainer)
+    trainer.config = _checkpoint_config(export_safetensors=False)
+    trainer.config.train.ema_enable = True
+    trainer.model = _NFTModel()
+    trainer.trainable_params = object()
+    trainer.optimizers = object()
+    trainer.lr_schedulers = object()
+    trainer.ckpt_manager = _FailingCheckpointManager()
+
+    with pytest.raises(RuntimeError, match="checkpoint failed"):
+        trainer.save_checkpoint(
+            current_step=3,
+            total_steps=8,
+            remain_samples_num=21,
+            is_final=False,
+        )
+
+    assert trainer.model.ema.events == [
+        ("copy_ema_to", trainer.trainable_params, True),
+        ("copy_temp_to", trainer.trainable_params),
+    ]
+
+
+@pytest.mark.parametrize("trainer_cls", [OpenVLAGRPOTrainer, PI05GRPOTrainer])
+def test_vla_checkpoint_hooks_preserve_configured_export_behavior(trainer_cls):
+    trainer = object.__new__(trainer_cls)
+    trainer.config = _checkpoint_config(export_safetensors=False)
+    trainer.model = object()
+    trainer.optimizers = object()
+    trainer.lr_schedulers = object()
+    trainer.ckpt_manager = _RecordingCheckpointManager()
+    exports = []
+    trainer.export_safetensors = lambda **kwargs: exports.append(kwargs)
+
+    trainer.save_checkpoint(
+        current_step=3,
+        total_steps=8,
+        remain_samples_num=21,
+        is_final=True,
+    )
+
+    assert exports == []
+    assert trainer.ckpt_manager.checkpoints == [
+        {
+            "model": trainer.model,
+            "optimizer": trainer.optimizers,
+            "scheduler": trainer.lr_schedulers,
+            "step": 3,
+            "total_steps": 8,
+            "remain_samples_num": 21,
+            "is_final": True,
+        }
+    ]
+    assert trainer.ckpt_manager.completed_steps == [3]

--- a/tests/test_terminal_drain_protocol.py
+++ b/tests/test_terminal_drain_protocol.py
@@ -1,0 +1,669 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import asyncio
+import unittest
+from queue import Queue
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from cosmos_rl.dispatcher.command import TrainingCompleteCommand
+from cosmos_rl.dispatcher.protocol import MESH_NAMES, Role
+from cosmos_rl.dispatcher.replica import Atom, Replica
+from cosmos_rl.dispatcher.status import (
+    PolicyStatus,
+    PolicyStatusManager,
+    RolloutStatusManager,
+)
+
+
+def _rollout_atom(replica_name: str, global_rank: int, dp_rank: int) -> Atom:
+    ranks = [0] * len(MESH_NAMES)
+    group_size = [1] * len(MESH_NAMES)
+    ranks[MESH_NAMES.index("dp_shard")] = dp_rank
+    group_size[MESH_NAMES.index("dp_shard")] = 2
+    return Atom(
+        global_rank=global_rank,
+        host_ip="127.0.0.1",
+        host_name="localhost",
+        trace_path="",
+        ranks=ranks,
+        group_size=group_size,
+        replica_name=replica_name,
+    )
+
+
+class TestRankedRolloutEnd(unittest.TestCase):
+    def test_replica_ends_only_after_every_reporting_rank(self):
+        replica = Replica(
+            "rollout-0",
+            Role.ROLLOUT,
+            [_rollout_atom("rollout-0", 0, 0), _rollout_atom("rollout-0", 1, 1)],
+        )
+        manager = RolloutStatusManager()
+        manager.rollout_replicas = {replica.name: replica}
+
+        self.assertFalse(manager.rollout_end(replica.name, src_global_rank=99))
+        self.assertFalse(replica.status.ended)
+        self.assertFalse(manager.rollout_end(replica.name, src_global_rank=0))
+        self.assertFalse(replica.status.ended)
+        self.assertTrue(manager.rollout_end(replica.name, src_global_rank=1))
+        self.assertTrue(replica.status.ended)
+        self.assertFalse(manager.rollout_end(replica.name, src_global_rank=1))
+
+    def test_rankless_legacy_end_marks_whole_replica(self):
+        replica = SimpleNamespace(status=SimpleNamespace(ended=False), atoms={})
+        manager = RolloutStatusManager()
+        manager.rollout_replicas = {"legacy": replica}
+        self.assertTrue(manager.rollout_end("legacy"))
+        self.assertTrue(replica.status.ended)
+
+    def test_rankless_command_participant_remains_safe_for_sync(self):
+        replica = _registered_rollout("trtllm")
+        manager = RolloutStatusManager()
+        manager.rollout_replicas = {replica.name: replica}
+
+        self.assertTrue(
+            manager.rollout_end(replica.name, stays_command_participant=True)
+        )
+        self.assertEqual(
+            manager.get_safe_weight_sync_replicas(validation_enabled=False),
+            [replica],
+        )
+
+    def test_http_forwards_rankless_command_participant_capability(self):
+        from cosmos_rl.dispatcher import run_web_panel
+
+        rollout_end = MagicMock(return_value=False)
+        fake_controller = SimpleNamespace(
+            rollout_status_manager=SimpleNamespace(rollout_end=rollout_end)
+        )
+        request = SimpleNamespace(
+            is_end=True,
+            src_replica_name="trtllm",
+            src_global_rank=None,
+            stays_command_participant=True,
+        )
+        with patch.object(run_web_panel, "controller", fake_controller):
+            response = asyncio.run(run_web_panel.put_rollout_group(request))
+
+        self.assertEqual(response, {"message": "Rollout end signal received"})
+        rollout_end.assert_called_once_with(
+            "trtllm",
+            src_global_rank=None,
+            stays_command_participant=True,
+        )
+
+
+def _registered_rollout(name: str, *, ended: bool = False):
+    return SimpleNamespace(
+        name=name,
+        start_time=0,
+        all_atoms_arrived=True,
+        in_mesh=True,
+        status=SimpleNamespace(ended=ended),
+    )
+
+
+class TestWeightSyncTopology(unittest.TestCase):
+    def test_ranked_checkout_keeps_full_registered_communicator(self):
+        manager = RolloutStatusManager()
+        manager.rollout_replicas = {
+            "r0": _registered_rollout("r0", ended=True),
+            "r1": _registered_rollout("r1"),
+            "r2": _registered_rollout("r2"),
+        }
+        manager._command_participant_ended_replicas = {"r0"}
+
+        targets = manager.get_safe_weight_sync_replicas(validation_enabled=False)
+
+        self.assertEqual([replica.name for replica in targets], ["r0", "r1", "r2"])
+
+    def test_legacy_checkout_suppresses_subset_sync(self):
+        manager = RolloutStatusManager()
+        manager.rollout_replicas = {
+            "legacy": _registered_rollout("legacy", ended=True),
+            "live": _registered_rollout("live"),
+        }
+
+        self.assertEqual(
+            manager.get_safe_weight_sync_replicas(validation_enabled=False),
+            [],
+        )
+
+    def test_unregister_rebuilds_all_safe_survivors_including_one(self):
+        policy_status = SimpleNamespace(training_finished=lambda: False)
+        for survivor_names in (["live", "ranked"], ["live"]):
+            with self.subTest(survivor_names=survivor_names):
+                manager = RolloutStatusManager()
+                manager.rollout_replicas = {
+                    "departing": _registered_rollout("departing"),
+                    **{
+                        name: _registered_rollout(name, ended=name == "ranked")
+                        for name in survivor_names
+                    },
+                }
+                manager._command_participant_ended_replicas = {
+                    name for name in survivor_names if name == "ranked"
+                }
+                rebuilds = []
+                manager.trigger_rebuild_mesh = lambda replicas: rebuilds.append(
+                    [replica.name for replica in replicas]
+                )
+
+                manager.unregister("departing", policy_status)
+
+                self.assertEqual(rebuilds, [survivor_names])
+
+
+class TestTrainingCompleteCoordinates(unittest.TestCase):
+    def test_constructor_preserves_legacy_positional_prefix(self):
+        command = TrainingCompleteCommand(
+            "policy-0",
+            2,
+            2,
+            7,
+            True,
+        )
+
+        self.assertEqual(command.remain_samples_num, 7)
+        self.assertTrue(command.do_save)
+        self.assertEqual(command.final_step, 1)
+        self.assertEqual(command.checkpoint_total_steps, 2)
+
+    def test_completion_is_staged_before_publish_and_does_not_advance_real_step(self):
+        replica = SimpleNamespace(
+            name="policy-0",
+            sub_profiler_config=SimpleNamespace(
+                do_profile=False,
+                active_steps=None,
+                rank_filter=None,
+                record_shape=None,
+                profile_memory=None,
+                with_stack=None,
+                with_modules=None,
+            ),
+        )
+        manager = PolicyStatusManager()
+        manager.current_step = 1
+        manager.total_steps = 99
+        manager.draining_total_steps = 5
+        manager.remain_samples_num = 3
+        manager.data_fetcher = SimpleNamespace(activated_val_iter=None)
+        manager.config = SimpleNamespace(
+            train=SimpleNamespace(ckpt=SimpleNamespace(enable_checkpoint=True))
+        )
+        manager.redis_handler = object()
+        manager.policy_replicas = {replica.name: replica}
+        manager.status = {replica.name: PolicyStatus.READY}
+        manager.get_all_atoms_arrived_replicas = lambda: [replica]
+        published = []
+
+        def fake_trigger(**kwargs):
+            self.assertEqual(manager.completion_step, 2)
+            self.assertEqual(manager.completion_recipients, {replica.name})
+            self.assertEqual(manager.completion_acks, set())
+            self.assertEqual(manager.status[replica.name], PolicyStatus.RUNNING)
+            self.assertTrue(manager.rollout_admission_closed())
+            published.append(kwargs)
+
+        with patch.object(TrainingCompleteCommand, "trigger", fake_trigger):
+            manager.trigger_training_complete()
+
+        self.assertEqual(manager.current_step, 1)
+        self.assertEqual(manager.dispatched_rollouts_by_step, {})
+        self.assertEqual(published[0]["global_step"], 2)
+        self.assertEqual(published[0]["total_steps"], 2)
+        self.assertEqual(published[0]["final_step"], 1)
+        self.assertEqual(published[0]["checkpoint_total_steps"], 5)
+        self.assertTrue(published[0]["do_save"])
+
+    def test_zero_horizon_and_resume_at_horizon_use_synthetic_completion(self):
+        for current_step, horizon, expect_save in ((0, 0, False), (5, 5, True)):
+            with self.subTest(current_step=current_step, horizon=horizon):
+                replica = SimpleNamespace(
+                    name="policy-0",
+                    sub_profiler_config=SimpleNamespace(
+                        do_profile=False,
+                        active_steps=None,
+                        rank_filter=None,
+                        record_shape=None,
+                        profile_memory=None,
+                        with_stack=None,
+                        with_modules=None,
+                    ),
+                )
+                manager = PolicyStatusManager()
+                manager.current_step = current_step
+                manager.total_steps = horizon
+                manager.data_fetcher = SimpleNamespace(activated_val_iter=None)
+                manager.config = SimpleNamespace(
+                    train=SimpleNamespace(ckpt=SimpleNamespace(enable_checkpoint=True))
+                )
+                manager.redis_handler = object()
+                manager.policy_replicas = {replica.name: replica}
+                manager.status = {replica.name: PolicyStatus.READY}
+                manager.get_all_atoms_arrived_replicas = lambda: [replica]
+                published = []
+
+                with patch.object(
+                    TrainingCompleteCommand,
+                    "trigger",
+                    side_effect=lambda **kwargs: published.append(kwargs),
+                ):
+                    manager.trigger_training_complete()
+
+                self.assertEqual(manager.current_step, current_step)
+                self.assertEqual(published[0]["global_step"], current_step + 1)
+                self.assertEqual(published[0]["total_steps"], current_step + 1)
+                self.assertEqual(published[0]["final_step"], current_step)
+                self.assertEqual(published[0]["checkpoint_total_steps"], horizon)
+                self.assertEqual(published[0]["do_save"], expect_save)
+
+    def test_partial_publication_cannot_shrink_completion_recipients(self):
+        replicas = [
+            SimpleNamespace(
+                name=name,
+                sub_profiler_config=SimpleNamespace(
+                    do_profile=False,
+                    active_steps=None,
+                    rank_filter=None,
+                    record_shape=None,
+                    profile_memory=None,
+                    with_stack=None,
+                    with_modules=None,
+                ),
+            )
+            for name in ("p0", "p1")
+        ]
+        manager = PolicyStatusManager()
+        manager.current_step = 1
+        manager.total_steps = 3
+        manager.data_fetcher = SimpleNamespace(activated_val_iter=None)
+        manager.config = SimpleNamespace(
+            train=SimpleNamespace(ckpt=SimpleNamespace(enable_checkpoint=False))
+        )
+        manager.redis_handler = object()
+        manager.policy_replicas = {replica.name: replica for replica in replicas}
+        manager.status = {replica.name: PolicyStatus.READY for replica in replicas}
+        manager.get_all_atoms_arrived_replicas = lambda: replicas
+
+        def publish(**kwargs):
+            if kwargs["replica"].name == "p1":
+                raise RuntimeError("publish failed")
+
+        with (
+            patch.object(TrainingCompleteCommand, "trigger", side_effect=publish),
+            self.assertRaisesRegex(RuntimeError, "publish failed"),
+        ):
+            manager.trigger_training_complete()
+
+        self.assertEqual(manager.completion_recipients, {"p0", "p1"})
+        self.assertEqual(manager.completion_acks, set())
+        self.assertTrue(manager.rollout_admission_closed())
+        self.assertFalse(manager.terminal_complete)
+
+
+class TestTailCleanup(unittest.TestCase):
+    def _manager(self):
+        manager = PolicyStatusManager()
+        manager.config = SimpleNamespace(
+            train=SimpleNamespace(
+                train_policy=SimpleNamespace(data_dispatch_as_rank_in_mesh=False)
+            )
+        )
+        manager.rollout_buffer = Queue()
+        manager.rollout_buffer_per_rank = []
+        manager.samples_on_the_fly = 3
+        manager.remain_samples_num = 11
+        manager.cleaned = []
+        manager._publish_payload_transport_cleanup = lambda dropped, retained: (
+            manager.cleaned.append((dropped, retained))
+        )
+        return manager
+
+    def test_buffer_cleanup_releases_payloads_without_consuming_budget(self):
+        manager = self._manager()
+        items = [object(), object(), object()]
+        for item in items:
+            manager.rollout_buffer.put(item)
+        self.assertEqual(manager.cleanup_buffered_rollouts(), 3)
+        self.assertTrue(manager.rollout_buffer.empty())
+        self.assertEqual(manager.samples_on_the_fly, 0)
+        self.assertEqual(manager.remain_samples_num, 11)
+        self.assertEqual(manager.cleaned, [(items, [])])
+
+    def test_rank_specific_cleanup_drains_uneven_tail(self):
+        manager = self._manager()
+        manager.config.train.train_policy.data_dispatch_as_rank_in_mesh = True
+        manager.rollout_buffer_per_rank = [Queue(), Queue()]
+        items = [object(), object(), object()]
+        manager.rollout_buffer_per_rank[0].put(items[0])
+        manager.rollout_buffer_per_rank[0].put(items[1])
+        manager.rollout_buffer_per_rank[1].put(items[2])
+
+        self.assertEqual(manager.cleanup_buffered_rollouts(), 3)
+
+        self.assertTrue(all(queue.empty() for queue in manager.rollout_buffer_per_rank))
+        self.assertEqual(manager.samples_on_the_fly, 0)
+        self.assertEqual(manager.remain_samples_num, 11)
+        self.assertEqual(manager.cleaned, [(items, [])])
+
+    def test_terminal_dapo_cleanup_settles_payload_and_filtered_counts(self):
+        manager = self._manager()
+        manager.samples_on_the_fly = 8
+        manager.filter_records = {"sampled": 9}
+        payloads = [object(), object()]
+        settled = manager.cleanup_terminal_rollouts(
+            payloads,
+            {
+                "sampled": 2,
+                "filtered_positive": 3,
+                "filtered_negative": 1,
+            },
+            is_dapo=True,
+        )
+        self.assertEqual(settled, 6)
+        self.assertEqual(manager.samples_on_the_fly, 2)
+        self.assertEqual(manager.remain_samples_num, 11)
+        self.assertEqual(manager.filter_records, {"sampled": 9})
+        self.assertEqual(manager.cleaned, [(payloads, [])])
+
+    def test_malformed_dapo_counts_are_non_throwing_zero(self):
+        manager = self._manager()
+        manager.samples_on_the_fly = 5
+        counts = manager.parse_dynamic_sampling_counts(
+            {
+                "sampled": "2",
+                "filtered_positive": True,
+                "filtered_negative": -1,
+            }
+        )
+        self.assertEqual(
+            counts,
+            {"sampled": 0, "filtered_positive": 0, "filtered_negative": 0},
+        )
+        manager.update_dynamic_sampling_statistics(
+            {"filtered_positive": None, "filtered_negative": 1.5}
+        )
+        self.assertEqual(manager.samples_on_the_fly, 5)
+        self.assertEqual(manager.remain_samples_num, 11)
+
+    def test_normal_dapo_path_settles_filtered_only_work(self):
+        manager = self._manager()
+        manager.samples_on_the_fly = 7
+        manager.filter_records = {}
+        manager.update_dynamic_sampling_statistics(
+            {"sampled": 2, "filtered_positive": 3, "filtered_negative": 1}
+        )
+        self.assertEqual(manager.samples_on_the_fly, 3)
+        self.assertEqual(manager.remain_samples_num, 7)
+        self.assertEqual(
+            manager.filter_records,
+            {"sampled": 2, "filtered_positive": 3, "filtered_negative": 1},
+        )
+
+
+class TestTerminalHttpAdmission(unittest.TestCase):
+    def test_terminal_cleanup_precedes_dapo_stats_and_outdated_filtering(self):
+        from cosmos_rl.dispatcher import run_web_panel
+
+        extracted = object()
+        cleaned = []
+        policy_status = SimpleNamespace(
+            rollout_admission_closed=lambda: True,
+            cleanup_terminal_rollouts=lambda rollouts, metrics, is_dapo: cleaned.append(
+                (rollouts, metrics, is_dapo)
+            ),
+            update_dynamic_sampling_statistics=lambda _metrics: (_ for _ in ()).throw(
+                AssertionError("terminal DAPO stats must be bypassed")
+            ),
+            filter_outdated_rollouts=lambda _rollouts: (_ for _ in ()).throw(
+                AssertionError("terminal outdated filtering must be bypassed")
+            ),
+        )
+        fake_controller = SimpleNamespace(
+            policy_status_manager=policy_status,
+            config=SimpleNamespace(
+                train=SimpleNamespace(train_policy=SimpleNamespace(variant="dapo"))
+            ),
+            put_rollouts=AsyncMock(
+                side_effect=AssertionError("terminal work must not be admitted")
+            ),
+        )
+        request = SimpleNamespace(
+            is_end=False,
+            src_replica_name="rollout-0",
+            payloads=[object()],
+            metrics={"filtered_positive": 2},
+        )
+        with (
+            patch.object(run_web_panel, "controller", fake_controller),
+            patch.object(run_web_panel, "extract_rollouts", return_value=[[extracted]]),
+        ):
+            response = asyncio.run(run_web_panel.put_rollout_group(request))
+
+        self.assertEqual(response, {"message": "Terminal rollout cleaned"})
+        self.assertEqual(
+            cleaned,
+            [([extracted], {"filtered_positive": 2}, True)],
+        )
+        fake_controller.put_rollouts.assert_not_awaited()
+
+
+class TestNaturalTerminalEvidence(unittest.TestCase):
+    def test_real_final_ack_closes_admission_and_cleans_surplus(self):
+        manager = PolicyStatusManager()
+        manager.config = SimpleNamespace(
+            mode="disaggregated",
+            train=SimpleNamespace(
+                train_policy=SimpleNamespace(data_dispatch_as_rank_in_mesh=False)
+            ),
+        )
+        manager.current_step = 2
+        manager.total_steps = 2
+        manager.samples_on_the_fly = 2
+        manager.remain_samples_num = 10
+        manager.rollout_buffer = Queue()
+        manager.rollout_buffer_per_rank = []
+        manager._publish_payload_transport_cleanup = lambda *_args: None
+        manager.rollout_buffer.put(object())
+        manager.rollout_buffer.put(object())
+
+        manager.record_real_datafetch_acked(2, 2)
+
+        self.assertEqual(manager.last_real_datafetch_acked_step, 2)
+        self.assertTrue(manager.rollout_admission_closed())
+        self.assertTrue(manager.terminal_complete)
+        self.assertTrue(manager.rollout_buffer.empty())
+        self.assertEqual(manager.samples_on_the_fly, 0)
+        self.assertEqual(manager.remain_samples_num, 10)
+
+    def test_ack_with_stale_advertised_horizon_is_not_terminal(self):
+        manager = PolicyStatusManager()
+        manager.config = SimpleNamespace(
+            train=SimpleNamespace(
+                train_policy=SimpleNamespace(data_dispatch_as_rank_in_mesh=False)
+            )
+        )
+        manager.current_step = 2
+        manager.total_steps = 2
+        manager.samples_on_the_fly = 0
+        manager.rollout_buffer = Queue()
+        manager.rollout_buffer_per_rank = []
+        manager._publish_payload_transport_cleanup = lambda *_args: None
+
+        manager.record_real_datafetch_acked(2, 3)
+
+        self.assertFalse(manager.real_terminal_command_acked())
+        self.assertFalse(manager.rollout_admission_closed())
+        self.assertFalse(manager.terminal_complete)
+
+    def test_completion_requires_every_prestaged_recipient_ack(self):
+        manager = PolicyStatusManager()
+        manager.policy_replicas = {
+            "p0": SimpleNamespace(name="p0"),
+            "p1": SimpleNamespace(name="p1"),
+        }
+        manager.status = {
+            "p0": PolicyStatus.RUNNING,
+            "p1": PolicyStatus.RUNNING,
+        }
+        manager.completion_step = 4
+        manager.completion_recipients = {"p0", "p1"}
+        manager.completion_acks = set()
+        manager.config = SimpleNamespace(
+            train=SimpleNamespace(train_policy=SimpleNamespace(type="grpo"))
+        )
+
+        self.assertTrue(manager.record_completion_ack("p0", 4))
+        self.assertFalse(manager.terminal_complete)
+        self.assertTrue(manager.record_completion_ack("p1", 4))
+        self.assertTrue(manager.terminal_complete)
+        self.assertEqual(manager.completion_acks, {"p0", "p1"})
+
+    def test_completion_ack_survives_early_recipient_unregister(self):
+        manager = PolicyStatusManager()
+        manager.policy_replicas = {
+            name: SimpleNamespace(name=name, in_mesh=True) for name in ("p0", "p1")
+        }
+        manager.status = {
+            name: PolicyStatus.RUNNING for name in manager.policy_replicas
+        }
+        manager.completion_step = 4
+        manager.completion_recipients = {"p0", "p1"}
+        rollout_status = SimpleNamespace()
+
+        manager.train_ack("p0", 4, 4, False, {}, rollout_status)
+        manager.unregister("p0")
+        manager.train_ack("p1", 4, 4, False, {}, rollout_status)
+
+        self.assertEqual(manager.completion_acks, {"p0", "p1"})
+        self.assertTrue(manager.terminal_complete)
+
+
+class TestTerminalMatrix(unittest.TestCase):
+    @staticmethod
+    def _manager(accepted_count):
+        replica = SimpleNamespace(
+            name="policy-0",
+            start_time=0,
+            put_rollout=MagicMock(),
+            sub_profiler_config=SimpleNamespace(
+                do_profile=False,
+                active_steps=None,
+                rank_filter=None,
+                record_shape=None,
+                profile_memory=None,
+                with_stack=None,
+                with_modules=None,
+            ),
+        )
+        manager = PolicyStatusManager()
+        manager.current_step = 0
+        manager.total_steps = 2
+        manager.remain_samples_num = 20
+        manager.samples_on_the_fly = accepted_count
+        manager.rollout_buffer = Queue()
+        for _ in range(accepted_count):
+            manager.rollout_buffer.put(object())
+        manager.policy_replicas = {replica.name: replica}
+        manager.status = {replica.name: PolicyStatus.READY}
+        manager.get_all_atoms_arrived_replicas = lambda: [replica]
+        manager.data_fetcher = SimpleNamespace(activated_val_iter=None)
+        manager.redis_handler = object()
+        manager.samples_per_epoch = 20
+        manager.config = SimpleNamespace(
+            mode="disaggregated",
+            validation=SimpleNamespace(enable=False, freq=1),
+            logging=SimpleNamespace(logger=[]),
+            train=SimpleNamespace(
+                train_batch_per_replica=2,
+                epoch=1,
+                non_text=False,
+                ckpt=SimpleNamespace(
+                    enable_checkpoint=False,
+                    save_freq=1,
+                    save_freq_in_epoch=0,
+                ),
+                train_policy=SimpleNamespace(
+                    data_dispatch_as_rank_in_mesh=False,
+                    rollout_as_token_ids=False,
+                ),
+            ),
+        )
+        manager._publish_payload_transport_cleanup = lambda *_args: None
+        return manager, replica
+
+    def test_complete_batches_train_and_only_partial_tail_is_synthetic(self):
+        rollout_status = SimpleNamespace(all_rollouts_ended=lambda: True)
+        expected_real_steps = {0: 0, 1: 0, 2: 1, 3: 1, 4: 2, 6: 2}
+        for accepted_count, expected_steps in expected_real_steps.items():
+            with self.subTest(accepted_count=accepted_count):
+                manager, _replica = self._manager(accepted_count)
+                real_commands = []
+                completion_commands = []
+
+                def datafetch_trigger(**kwargs):
+                    real_commands.append(kwargs)
+
+                def completion_trigger(**kwargs):
+                    completion_commands.append(kwargs)
+
+                with (
+                    patch(
+                        "cosmos_rl.dispatcher.command.DataFetchCommand.trigger",
+                        datafetch_trigger,
+                    ),
+                    patch.object(
+                        TrainingCompleteCommand, "trigger", completion_trigger
+                    ),
+                ):
+                    manager.finish_draining_phase(rollout_status)
+                    while len(real_commands) < expected_steps:
+                        manager.status["policy-0"] = PolicyStatus.READY
+                        manager.finish_draining_phase(rollout_status)
+
+                    if expected_steps == 2:
+                        manager.record_real_datafetch_acked(2, 2)
+                    elif expected_steps == 1:
+                        manager.status["policy-0"] = PolicyStatus.READY
+                        manager.finish_draining_phase(rollout_status)
+
+                self.assertEqual(len(real_commands), expected_steps)
+                self.assertEqual(
+                    [command["total_steps"] for command in real_commands],
+                    [2] * expected_steps,
+                )
+                self.assertEqual(
+                    len(completion_commands),
+                    0 if expected_steps == 2 else 1,
+                )
+                self.assertEqual(manager.current_step, expected_steps)
+                self.assertEqual(manager.total_steps, 2)
+
+    def test_tail_dispatch_uses_snapshot_after_late_total_step_write(self):
+        rollout_status = SimpleNamespace(all_rollouts_ended=lambda: True)
+        for late_total_steps in (1, 99):
+            with self.subTest(late_total_steps=late_total_steps):
+                manager, _replica = self._manager(2)
+                manager.current_step = 1
+                manager.config.train.ckpt.enable_checkpoint = True
+                manager.enter_draining_phase()
+                manager.total_steps = late_total_steps
+                real_commands = []
+
+                with patch(
+                    "cosmos_rl.dispatcher.command.DataFetchCommand.trigger",
+                    side_effect=lambda **kwargs: real_commands.append(kwargs),
+                ):
+                    manager.finish_draining_phase(rollout_status)
+
+                self.assertEqual(len(real_commands), 1)
+                self.assertEqual(real_commands[0]["global_step"], 2)
+                self.assertEqual(real_commands[0]["total_steps"], 2)
+                self.assertTrue(real_commands[0]["do_save"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_training_complete_checkpoint.py
+++ b/tests/test_training_complete_checkpoint.py
@@ -1,0 +1,119 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import unittest
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import torch
+
+from cosmos_rl.dispatcher.command import TrainingCompleteCommand
+from cosmos_rl.policy.worker.rl_worker import RLPolicyWorker
+
+
+def _command(*, do_save: bool = True) -> TrainingCompleteCommand:
+    return TrainingCompleteCommand(
+        "policy-0",
+        global_step=2,
+        total_steps=2,
+        final_step=1,
+        checkpoint_total_steps=5,
+        remain_samples_num=7,
+        do_save=do_save,
+    )
+
+
+def _worker(save_checkpoint=None, invalidate_checkpoint=None):
+    return SimpleNamespace(
+        replica_name="policy-0",
+        replica_batch_for_this_step=-1,
+        is_master_replica=True,
+        trainer=SimpleNamespace(
+            save_checkpoint=save_checkpoint or MagicMock(),
+            invalidate_checkpoint_completion=(invalidate_checkpoint or MagicMock()),
+        ),
+        profiler=SimpleNamespace(step=MagicMock(), check_finished=lambda: False),
+        parallel_dims=object(),
+        global_rank=0,
+        api_client=SimpleNamespace(post_policy_train_ack=MagicMock()),
+    )
+
+
+class TestTrainingCompleteCheckpointAgreement(unittest.TestCase):
+    def test_local_save_failure_participates_then_prevents_ack(self):
+        local_error = RuntimeError("local shard failed")
+        worker = _worker(MagicMock(side_effect=local_error))
+        with patch(
+            "cosmos_rl.policy.worker.rl_worker.dist_util.all_reduce_tensor_object_cpu",
+            side_effect=[torch.tensor([1]), torch.tensor([0])],
+        ) as reduce_ok:
+            with self.assertRaisesRegex(RuntimeError, "local shard failed"):
+                RLPolicyWorker.execute_training_complete(worker, _command())
+        self.assertEqual(reduce_ok.call_count, 2)
+        worker.api_client.post_policy_train_ack.assert_not_called()
+
+    def test_peer_save_failure_prevents_master_ack(self):
+        worker = _worker()
+        with patch(
+            "cosmos_rl.policy.worker.rl_worker.dist_util.all_reduce_tensor_object_cpu",
+            side_effect=[torch.tensor([1]), torch.tensor([0])],
+        ):
+            with self.assertRaisesRegex(RuntimeError, "another rank"):
+                RLPolicyWorker.execute_training_complete(worker, _command())
+        worker.api_client.post_policy_train_ack.assert_not_called()
+
+    def test_unanimous_save_acks_with_real_checkpoint_coordinates(self):
+        save = MagicMock()
+        worker = _worker(save)
+        with (
+            patch(
+                "cosmos_rl.policy.worker.rl_worker.dist_util.all_reduce_tensor_object_cpu",
+                return_value=torch.tensor([1]),
+            ),
+            patch(
+                "cosmos_rl.policy.worker.rl_worker.is_master_rank",
+                return_value=True,
+            ),
+        ):
+            should_stop = RLPolicyWorker.execute_training_complete(worker, _command())
+        save.assert_called_once_with(
+            current_step=1,
+            total_steps=5,
+            remain_samples_num=7,
+            is_final=True,
+        )
+        worker.trainer.invalidate_checkpoint_completion.assert_called_once_with(1)
+        worker.api_client.post_policy_train_ack.assert_called_once()
+        self.assertTrue(should_stop)
+
+    def test_invalidation_failure_prevents_save_and_ack(self):
+        error = RuntimeError("stale marker removal failed")
+        worker = _worker(invalidate_checkpoint=MagicMock(side_effect=error))
+        with patch(
+            "cosmos_rl.policy.worker.rl_worker.dist_util.all_reduce_tensor_object_cpu",
+            return_value=torch.tensor([0]),
+        ):
+            with self.assertRaisesRegex(RuntimeError, "stale marker removal failed"):
+                RLPolicyWorker.execute_training_complete(worker, _command())
+        worker.trainer.save_checkpoint.assert_not_called()
+        worker.api_client.post_policy_train_ack.assert_not_called()
+
+    def test_disabled_save_skips_collective_and_still_acks(self):
+        worker = _worker()
+        with (
+            patch(
+                "cosmos_rl.policy.worker.rl_worker.dist_util.all_reduce_tensor_object_cpu"
+            ) as reduce_ok,
+            patch(
+                "cosmos_rl.policy.worker.rl_worker.is_master_rank",
+                return_value=True,
+            ),
+        ):
+            RLPolicyWorker.execute_training_complete(worker, _command(do_save=False))
+        reduce_ok.assert_not_called()
+        worker.trainer.save_checkpoint.assert_not_called()
+        worker.api_client.post_policy_train_ack.assert_called_once()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/utils/mock_policy_entrance.py
+++ b/tests/utils/mock_policy_entrance.py
@@ -204,10 +204,9 @@ def main(*args, **kwargs):
             )
             worker.main_loop()
             if args.test == "custom_rollout":
-                assert worker.trainer.computed_cnt == 3, (
-                    "custom_rollout should compute logprobs for the three real "
-                    "training steps; the final TrainingCompleteCommand is a "
-                    "zero-work ack and must not call compute_logprobs "
+                assert worker.trainer.computed_cnt == 4, (
+                    "custom_rollout should compute logprobs for all four complete "
+                    "training batches "
                     f"(got computed_cnt={getattr(worker.trainer, 'computed_cnt', None)})"
                 )
         elif policy_type == "sft":


### PR DESCRIPTION
<!--mr-summary:start-->
## Motivation and expected outcome

Close rollout input only after every producer drains, so late multirank results finish training without stale collectives or incomplete final checkpoints.

## Fixes in this MR

| What | Why | How |
| --- | --- | --- |
| Terminal drain state | The first rollout checkout could truncate the planned horizon while peers still held results | Aggregate reporter checkout, freeze the horizon at final input closure, and dispatch only complete tail batches |
| Rollout topology and shutdown | Partial checkout and asynchronous sync could reuse stale communicators or exit ahead of queued NCCL work | Keep command participants in the full topology, order mesh rebuilds, and fence weight sync before explicit STOP |
| Final checkpoint promotion | Early completion could skip the final save or expose a mixed distributed checkpoint | Save the last real step through trainer hooks, require all-rank success, and invalidate markers after prior async writes finish |
| Terminal result accounting | Late and filtered DAPO results could be admitted after completion began, mutate resumable counters, or be settled twice | Close admission when completion is staged and use type-safe, single-settlement cleanup |

## Diagram 1: Change map

```text
Before                                      After
------------------------------------        ----------------------------------------
first rollout end                           per-rank rollout end votes
  -> recompute training horizon               -> whole replica drained
  -> suppress partial topology sync            -> last replica freezes horizon

tail smaller than a full batch               complete tail batch -> normal DataFetch
  -> ambiguous policy termination             partial/surplus tail -> cleanup
                                               no real T/T ACK -> completion command

periodic checkpoint at final real step       all ranks invalidate completion markers
  -> uncoordinated final rewrite               -> coordinated final promotion

queued async weight work                     BuildMesh / STOP ordering gates
  -> mesh or process teardown race             -> queue and CUDA-stream fences
```

## Diagram 2: Conceptual design map

```text
rollout reporters drain
        |
        v
controller records replica-local votes
        |
        +-- producers remain --> RUNNING + full safe sync topology
        |
        `-- last producer ----> DRAINING; freeze planned horizon T
                                      |
                         +------------+-------------+
                         |                          |
                  full batch exists           no full batch
                         |                          |
                  DataFetch K/T                release tail
                         |                          |
                 exact T/T ACK?              completion K+1/K+1
                    |         |                    |
                   yes        no                   v
                    |         `--------------> final checkpoint
                    |                              |
                    `------------------------------+
                                                   v
                                      policies unregister -> STOP rollouts
```

## Diagram 3: Main use-case path

```text
two rollout replicas, one drains early
├── controller records its reporter votes and keeps the full communicator
├── remaining replica posts late results and then drains
├── controller freezes T and trains every complete buffered batch
├── controller cleans the unusable tail without changing resume budget
├── policies either ACK real T/T or save K/T through completion
└── controller sends STOP after policy shutdown; rollouts fence queued sync work
```

## Diff stats

```text
  Total: +2497 / −707 across 25 files
  Core code ······· +821 / −432  (39%)
  Tests ··········· +1674 / −273 (61%)
  Scripts & tooling +2 / −2       (0%)
```
<!--mr-summary:end-->
