### PR TITLE
Add optional NCCL P2P phase observer

### DIFF
--- a/cosmos_rl/utils/pynccl.py
+++ b/cosmos_rl/utils/pynccl.py
@@ -32,7 +32,7 @@ import threading
 import time
 from contextlib import contextmanager
 from dataclasses import dataclass, field
-from typing import Callable, Dict, List, Optional
+from typing import Callable, Dict, List, Literal, Optional
 
 import torch
 from cosmos_rl.utils.logging import logger
@@ -179,11 +179,39 @@ def _current_ctx() -> _WatchdogContext | None:  # noqa: D401
 # ---------------------------------------------------------------------------
 
 
+_P2PPhase = Literal[
+    "raw_call_enter",
+    "raw_call_return",
+    "async_error_query_enter",
+    "async_error_query_return",
+    "abort_enter",
+    "abort_return",
+]
+_P2PPhaseObserver = Callable[[_P2PPhase, int | None, int | None], None]
+
+
+def _notify_p2p_phase(
+    observer: Optional[_P2PPhaseObserver],
+    phase: _P2PPhase,
+    api_result: int | None = None,
+    comm_state: int | None = None,
+) -> None:
+    """Notify a non-blocking observer without changing NCCL behavior."""
+    if observer is None:
+        return
+    try:
+        observer(phase, api_result, comm_state)
+    except Exception:
+        # Diagnostics must never mask or alter the NCCL operation.
+        pass
+
+
 @dataclass(slots=True)
 class _Task:
     functor: Callable[[], ncclComm_t]
     timeout_ms: int
     comm_idx: Optional[int]
+    phase_observer: Optional[_P2PPhaseObserver] = None
     done: threading.Event = field(default_factory=threading.Event)
     timed_out: threading.Event = field(default_factory=threading.Event)
 
@@ -217,7 +245,17 @@ def run_task(task: _Task):
         deadline = time.monotonic() + task.timeout_ms / 1000.0
         # Poll async error status until success or timeout.
         while time.monotonic() < deadline:
-            err = _nccl.ncclCommGetAsyncError(comm)
+            if task.phase_observer is None:
+                err = _nccl.ncclCommGetAsyncError(comm)
+            else:
+                _notify_p2p_phase(task.phase_observer, "async_error_query_enter")
+                api_result, err = _nccl._ncclCommGetAsyncErrorResult(comm)
+                _notify_p2p_phase(
+                    task.phase_observer,
+                    "async_error_query_return",
+                    api_result,
+                    err,
+                )
             if err == ncclResultEnum.ncclSuccess:
                 break
             if err != ncclResultEnum.ncclInProgress:
@@ -225,7 +263,9 @@ def run_task(task: _Task):
                 logger.error(
                     f"NCCL: async error detected (err={err}), task {task} failed"
                 )
+                _notify_p2p_phase(task.phase_observer, "abort_enter")
                 _safe_abort(task.comm_idx, comm)
+                _notify_p2p_phase(task.phase_observer, "abort_return")
                 task.timed_out.set()
                 break
             time.sleep(0.001)
@@ -233,7 +273,9 @@ def run_task(task: _Task):
         else:
             # Enqueue timeout hit – abort communicator.
             logger.error(f"NCCL: non-blocking enqueue timed out for task {task}")
+            _notify_p2p_phase(task.phase_observer, "abort_enter")
             _safe_abort(task.comm_idx, comm)
+            _notify_p2p_phase(task.phase_observer, "abort_return")
             task.timed_out.set()
     except Exception as e:
         logger.error(f"[Worker] Exception during task {task}: {e}")
@@ -280,6 +322,8 @@ def _submit_nccl(
     timeout_ms: Optional[int],
     comm_idx: Optional[int] = None,
     run_inline: bool = True,
+    *,
+    phase_observer: Optional[_P2PPhaseObserver] = None,
 ):
     """Execute *functor* in the NCCL worker thread with watchdog integration."""
     if not _worker_started:
@@ -288,7 +332,12 @@ def _submit_nccl(
         )
 
     resolved_timeout = _get_timeout_ms(timeout_ms)
