### PR TITLE
test(policy): fix TestPolicyShutdownTeardownOrder broken by the #707+#709 merge skew

### DIFF
--- a/tests/test_multirank_shutdown.py
+++ b/tests/test_multirank_shutdown.py
@@ -1201,6 +1201,7 @@ class TestPolicyShutdownTeardownOrder(unittest.TestCase):
             teacher_interact_thread=None,
             heartbeat_thread=None,
             upload_thread=None,
+            _shutdown_payload_data_packers=lambda: order.append("shutdown_payload"),
             destroy_worker=lambda: order.append("destroy_worker"),
             unregister_from_controller=lambda: order.append("unregister"),
         )
@@ -1225,6 +1226,12 @@ class TestPolicyShutdownTeardownOrder(unittest.TestCase):
         # unregister.
         self.assertLess(order.index("nccl_abort_all"), order.index("unregister"))
         self.assertLess(order.index("destroy_worker"), order.index("unregister"))
+        # Combined teardown order: the payload data packers are released FIRST
+        # (stop prefetch + abort transport comms) so their half-open 2-rank comms
+        # can't wedge the NCCL/process-group teardown, THEN nccl_abort_all sweeps
+        # any remaining comms.
+        self.assertIn("shutdown_payload", order)
+        self.assertLess(order.index("shutdown_payload"), order.index("nccl_abort_all"))
 
     def test_handle_shutdown_runs_once(self):
         from cosmos_rl.policy.worker.rl_worker import RLPolicyWorker


### PR DESCRIPTION
PRs #707 (in-tree NCCL payload transport) and #709 (policy shutdown clean-exit) merged with no textual conflict -- their rl_worker.py edits are in different regions -- but their COMBINATION breaks TestPolicyShutdownTeardownOrder on main: #707 added an unconditional self._shutdown_payload_data_packers() at the top of handle_shutdown(), and the #709 test's SimpleNamespace stub (authored on the pre-#707 tree) doesn't provide it, so handle_shutdown(stub) raises AttributeError on the merged tree. Each PR was green on its own base; the combination was never exercised.

Add _shutdown_payload_data_packers to the stub (order-tracked) and assert the combined teardown order: payload data packers released FIRST (stop prefetch + abort the transport comms so their half-open 2-rank comms can't wedge teardown), THEN nccl_abort_all sweeps any remaining comms, THEN destroy_worker, THEN the reap-arming unregister_from_controller LAST -- the exact #707+#709 interaction that was previously untested.

3/3 TestPolicyShutdownTeardownOrder + 63/63 shutdown suite green on main; ruff clean.