### PR TITLE
fix: release capacity for discarded rollouts

### DIFF
--- a/cosmos_rl/dispatcher/run_web_panel.py
+++ b/cosmos_rl/dispatcher/run_web_panel.py
@@ -689,6 +689,9 @@ async def put_rollout_group(rollout: RolloutRequest):
                 controller.policy_status_manager.on_rollout_is_end(
                     controller.rollout_status_manager
                 )
+                controller.policy_status_manager.forget_discard_reports(
+                    rollout.src_replica_name
+                )
 
             return {"message": "Rollout end signal received"}
 
@@ -702,6 +705,15 @@ async def put_rollout_group(rollout: RolloutRequest):
         ]
         policy_status = controller.policy_status_manager
         is_dapo = controller.config.train.train_policy.variant == "dapo"
+        if "discarded_samples" in rollout.metrics:
+            discarded_samples = policy_status._parse_non_negative_count(
+                rollout.metrics, "discarded_samples"
+            )
+            policy_status.settle_discarded_samples(
+                source_replica=rollout.src_replica_name,
+                report_id=rollout.metrics.get("discard_report_id"),
+                count=discarded_samples,
+            )
         if policy_status.rollout_admission_closed():
             policy_status.cleanup_terminal_rollouts(
                 rollouts,

--- a/cosmos_rl/dispatcher/status.py
+++ b/cosmos_rl/dispatcher/status.py
@@ -282,6 +282,7 @@ class PolicyStatusManager:
         self.rollout_buffer = Queue()
         self.remain_samples_num = 0
         self.samples_on_the_fly = 0
+        self._applied_discard_report_ids: Dict[str, set[str]] = {}
 
         # Actual rollout count for each in-flight real training command.
         # Entries are keyed by the command step and consumed after its full
@@ -1111,7 +1112,7 @@ class PolicyStatusManager:
         if type(value) is int and value >= 0:
             return value
         logger.warning(
-            "[Controller] Ignoring malformed DAPO metric %s=%r; expected a "
+            "[Controller] Ignoring malformed accounting metric %s=%r; expected a "
             "non-negative integer",
             key,
             value,
@@ -1140,6 +1141,39 @@ class PolicyStatusManager:
             self.samples_on_the_fly,
             extra=f"settled_count={count}",
         )
+
+    def settle_discarded_samples(
+        self,
+        source_replica: str,
+        report_id: Any,
+        count: int,
+    ) -> int:
+        """Settle one idempotent report of terminally discarded samples."""
+        if count <= 0:
+            return 0
+        if not isinstance(report_id, str) or not report_id:
+            logger.warning(
+                "[Controller] Ignoring discarded_samples=%d from %s without "
+                "a non-empty discard_report_id",
+                count,
+                source_replica,
+            )
+            return 0
+
+        applied_ids = self._applied_discard_report_ids.setdefault(source_replica, set())
+        if report_id in applied_ids:
+            return 0
+        applied_ids.add(report_id)
+
+        self.filter_records["rollout_failed"] = (
+            self.filter_records.get("rollout_failed", 0) + count
+        )
+        self._settle_samples_on_the_fly(count, "rollout_failure")
+        return count
+
+    def forget_discard_reports(self, source_replica: str) -> None:
+        """Release discard-report deduplication state for an ended replica."""
+        self._applied_discard_report_ids.pop(source_replica, None)
 
     def _discard_rollouts(self, rollouts: List[Rollout], source: str) -> int:
         if not rollouts:

--- a/cosmos_rl/rollout/worker/rollout_control.py
+++ b/cosmos_rl/rollout/worker/rollout_control.py
@@ -2301,6 +2301,30 @@ class DisaggregatedRolloutControlWorker(RolloutWorkerBase):
                         self.send_end_signal()
         logger.info(f"[Rollout] Main loop of {self.replica_name} finished")
 
+    def _report_discarded_samples(self, count: int) -> None:
+        """Report fetched samples that terminated without trainable results."""
+        if count <= 0 or not self.should_report:
+            return
+
+        report_id = uuid.uuid4().hex
+        response = RolloutRequest(
+            src_replica_name=self.replica_name,
+            src_global_rank=self.global_rank,
+            payloads=[],
+            metrics={
+                "discarded_samples": count,
+                "discard_report_id": report_id,
+            },
+            is_end=False,
+        )
+        if not self.api_client.post_rollout_completion(response):
+            logger.error(
+                "[Rollout] Failed to report %d discarded samples "
+                "(discard_report_id=%s)",
+                count,
+                report_id,
+            )
+
     def _filter_valid_rollout_results_and_report(
         self, rollout_results: List[RolloutResult], payloads_list: List[RLPayload]
     ) -> Tuple[List[RolloutResult], List[RLPayload]]:
@@ -2364,6 +2388,11 @@ class DisaggregatedRolloutControlWorker(RolloutWorkerBase):
                     rr.completions = output_texts
                     valid_result.append(rr)
                     valid_payloads_list.append(payload)
+
+        self._report_discarded_samples(
+            (len(payloads_list) - len(valid_payloads_list))
+            * self.config.rollout.n_generation
+        )
 
         should_report = self.should_report and len(valid_result) > 0
         if should_report:
@@ -2433,6 +2462,9 @@ class DisaggregatedRolloutControlWorker(RolloutWorkerBase):
         )
 
         if len(rollout_results) == 0:
+            self._report_discarded_samples(
+                len(payloads_list) * self.config.rollout.n_generation
+            )
             logger.debug(
                 "[one_step_generation exit] rank=%d elapsed_ms=%.1f "
                 "batch=%d produced=0 returned_false=True",

--- a/tests/test_discarded_rollout_accounting.py
+++ b/tests/test_discarded_rollout_accounting.py
@@ -1,0 +1,149 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-License-Identifier: Apache-2.0
+
+import asyncio
+from queue import Queue
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from cosmos_rl.dispatcher.protocol import RolloutRequest
+from cosmos_rl.dispatcher.status import PolicyStatusManager
+from cosmos_rl.rollout.schema import RolloutResult
+from cosmos_rl.rollout.worker.rollout_control import (
+    DisaggregatedRolloutControlWorker,
+)
+
+
+def _rollout_worker(*, n_generation: int = 2, should_report: bool = True):
+    worker = object.__new__(DisaggregatedRolloutControlWorker)
+    worker.config = SimpleNamespace(
+        train=SimpleNamespace(
+            non_text=True,
+            local_dataset=False,
+            train_policy=SimpleNamespace(bypass_reward=False),
+        ),
+        rollout=SimpleNamespace(
+            n_generation=n_generation,
+            multi_turn_config=SimpleNamespace(enable=False),
+        ),
+    )
+    worker.should_report = should_report
+    worker.replica_name = "rollout-0"
+    worker.global_rank = 3
+    worker.current_weight_version = 0
+    worker.api_client = SimpleNamespace(
+        post_rollout_completion=MagicMock(return_value=True)
+    )
+    worker.reward_dispatcher = SimpleNamespace(enqueue_rewards_cal=MagicMock())
+    worker.enqueue_teacher_calculation = lambda payloads: payloads
+    return worker
+
+
+def test_empty_non_text_result_reports_reserved_samples():
+    worker = _rollout_worker(n_generation=2)
+    payload = SimpleNamespace(prompt_idx=7)
+
+    valid_payloads, valid_results = worker._filter_valid_rollout_results_and_report(
+        [RolloutResult(completions=[])],
+        [payload],
+    )
+
+    assert valid_payloads == []
+    assert valid_results == []
+    worker.reward_dispatcher.enqueue_rewards_cal.assert_not_called()
+    request = worker.api_client.post_rollout_completion.call_args.args[0]
+    assert request.payloads == []
+    assert request.src_replica_name == "rollout-0"
+    assert request.src_global_rank == 3
+    assert request.metrics["discarded_samples"] == 2
+    assert request.metrics["discard_report_id"]
+
+
+def test_empty_outer_result_reports_every_consumed_prompt():
+    worker = _rollout_worker(n_generation=4)
+    worker._prompt_queue = Queue()
+    worker._prompt_queue.put(
+        [SimpleNamespace(prompt_idx=0), SimpleNamespace(prompt_idx=1)]
+    )
+    worker._call_rollout_generation = MagicMock(return_value=[])
+    worker.inference_stream = None
+    worker.data_packer = None
+    worker.data_fetcher = None
+
+    assert worker.one_step_generation() is False
+
+    request = worker.api_client.post_rollout_completion.call_args.args[0]
+    assert request.metrics["discarded_samples"] == 8
+
+
+def test_non_reporting_rank_does_not_report_discard():
+    worker = _rollout_worker(should_report=False)
+
+    worker._filter_valid_rollout_results_and_report(
+        [RolloutResult(completions=[])],
+        [SimpleNamespace(prompt_idx=0)],
+    )
+
+    worker.api_client.post_rollout_completion.assert_not_called()
+
+
+def test_discard_settlement_is_idempotent_per_replica_and_report():
+    manager = PolicyStatusManager()
+    manager.samples_on_the_fly = 10
+
+    assert manager.settle_discarded_samples("rollout-0", "report-1", 3) == 3
+    assert manager.samples_on_the_fly == 7
+    assert manager.settle_discarded_samples("rollout-0", "report-1", 3) == 0
+    assert manager.samples_on_the_fly == 7
+    assert manager.settle_discarded_samples("rollout-0", "report-2", 2) == 2
+    assert manager.samples_on_the_fly == 5
+    assert manager.filter_records["rollout_failed"] == 5
+
+    manager.forget_discard_reports("rollout-0")
+    assert "rollout-0" not in manager._applied_discard_report_ids
+
+
+def test_discard_settlement_requires_report_id():
+    manager = PolicyStatusManager()
+    manager.samples_on_the_fly = 5
+
+    assert manager.settle_discarded_samples("rollout-0", None, 2) == 0
+    assert manager.samples_on_the_fly == 5
+    assert manager.filter_records == {}
+
+
+def test_http_discard_report_settles_before_normal_admission():
+    from cosmos_rl.dispatcher import run_web_panel
+
+    policy_status = SimpleNamespace(
+        _parse_non_negative_count=PolicyStatusManager._parse_non_negative_count,
+        settle_discarded_samples=MagicMock(),
+        rollout_admission_closed=lambda: False,
+        filter_outdated_rollouts=lambda rollouts: rollouts,
+    )
+    fake_controller = SimpleNamespace(
+        policy_status_manager=policy_status,
+        config=SimpleNamespace(
+            train=SimpleNamespace(train_policy=SimpleNamespace(variant="grpo"))
+        ),
+        put_rollouts=AsyncMock(),
+    )
+    request = RolloutRequest(
+        src_replica_name="rollout-0",
+        payloads=[],
+        metrics={
+            "discarded_samples": 4,
+            "discard_report_id": "report-1",
+        },
+    )
+
+    with patch.object(run_web_panel, "controller", fake_controller):
+        response = asyncio.run(run_web_panel.put_rollout_group(request))
+
+    assert response == {"message": "Rollout put"}
+    policy_status.settle_discarded_samples.assert_called_once_with(
+        source_replica="rollout-0",
+        report_id="report-1",
+        count=4,
+    )
+    fake_controller.put_rollouts.assert_awaited_once_with([])


### PR DESCRIPTION
## Summary

- report terminal rollout failures through the existing RolloutRequest.metrics envelope
- idempotently settle samples_on_the_fly so failed rollouts release reserved capacity
- cover both whole-batch failures and per-payload empty results

## Backwards compatibility

- no changes to RolloutRequest, RolloutResult, or rollout backend interfaces
- existing workers remain unchanged against the new controller
- new metrics are ignored safely by older controllers

## Validation

- precommit-changed-branch-files
- 6 passed: tests/test_discarded_rollout_accounting.py
- 41 passed, 12 subtests passed: existing terminal-drain and ranked-rollout tests