-    task = _Task(functor, resolved_timeout, comm_idx)
+    task = _Task(
+        functor,
+        resolved_timeout,
+        comm_idx,
+        phase_observer=phase_observer,
+    )
     if run_inline:
         run_task(task)
     else:
@@ -654,25 +703,53 @@ def nccl_send(
     comm_idx: int,
     stream: Optional[Stream] = None,
     timeout_ms: Optional[int] = None,
+    *,
+    phase_observer: Optional[_P2PPhaseObserver] = None,
 ):
-    """Point-to-point send."""
+    """Point-to-point send with an optional synchronous phase observer.
+
+    The observer must return promptly and must not perform I/O. Its exceptions
+    are contained so diagnostics cannot change the NCCL operation's outcome.
+    """
     _check_tensor(tensor)
     meta = _COMM_REGISTRY.get(comm_idx)
 
     stream_ptr = _stream_ptr(stream)
 
     def _send_call():
-        _nccl.ncclSend(
-            _buf(tensor),
-            tensor.numel(),
-            _dtype_enum(tensor.dtype),
-            peer,
-            meta.comm,
-            stream_ptr,
-        )
+        if phase_observer is None:
+            _nccl.ncclSend(
+                _buf(tensor),
+                tensor.numel(),
+                _dtype_enum(tensor.dtype),
+                peer,
+                meta.comm,
+                stream_ptr,
+            )
+        else:
+            _notify_p2p_phase(phase_observer, "raw_call_enter")
+            api_result = _nccl._ncclSendResult(
+                _buf(tensor),
+                tensor.numel(),
+                _dtype_enum(tensor.dtype),
+                peer,
+                meta.comm,
+                stream_ptr,
+            )
+            _notify_p2p_phase(
+                phase_observer,
+                "raw_call_return",
+                api_result,
+            )
+            _nccl.NCCL_CHECK(api_result)
         return meta.comm
 
