### PR TITLE
fix(policy): abort NCCL + tear down before unregister on RL policy shutdown

### DIFF
--- a/cosmos_rl/policy/worker/rl_worker.py
+++ b/cosmos_rl/policy/worker/rl_worker.py
@@ -43,6 +43,7 @@ from cosmos_rl.utils.parallelism_map import (
 )
 from cosmos_rl.utils.pynccl import (
     bounded_drain_or_abort,
+    nccl_abort_all,
     nccl_group_start,
     nccl_group_end,
 )
@@ -252,7 +253,21 @@ class RLPolicyWorker(PolicyWorkerBase):
                 self.heartbeat_thread.join()
                 self.heartbeat_thread = None
 
-            # Manually unregister from controller
+            # Complete NCCL + distributed teardown BEFORE announcing departure.
+            # unregister_from_controller() arms the controller's
+            # COSMOS_SHUTDOWN_ON_NO_POLICY_REPLICAS fast-reap, which SIGTERMs the
+            # job within ~8s.  If we unregister first, the reap pre-empts the
+            # trailing sleep and destroy_worker() (in execute()'s finally) never
+            # runs -- leaving the weight-sync comm (idx=0) un-aborted (a latent
+            # hang were the reap ever disabled) and no graceful teardown.  The
+            # background threads above are joined, so no comm is in use here;
+            # nccl_abort_all() is idempotent and forces any in-flight collective
+            # to stop, so a departed peer can't wedge the destroy.
+            nccl_abort_all()
+            self.destroy_worker()
+
+            # Announce departure LAST -- the reap now races an already-torn-down
+            # process, which exits cleanly instead of being killed mid-teardown.
             self.unregister_from_controller()
 
             if hasattr(self, "upload_thread") and self.upload_thread is not None:
@@ -1004,5 +1019,12 @@ class RLPolicyWorker(PolicyWorkerBase):
         )
 
     def destroy_worker(self):
+        # Idempotent: handle_shutdown() now runs the teardown before the
+        # controller reap, and execute()'s finally also calls this -- the guard
+        # prevents a double destroy_distributed / duplicate log on the graceful
+        # (non-reaped) path.
+        if getattr(self, "_worker_destroyed", False):
+            return
+        self._worker_destroyed = True
         destroy_distributed()
         logger.info("[Policy] Process group destroyed.")

--- a/tests/test_multirank_shutdown.py
+++ b/tests/test_multirank_shutdown.py
@@ -1179,5 +1179,85 @@ class TestTrainAckDuringPartialDrain(unittest.TestCase):
         self.assertFalse(psm.should_weight_sync_after_train_ack(2, rsm))
 
 
+# ---------------------------------------------------------------------------
+# Policy -- teardown-before-unregister ordering (clean fast-reap exit)
+# ---------------------------------------------------------------------------
+class TestPolicyShutdownTeardownOrder(unittest.TestCase):
+    """Bug fix (policy_shutdown_reaped_before_clean_exit): the policy must
+    complete NCCL + distributed teardown BEFORE ``unregister_from_controller()``
+    arms the controller's ``COSMOS_SHUTDOWN_ON_NO_POLICY_REPLICAS`` fast-reap.
+    Otherwise the reap SIGTERMs the process mid-``sleep(15)``, ``destroy_worker``
+    (in ``execute``'s ``finally``) never runs, and the weight-sync comm (idx=0)
+    is left un-aborted."""
+
+    @staticmethod
+    def _worker(order):
+        return SimpleNamespace(
+            shutdown_signal=threading.Event(),
+            shutdown_mp_signal=threading.Event(),
+            inter_policy_nccl=SimpleNamespace(shutdown=lambda: None),
+            fetch_rollouts_thread=None,
+            fetch_command_thread=None,
+            teacher_interact_thread=None,
+            heartbeat_thread=None,
+            upload_thread=None,
+            destroy_worker=lambda: order.append("destroy_worker"),
+            unregister_from_controller=lambda: order.append("unregister"),
+        )
+
+    def test_abort_and_destroy_before_unregister(self):
+        from cosmos_rl.policy.worker.rl_worker import RLPolicyWorker
+
+        order = []
+        worker = self._worker(order)
+        with (
+            patch(
+                "cosmos_rl.policy.worker.rl_worker.nccl_abort_all",
+                lambda: order.append("nccl_abort_all"),
+            ),
+            patch("cosmos_rl.policy.worker.rl_worker.time.sleep", lambda _s: None),
+        ):
+            RLPolicyWorker.handle_shutdown(worker)
+        self.assertIn("nccl_abort_all", order)
+        self.assertIn("destroy_worker", order)
+        self.assertIn("unregister", order)
+        # Teardown (abort + graceful destroy) must precede the reap-arming
+        # unregister.
+        self.assertLess(order.index("nccl_abort_all"), order.index("unregister"))
+        self.assertLess(order.index("destroy_worker"), order.index("unregister"))
+
+    def test_handle_shutdown_runs_once(self):
+        from cosmos_rl.policy.worker.rl_worker import RLPolicyWorker
+
+        order = []
+        worker = self._worker(order)
+        with (
+            patch(
+                "cosmos_rl.policy.worker.rl_worker.nccl_abort_all",
+                lambda: order.append("nccl_abort_all"),
+            ),
+            patch("cosmos_rl.policy.worker.rl_worker.time.sleep", lambda _s: None),
+        ):
+            RLPolicyWorker.handle_shutdown(worker)
+            RLPolicyWorker.handle_shutdown(worker)  # idempotent -- guard flag
+        self.assertEqual(order.count("unregister"), 1)
+
+    def test_destroy_worker_is_idempotent(self):
+        from cosmos_rl.policy.worker.rl_worker import RLPolicyWorker
+
+        calls = []
+        worker = SimpleNamespace()
+        with (
+            patch(
+                "cosmos_rl.policy.worker.rl_worker.destroy_distributed",
+                lambda: calls.append(1),
+            ),
+            patch("cosmos_rl.policy.worker.rl_worker.logger"),
+        ):
+            RLPolicyWorker.destroy_worker(worker)
+            RLPolicyWorker.destroy_worker(worker)  # execute()'s finally re-calls
+        self.assertEqual(calls, [1])  # destroy_distributed ran exactly once
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
RLPolicyWorker.handle_shutdown() unregistered from the controller -- which arms the COSMOS_SHUTDOWN_ON_NO_POLICY_REPLICAS fast-reap (SIGTERM within ~8s) -- and THEN did ~15s of local teardown. The reap therefore killed the process mid-sleep: destroy_worker() in execute()'s finally never ran, so the weight-sync comm (idx=0) was never aborted (a latent hang were the reap ever disabled) and the policy never logged a graceful exit.

Fix: handle_shutdown() now aborts every NCCL comm (nccl_abort_all(), idempotent) and tears down the process group BEFORE announcing departure, then unregisters last. destroy_worker() is made idempotent so execute()'s finally is a no-op on the graceful (non-reaped) path. Unit tests assert the teardown-before-unregister ordering and the idempotency.