-    _submit_nccl(_send_call, timeout_ms, comm_idx)
+    _submit_nccl(
+        _send_call,
+        timeout_ms,
+        comm_idx,
+        phase_observer=phase_observer,
+    )
 
 
 def nccl_recv(
@@ -681,25 +758,53 @@ def nccl_recv(
     comm_idx: int,
     stream: Optional[Stream] = None,
     timeout_ms: Optional[int] = None,
+    *,
+    phase_observer: Optional[_P2PPhaseObserver] = None,
 ):
-    """Point-to-point receive."""
+    """Point-to-point receive with an optional synchronous phase observer.
+
+    The observer must return promptly and must not perform I/O. Its exceptions
+    are contained so diagnostics cannot change the NCCL operation's outcome.
+    """
     _check_tensor(tensor)
     meta = _COMM_REGISTRY.get(comm_idx)
 
     stream_ptr = _stream_ptr(stream)
 
     def _recv_call():
-        _nccl.ncclRecv(
-            _buf(tensor),
-            tensor.numel(),
-            _dtype_enum(tensor.dtype),
-            peer,
-            meta.comm,
-            stream_ptr,
-        )
+        if phase_observer is None:
+            _nccl.ncclRecv(
+                _buf(tensor),
+                tensor.numel(),
+                _dtype_enum(tensor.dtype),
+                peer,
+                meta.comm,
+                stream_ptr,
+            )
+        else:
+            _notify_p2p_phase(phase_observer, "raw_call_enter")
+            api_result = _nccl._ncclRecvResult(
+                _buf(tensor),
+                tensor.numel(),
+                _dtype_enum(tensor.dtype),
+                peer,
+                meta.comm,
+                stream_ptr,
+            )
+            _notify_p2p_phase(
+                phase_observer,
+                "raw_call_return",
+                api_result,
+            )
+            _nccl.NCCL_CHECK(api_result)
         return meta.comm
 
-    _submit_nccl(_recv_call, timeout_ms, comm_idx)
+    _submit_nccl(
+        _recv_call,
+        timeout_ms,
+        comm_idx,
+        phase_observer=phase_observer,
+    )
 
 
 def nccl_allreduce(

--- a/cosmos_rl/utils/pynccl_wrapper.py
+++ b/cosmos_rl/utils/pynccl_wrapper.py
@@ -512,6 +512,20 @@ class NCCLLibrary:
             self._funcs["ncclSend"](sendbuff, count, datatype, dest, comm, stream)
         )
 
+    def _ncclSendResult(
+        self,
+        sendbuff: buffer_type,
+        count: int,
+        datatype: int,
+        dest: int,
+        comm: ncclComm_t,
+        stream: cudaStream_t,
+    ) -> int:
+        """Return the unchecked result from ``ncclSend``."""
+        return int(
+            self._funcs["ncclSend"](sendbuff, count, datatype, dest, comm, stream)
+        )
+
     def ncclRecv(
         self,
         recvbuff: buffer_type,
@@ -522,6 +536,20 @@ class NCCLLibrary:
         stream: cudaStream_t,
     ) -> None:
         self.NCCL_CHECK(
+            self._funcs["ncclRecv"](recvbuff, count, datatype, src, comm, stream)
+        )
+
+    def _ncclRecvResult(
+        self,
+        recvbuff: buffer_type,
+        count: int,
+        datatype: int,
+        src: int,
+        comm: ncclComm_t,
+        stream: cudaStream_t,
+    ) -> int:
+        """Return the unchecked result from ``ncclRecv``."""
+        return int(
             self._funcs["ncclRecv"](recvbuff, count, datatype, src, comm, stream)
         )
 
@@ -556,6 +584,12 @@ class NCCLLibrary:
         err = ncclResult_t()
         self._funcs["ncclCommGetAsyncError"](comm, ctypes.byref(err))
         return int(err.value)
+
+    def _ncclCommGetAsyncErrorResult(self, comm: ncclComm_t) -> tuple[int, int]:
+        """Return the query API result and the communicator state separately."""
+        err = ncclResult_t()
+        api_result = self._funcs["ncclCommGetAsyncError"](comm, ctypes.byref(err))
+        return int(api_result), int(err.value)
 
     def ncclCommAbort(self, comm: ncclComm_t) -> None:
         # abort can return error itself; ignore it to avoid masking original issue

--- a/tests/run_test.sh
+++ b/tests/run_test.sh
@@ -65,6 +65,7 @@ run python tests/test_freeze_pattern.py
 run python tests/test_high_availability_nccl.py
 run python tests/test_nccl_collectives.py
 run python tests/test_nccl_timeout.py
+run python tests/test_pynccl_phase_observer.py
 run python tests/test_parallel_map.py
 run python tests/test_policy_to_policy.py
 run python tests/test_policy_to_rollout.py

--- a/tests/test_pynccl_phase_observer.py
+++ b/tests/test_pynccl_phase_observer.py
@@ -1,0 +1,305 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""CPU tests for the optional point-to-point NCCL phase observer."""
+
+import threading
+import unittest
+from contextlib import ExitStack
+from unittest.mock import Mock, patch
+
+from cosmos_rl.utils import pynccl
+from cosmos_rl.utils.pynccl_wrapper import NCCLLibrary, ncclResultEnum
+
+
+class TestP2PPhaseObserver(unittest.TestCase):
+    def _invoke_p2p(
+        self,
+        direction: str,
+        *,
+        observer=None,
+        raw_result: int = ncclResultEnum.ncclSuccess,
+        query_results=((ncclResultEnum.ncclSuccess, ncclResultEnum.ncclSuccess),),
+    ) -> dict[str, Mock]:
+        tensor = Mock()
+        tensor.numel.return_value = 8
+        meta = pynccl._CommMeta(comm=Mock(), rank=1, world_size=2)
+        legacy_raw = Mock()
+        result_raw = Mock(return_value=raw_result)
+        legacy_query = Mock(return_value=ncclResultEnum.ncclSuccess)
+        result_query = Mock(side_effect=query_results)
+        call = pynccl.nccl_send if direction == "send" else pynccl.nccl_recv
+        legacy_raw_name = "ncclSend" if direction == "send" else "ncclRecv"
+        result_raw_name = (
+            "_ncclSendResult" if direction == "send" else "_ncclRecvResult"
+        )
+
+        with ExitStack() as stack:
+            stack.enter_context(patch.object(pynccl, "_worker_started", True))
+            stack.enter_context(patch.object(pynccl, "_check_tensor"))
+            stack.enter_context(
+                patch.object(pynccl, "_stream_ptr", return_value=Mock())
+            )
+            stack.enter_context(patch.object(pynccl, "_buf", return_value=Mock()))
+            stack.enter_context(patch.object(pynccl, "_dtype_enum", return_value=7))
+            stack.enter_context(
+                patch.object(pynccl._CommunicatorRegistry, "get", return_value=meta)
+            )
+            stack.enter_context(patch.object(pynccl._nccl, legacy_raw_name, legacy_raw))
+            stack.enter_context(
+                patch.object(
+                    pynccl._nccl,
+                    result_raw_name,
+                    result_raw,
+                    create=True,
+                )
+            )
+            stack.enter_context(
+                patch.object(
+                    pynccl._nccl,
+                    "ncclCommGetAsyncError",
+                    legacy_query,
+                )
+            )
+            stack.enter_context(
+                patch.object(
+                    pynccl._nccl,
+                    "_ncclCommGetAsyncErrorResult",
+                    result_query,
+                    create=True,
+                )
+            )
+            stack.enter_context(patch.object(pynccl.time, "sleep"))
+
+            kwargs = {"phase_observer": observer} if observer is not None else {}
+            call(tensor, 0, 4, **kwargs)
+
+        return {
+            "legacy_raw": legacy_raw,
+            "result_raw": result_raw,
+            "legacy_query": legacy_query,
+            "result_query": result_query,
+        }
+
+    def test_disabled_path_uses_the_legacy_calls(self):
+        for direction in ("send", "recv"):
+            with self.subTest(direction=direction):
+                calls = self._invoke_p2p(direction)
+
+                calls["legacy_raw"].assert_called_once()
+                calls["legacy_query"].assert_called_once()
+                calls["result_raw"].assert_not_called()
+                calls["result_query"].assert_not_called()
+
+    def test_send_and_recv_report_results_in_order(self):
+        expected_events = [
+            ("raw_call_enter", None, None),
+            ("raw_call_return", ncclResultEnum.ncclSuccess, None),
+            ("async_error_query_enter", None, None),
+            (
+                "async_error_query_return",
+                ncclResultEnum.ncclSuccess,
+                ncclResultEnum.ncclInProgress,
+            ),
+            ("async_error_query_enter", None, None),
+            (
+                "async_error_query_return",
+                ncclResultEnum.ncclSuccess,
+                ncclResultEnum.ncclSuccess,
+            ),
+        ]
+        for direction in ("send", "recv"):
+            with self.subTest(direction=direction):
+                events = []
+                calls = self._invoke_p2p(
+                    direction,
+                    observer=lambda *event: events.append(event),
+                    query_results=(
+                        (ncclResultEnum.ncclSuccess, ncclResultEnum.ncclInProgress),
+                        (ncclResultEnum.ncclSuccess, ncclResultEnum.ncclSuccess),
+                    ),
+                )
+
+                self.assertEqual(events, expected_events)
+                calls["result_raw"].assert_called_once()
+                self.assertEqual(calls["result_query"].call_count, 2)
+                calls["legacy_raw"].assert_not_called()
+                calls["legacy_query"].assert_not_called()
+
+    def test_query_api_result_is_distinct_from_communicator_state(self):
+        events = []
+
+        self._invoke_p2p(
+            "send",
+            observer=lambda *event: events.append(event),
+            query_results=(
+                (ncclResultEnum.ncclSystemError, ncclResultEnum.ncclSuccess),
+            ),
+        )
+
+        self.assertEqual(
+            events[-1],
+            (
+                "async_error_query_return",
+                ncclResultEnum.ncclSystemError,
+                ncclResultEnum.ncclSuccess,
+            ),
+        )
+
+    def test_observer_failure_does_not_change_the_operation(self):
+        calls = 0
+
+        def fail_observer(*_event):
+            nonlocal calls
+            calls += 1
+            raise RuntimeError("observer failed")
+
+        self._invoke_p2p("send", observer=fail_observer)
+
+        self.assertGreater(calls, 0)
+
+    def test_query_enter_is_visible_while_the_native_query_is_blocked(self):
+        native_query_entered = threading.Event()
+        release_native_query = threading.Event()
+        events = []
+        errors = []
+
+        def blocking_query(_comm):
+            native_query_entered.set()
+            release_native_query.wait(timeout=2)
+            return ncclResultEnum.ncclSuccess, ncclResultEnum.ncclSuccess
+
+        def invoke():
+            try:
+                self._invoke_p2p(
+                    "send",
+                    observer=lambda *event: events.append(event),
+                    query_results=blocking_query,
+                )
+            except Exception as error:  # pragma: no cover - asserted below
+                errors.append(error)
+
+        thread = threading.Thread(target=invoke)
+        thread.start()
+        self.assertTrue(native_query_entered.wait(timeout=1))
+        self.assertEqual(events[-1], ("async_error_query_enter", None, None))
+        release_native_query.set()
+        thread.join(timeout=1)
+
+        self.assertFalse(thread.is_alive())
+        self.assertEqual(errors, [])
+
+    def test_async_error_reports_abort_without_reordering_timeout_state(self):
+        events = []
+        task = pynccl._Task(
+            functor=lambda: Mock(),
+            timeout_ms=100,
+            comm_idx=4,
+            phase_observer=lambda *event: events.append(event),
+        )
+        timed_out_during_abort = []
+
+        def abort(_comm_idx, _comm):
+            timed_out_during_abort.append(task.timed_out.is_set())
+
+        with (
+            patch.object(
+                pynccl._nccl,
+                "_ncclCommGetAsyncErrorResult",
+                return_value=(
+                    ncclResultEnum.ncclSuccess,
+                    ncclResultEnum.ncclSystemError,
+                ),
+                create=True,
+            ),
+            patch.object(pynccl, "_safe_abort", side_effect=abort),
+        ):
+            pynccl.run_task(task)
+
+        self.assertEqual(
+            [event[0] for event in events[-4:]],
+            [
+                "async_error_query_enter",
+                "async_error_query_return",
+                "abort_enter",
+                "abort_return",
+            ],
+        )
+        self.assertEqual(timed_out_during_abort, [False])
+        self.assertTrue(task.timed_out.is_set())
+
+    def test_enqueue_timeout_reports_abort_without_querying(self):
+        events = []
+        task = pynccl._Task(
+            functor=lambda: Mock(),
+            timeout_ms=0,
+            comm_idx=4,
+            phase_observer=lambda *event: events.append(event),
+        )
+
+        with (
+            patch.object(
+                pynccl._nccl,
+                "_ncclCommGetAsyncErrorResult",
+                create=True,
+            ) as query,
+            patch.object(pynccl, "_safe_abort") as abort,
+        ):
+            pynccl.run_task(task)
+
+        self.assertEqual(
+            [event[0] for event in events],
+            ["abort_enter", "abort_return"],
+        )
+        query.assert_not_called()
+        abort.assert_called_once()
+        self.assertTrue(task.timed_out.is_set())
+
+
+class TestNCCLResultSeams(unittest.TestCase):
+    def _library(self, functions: dict[str, Mock]) -> NCCLLibrary:
+        library = object.__new__(NCCLLibrary)
+        library._funcs = functions
+        return library
+
+    def test_send_and_recv_result_seams_preserve_checked_methods(self):
+        for name, arguments in (
+            ("Send", (None, 8, 7, 1, None, None)),
+            ("Recv", (None, 8, 7, 1, None, None)),
+        ):
+            with self.subTest(name=name):
+                native = Mock(return_value=ncclResultEnum.ncclSystemError)
+                library = self._library(
+                    {
+                        f"nccl{name}": native,
+                        "ncclGetErrorString": Mock(return_value=b"simulated"),
+                    }
+                )
+
+                raw_result = getattr(library, f"_nccl{name}Result")(*arguments)
+                with self.assertRaisesRegex(RuntimeError, "NCCL error: simulated"):
+                    getattr(library, f"nccl{name}")(*arguments)
+
+                self.assertEqual(raw_result, ncclResultEnum.ncclSystemError)
+
+    def test_async_query_result_seam_preserves_compatibility_result(self):
+        def query(_comm, state):
+            state._obj.value = ncclResultEnum.ncclInProgress
+            return ncclResultEnum.ncclSystemError
+
+        native = Mock(side_effect=query)
+        library = self._library({"ncclCommGetAsyncError": native})
+
+        exact_result = library._ncclCommGetAsyncErrorResult(None)
+        compatibility_result = library.ncclCommGetAsyncError(None)
+
+        self.assertEqual(
+            exact_result,
+            (ncclResultEnum.ncclSystemError, ncclResultEnum.ncclInProgress),
+        )
+        self.assertEqual(compatibility_result, ncclResultEnum.ncclInProgress)
+        self.assertEqual(native.call_count, 2)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Why this change is needed

Max's AlpaGym jobs `5315767` and `5378912` each hung on the first rollout-to-policy transfer over one accepted route. Both jobs stopped during NCCL asynchronous progress and timed out after about 600 seconds. Their retained WARN logs could not show which native NCCL boundary stopped returning.

This PR adds the smallest upstream observation seam needed to answer that question. An opt-in callback brackets send or receive submission, each asynchronous-error query, and communicator abort. The callback receives native return values, performs no logging, and cannot change the NCCL operation if the observer raises.

## What the next recurrence can rule out

- `async_error_query_enter` without its matching return identifies a native query that did not return. This rules out later Python polling, stream synchronization, and abort as the original blocked boundary.
- Repeated query return events rule out one blocked query and show that NCCL is still answering the progress check.
- Missing `raw_call_return` or `abort_return` isolates submission or communicator teardown in the same way.

This PR does not fix the intermittent hang or prove its cause. Calls without an observer keep the original direct wrapper path.

## Downstream consumer

[Alpamayo MR !2540](https://gitlab-master.nvidia.com/alpamayo/alpamayo/-/merge_requests/2540) records these phases, correlates both endpoints, and captures process evidence when a phase stalls.

<!--mr-summary:start-->
## Fixes in this MR

| What | Why | How |
| --- | --- | --- |
| Optional P2P phase observer | Current timeout logs cannot identify the native call that stopped returning | Adds keyword-only callbacks around raw submission, async-error queries, and abort |
| Exact native result seams | Checked wrappers discard values needed for diagnosis | Adds private result-returning wrapper methods while preserving existing checked methods |
| Observer contract coverage | Instrumentation must not change disabled calls, abort ordering, or failure behavior | Tests send and receive phases, blocked queries, callback failures, and CI registration |

## Diagram 1: Change map

```text
Before
`nccl_send` / `nccl_recv` -> timeout -> last native boundary unknown

After
`nccl_send` / `nccl_recv`
        │
        ▼
optional ordered phase callback ──► downstream stall recorder
        │
        ▼
exact raw-call / query / abort boundary
```

## Diagram 2: Conceptual design map

```text
observer omitted
        │
        └─ original checked wrapper path; no callback work

observer supplied
        │
        ▼
raw call enter / return
        │
        ▼
async query enter / return ──► exact API result + communicator state
        │
        ▼
abort enter / return when timeout or error requires teardown

observer exception ──────────► contained; NCCL outcome stays authoritative
```

## Diagram 3: Main use-case path

```text
`nccl_send(..., phase_observer=...)` -> ordered phase evidence:
├── caller opts into observation at the P2P boundary                  [pynccl.py]
├── callback brackets the native send or receive call                 [pynccl.py]
│   └── private result seam returns the exact native status           [pynccl_wrapper.py]
├── worker brackets every asynchronous-error query                    [pynccl.py]
│   └── callback separates query API status from communicator state   [pynccl.py]
└── timeout or error brackets communicator abort                      [pynccl.py]
```

## Diff stats

```text
  Total: +468 / −23 across 4 files
  Core code ···· +162 / −23  (38%)
  Tests ········ +305 / −0   (62%)
  Scripts ······ +1 / −0      (0%)
```
<!--mr-summary:end-->