### PR TITLE
fix(transport): reject nccl/ucxx payload transport under policy model parallelism

### DIFF
--- a/cosmos_rl/comm/base.py
+++ b/cosmos_rl/comm/base.py
@@ -45,6 +45,7 @@ from cosmos_rl.utils.payload_transport import (
     RedisEndpoint,
     get_payload_transfer_mode,
     is_payload_transfer_mode_explicit,
+    validate_single_receiver_topology,
 )
 import multiprocessing as mp
 from cosmos_rl.dispatcher.api.client import APIClient
@@ -241,6 +242,13 @@ class CommMixin:
         crashes loudly.  Other failures are logged and swallowed.
         """
         mode = get_payload_transfer_mode(self.config)
+        # Fail fast (before any transfer) when a point-to-point transport is
+        # paired with policy-side model parallelism: nccl/ucxx each deliver a
+        # payload to exactly ONE receiver, but the policy hands the same
+        # rollout reference to every rank sharing a DP coordinate.  Raised
+        # OUTSIDE the attach try/except below so it is never swallowed by the
+        # non-explicit-mode path -- a broken topology is fatal either way.
+        validate_single_receiver_topology(self.config, mode)
         explicit = is_payload_transfer_mode_explicit(self.config)
         transport = PayloadTransportRegistry.get_optional(mode)
         endpoint = self._build_redis_endpoint()

--- a/cosmos_rl/utils/payload_transport/__init__.py
+++ b/cosmos_rl/utils/payload_transport/__init__.py
@@ -72,12 +72,14 @@ from cosmos_rl.utils.payload_transport.prefetch_mixin import (
 from cosmos_rl.utils.payload_transport.registry import (
     DEFAULT_TRANSFER_MODE,
     LEGACY_NCCL_KEY,
+    P2P_TRANSFER_MODES,
     PAYLOAD_TRANSFER_KEY,
     PayloadTransport,
     PayloadTransportRegistry,
     RedisEndpoint,
     get_payload_transfer_mode,
     is_payload_transfer_mode_explicit,
+    validate_single_receiver_topology,
 )
 
 # Importing the NCCL submodule registers the backend as a side effect.
@@ -91,6 +93,7 @@ PayloadTransportRegistry.register_default_redis()
 __all__ = [
     "DEFAULT_TRANSFER_MODE",
     "LEGACY_NCCL_KEY",
+    "P2P_TRANSFER_MODES",
     "PAYLOAD_TRANSFER_KEY",
     "PayloadTransport",
     "PayloadTransportRegistry",
@@ -98,4 +101,5 @@ __all__ = [
     "RedisEndpoint",
     "get_payload_transfer_mode",
     "is_payload_transfer_mode_explicit",
+    "validate_single_receiver_topology",
 ]

--- a/cosmos_rl/utils/payload_transport/registry.py
+++ b/cosmos_rl/utils/payload_transport/registry.py
@@ -421,6 +421,76 @@ def is_payload_transfer_mode_explicit(config: Any) -> bool:
     return bool(legacy)
 
 
+#: Transports that deliver each payload to exactly ONE receiver.  ``redis`` is
+#: absent on purpose: a GET is non-destructive and repeatable, so several ranks
+#: may resolve the same reference.
+P2P_TRANSFER_MODES = ("nccl", "ucxx")
+
+
+def validate_single_receiver_topology(config: Any, mode: str) -> None:
+    """Reject a point-to-point payload transport paired with policy-side
+    model parallelism.
+
+    ``nccl`` and ``ucxx`` both deliver a payload to exactly one receiver:
+
+    * a UCXX slot is single-consumer -- the server marks it ``FREE`` after the
+      first successful read, so any later reader gets ``StaleSlotError``;
+    * an NCCL send buffer is reaped once its send drains, so a later requester
+      can find the buffer already recycled.
+
+    Meanwhile the policy scatters rollout *references* by DP coordinate (see
+    ``RLWorker._prepare_rollouts``), handing the SAME reference to every rank
+    sharing a DP id; each then resolves it independently.  Ranks per DP
+    coordinate is ``cp * tp * pp`` -- ``world_size`` factorises as
+    ``dp_replicate * dp_shard * cp * tp * pp`` (see
+    :meth:`ParallelDims._validate`) -- so any of those dims above 1 puts
+    several ranks on one payload.
+
+    The result is dropped episodes, and because the ranks of a TP/CP/PP group
+    must train on the SAME batch, divergent batches then mismatch that group's
+    collectives and hang.  Refuse to start instead of failing mid-run.
+
+    Args:
+        config: A cosmos-rl ``Config``-like object.
+        mode: The resolved transport name from
+            :func:`get_payload_transfer_mode`.
+
+    Raises:
+        ValueError: when ``mode`` is point-to-point and the policy is
+            configured with non-data parallelism.
+    """
+    if mode not in P2P_TRANSFER_MODES:
+        return
+    parallelism = getattr(getattr(config, "policy", None), "parallelism", None)
+    if parallelism is None:
+        return
+
+    dims = {
+        name: int(getattr(parallelism, name, 1) or 1)
+        for name in ("tp_size", "cp_size", "pp_size")
+    }
+    offending = {name: size for name, size in dims.items() if size > 1}
+    if not offending:
+        return
+
+    receivers = dims["tp_size"] * dims["cp_size"] * dims["pp_size"]
+    detail = ", ".join(
+        f"policy.parallelism.{name}={size}" for name, size in sorted(offending.items())
+    )
+    raise ValueError(
+        f"[custom].{PAYLOAD_TRANSFER_KEY}={mode!r} requires a single-receiver "
+        f"policy topology, but {detail}. The {mode} payload transport delivers "
+        f"each trajectory to exactly ONE receiver, while the policy hands the "
+        f"same rollout reference to every rank sharing a DP coordinate "
+        f"({receivers} ranks here) -- they would race for one payload and all "
+        f"but one would drop the episode, then diverge and hang on the group's "
+        f"collectives. Set policy.parallelism.tp_size / cp_size / pp_size = 1 "
+        f"(pure data parallelism), or use "
+        f'[custom].{PAYLOAD_TRANSFER_KEY} = "redis", which supports repeated '
+        f"reads."
+    )
+
+
 def _maybe_autoload_backend(name: str) -> None:
     """Best-effort import of optional backends keyed by transport name.
 
@@ -444,10 +514,12 @@ def _maybe_autoload_backend(name: str) -> None:
 __all__ = [
     "DEFAULT_TRANSFER_MODE",
     "LEGACY_NCCL_KEY",
+    "P2P_TRANSFER_MODES",
     "PAYLOAD_TRANSFER_KEY",
     "PayloadTransport",
     "PayloadTransportRegistry",
     "RedisEndpoint",
     "get_payload_transfer_mode",
     "is_payload_transfer_mode_explicit",
+    "validate_single_receiver_topology",
 ]

--- a/tests/test_comm_base_attach.py
+++ b/tests/test_comm_base_attach.py
@@ -90,9 +90,13 @@ class _CommHarness(CommMixin):
     ``_attach_payload_transport`` in isolation.
     """
 
-    def __init__(self, *, mode, data_packer, val_data_packer=None):
+    def __init__(self, *, mode, data_packer, val_data_packer=None, parallelism=None):
         self.role = "test_role"
         self.config = SimpleNamespace(custom={PAYLOAD_TRANSFER_KEY: mode})
+        if parallelism is not None:
+            self.config.policy = SimpleNamespace(
+                parallelism=SimpleNamespace(**parallelism)
+            )
         self.data_packer = data_packer
         if val_data_packer is not None:
             self.val_data_packer = val_data_packer
@@ -151,6 +155,71 @@ class TestAttachPayloadTransportContract(unittest.TestCase):
         with self._patch_nccl_redis(factory):
             harness._attach_payload_transport()
         self.assertFalse(hasattr(packer, "_nccl_dp_receiver_replica"))
+
+
+class TestSingleReceiverTopologyGuard(unittest.TestCase):
+    """The nccl/ucxx single-receiver guard, through the real attach path.
+
+    Both transports deliver a payload to exactly ONE receiver, while the policy
+    hands the same rollout reference to every rank sharing a DP coordinate.  The
+    guard must reject that topology at attach time -- before any transfer -- and
+    must do so regardless of whether the transport attach itself would succeed.
+    """
+
+    def _patch_nccl_redis(self, fake_factory):
+        return mock.patch(
+            "cosmos_rl.utils.payload_transport.nccl.transport._redis_lib",
+            SimpleNamespace(Redis=fake_factory),
+        )
+
+    def test_attach_rejects_model_parallel_policy(self):
+        for mode in ("nccl", "ucxx"):
+            for dim in ("tp_size", "cp_size", "pp_size"):
+                with self.subTest(mode=mode, dim=dim):
+                    harness = _CommHarness(
+                        mode=mode,
+                        data_packer=_NcclAwarePacker(),
+                        parallelism={dim: 2},
+                    )
+                    with self.assertRaises(ValueError) as ctx:
+                        harness._attach_payload_transport()
+                    self.assertIn(f"{dim}=2", str(ctx.exception))
+
+    def test_guard_raises_even_when_mode_not_explicit_is_irrelevant(self):
+        # The guard runs OUTSIDE the attach try/except, so it is never
+        # downgraded to a warning the way an attach ImportError/RuntimeError is
+        # for a non-explicitly-selected transport.
+        harness = _CommHarness(
+            mode="ucxx",  # ucxx-cu12 need not be installed; guard fires first
+            data_packer=_NoOpPacker(),
+            parallelism={"tp_size": 8},
+        )
+        with self.assertRaises(ValueError):
+            harness._attach_payload_transport()
+
+    def test_attach_allows_pure_data_parallel(self):
+        # tp/cp/pp all 1 -> exactly one receiver per transfer -> attach proceeds
+        # normally and still wires the packer.
+        packer = _NcclAwarePacker()
+        fake = _FakeRedis()
+        harness = _CommHarness(
+            mode="nccl",
+            data_packer=packer,
+            parallelism={"tp_size": 1, "cp_size": 1, "pp_size": 1},
+        )
+        with self._patch_nccl_redis(_FakeRedisFactory(fake)):
+            harness._attach_payload_transport()
+        self.assertIs(packer.redis_client, fake)
+        self.assertTrue(packer.post_called)
+
+    def test_attach_allows_model_parallel_under_redis(self):
+        # redis GETs are repeatable, so model parallelism is fine there.
+        harness = _CommHarness(
+            mode="redis",
+            data_packer=_NoOpPacker(),
+            parallelism={"tp_size": 8, "cp_size": 2, "pp_size": 4},
+        )
+        harness._attach_payload_transport()  # must not raise
 
     def test_ping_failure_leaves_packer_unchanged(self):
         # If Redis ping fails, the packer must not be left in a half-

--- a/tests/test_payload_transport.py
+++ b/tests/test_payload_transport.py
@@ -41,11 +41,13 @@ from unittest import mock
 from cosmos_rl.utils.payload_transport import (
     PAYLOAD_TRANSFER_KEY,
     LEGACY_NCCL_KEY,
+    P2P_TRANSFER_MODES,
     PayloadTransport,
     PayloadTransportRegistry,
     RedisEndpoint,
     get_payload_transfer_mode,
     is_payload_transfer_mode_explicit,
+    validate_single_receiver_topology,
 )
 from cosmos_rl.utils.payload_transport.nccl import (
     NCCL_COMPLETION_PREFIX,
@@ -563,6 +565,86 @@ class TestIsPayloadTransferModeExplicit(unittest.TestCase):
     def test_empty_string_is_not_explicit(self):
         config = SimpleNamespace(custom={PAYLOAD_TRANSFER_KEY: "   "})
         self.assertFalse(is_payload_transfer_mode_explicit(config))
+
+
+def _cfg_parallelism(*, tp_size=1, cp_size=1, pp_size=1, **extra):
+    """Config exposing only ``policy.parallelism`` (transport mode is passed
+    to the validator directly, so ``custom`` is irrelevant here)."""
+    return SimpleNamespace(
+        policy=SimpleNamespace(
+            parallelism=SimpleNamespace(
+                tp_size=tp_size, cp_size=cp_size, pp_size=pp_size, **extra
+            )
+        )
+    )
+
+
+class TestValidateSingleReceiverTopology(unittest.TestCase):
+    """nccl/ucxx deliver each payload to exactly ONE receiver, but the policy
+    hands the same rollout reference to every rank sharing a DP coordinate
+    (``cp * tp * pp`` of them).  Any non-DP policy parallelism must fail loud
+    at startup rather than dropping episodes and hanging mid-run."""
+
+    def test_pure_data_parallel_is_allowed(self):
+        for mode in P2P_TRANSFER_MODES:
+            with self.subTest(mode=mode):
+                validate_single_receiver_topology(_cfg_parallelism(), mode)
+
+    def test_tensor_parallel_rejected(self):
+        for mode in P2P_TRANSFER_MODES:
+            with self.subTest(mode=mode):
+                with self.assertRaises(ValueError) as ctx:
+                    validate_single_receiver_topology(_cfg_parallelism(tp_size=2), mode)
+                self.assertIn("tp_size=2", str(ctx.exception))
+
+    def test_context_parallel_rejected(self):
+        # cp is NOT covered by a tp_size==1 check -- it splits the same batch
+        # across ranks just like tp, so it must be caught too.
+        with self.assertRaises(ValueError) as ctx:
+            validate_single_receiver_topology(_cfg_parallelism(cp_size=2), "nccl")
+        self.assertIn("cp_size=2", str(ctx.exception))
+
+    def test_pipeline_parallel_rejected(self):
+        with self.assertRaises(ValueError) as ctx:
+            validate_single_receiver_topology(_cfg_parallelism(pp_size=4), "ucxx")
+        self.assertIn("pp_size=4", str(ctx.exception))
+
+    def test_error_reports_every_offending_dim_and_receiver_count(self):
+        with self.assertRaises(ValueError) as ctx:
+            validate_single_receiver_topology(
+                _cfg_parallelism(tp_size=2, cp_size=2, pp_size=2), "nccl"
+            )
+        msg = str(ctx.exception)
+        for field in ("tp_size=2", "cp_size=2", "pp_size=2"):
+            self.assertIn(field, msg)
+        # cp * tp * pp = 8 ranks would race for one payload.
+        self.assertIn("8 ranks", msg)
+        # Actionable: names both escape hatches.
+        self.assertIn("redis", msg)
+
+    def test_redis_is_unaffected(self):
+        # A redis GET is non-destructive/repeatable, so model parallelism is
+        # fine there -- the guard must not fire.
+        validate_single_receiver_topology(
+            _cfg_parallelism(tp_size=8, cp_size=2, pp_size=4), "redis"
+        )
+
+    def test_missing_policy_config_is_tolerated(self):
+        # Rollout/reference workers may carry a config without policy dims;
+        # the guard must not crash on them.
+        validate_single_receiver_topology(SimpleNamespace(), "nccl")
+        validate_single_receiver_topology(SimpleNamespace(policy=None), "nccl")
+
+    def test_absent_or_none_dims_default_to_one(self):
+        # Sparse configs (missing keys, explicit None) must read as 1, not fail.
+        cfg = SimpleNamespace(policy=SimpleNamespace(parallelism=SimpleNamespace()))
+        validate_single_receiver_topology(cfg, "nccl")
+        cfg_none = SimpleNamespace(
+            policy=SimpleNamespace(
+                parallelism=SimpleNamespace(tp_size=None, cp_size=None, pp_size=None)
+            )
+        )
+        validate_single_receiver_topology(cfg_none, "nccl")
 
 
 class TestPayloadTransportDefaults(unittest.TestCase):


### PR DESCRIPTION
## What

  Refuses to start when `payload_transfer` is `nccl` or `ucxx` and the policy is
  configured with non-data parallelism (`policy.parallelism.{tp,cp,pp}_size > 1`).

  ## Why

  Both P2P payload transports deliver a payload to exactly **one** receiver:

  - **UCXX is single-consumer by construction.** The slot state machine is
    `FREE → WRITING → READY → READING → FREE`, and the server handler is the
    "unique owner" of the `READING → FREE` transition — it calls
    `mark_consumed(slot)` after a successful send (`ucxx_buffer.py`). A second
    reader gets status `1` → `StaleSlotError`. Deterministic, not a race. (A prior
    refcounting design, `_SlotReadGuard`, was tried and abandoned.)
  - **NCCL** was built for multiple receivers, but `_send_drained` frees the
    buffer once the first receiver's send drains.

  Meanwhile the policy scatters rollout **references** by DP coordinate
  (`rl_worker.py`), handing the same reference to every rank sharing a DP id;
  each rank then resolves it independently over the transport. Ranks per DP
  coordinate is `cp * tp * pp`.

  So under TP/CP/PP > 1 all but one rank drops the episode — and because the ranks
  of such a group must train on the *same* batch, the divergent batches then
  mismatch that group's collectives and hang.

  `tp_size` **defaults to 2**, so this combination was reachable by default with
  no guard anywhere.

  ## Notes for review

  - The check is `cp * tp * pp`, not `tp` alone — CP and PP create the identical
    condition, and a `tp_size == 1` check would let `cp_size=2` straight through.
  - It reads `config.policy.parallelism` rather than the local mesh, because
    `init_data_packer` also runs on rollout and reference workers where
    `parallel_dims` is the wrong mesh.
  - It is raised **outside** the attach `try/except`, so a broken topology is
    always fatal and never downgraded to a warning for a non-explicitly-selected
    transport.
  - `redis` is exempt: a GET is non-destructive and repeatable.
  - Because `tp_size` defaults to 2, this will hard-fail configs that enable
    nccl/ucxx without setting the parallelism dims — intended, since those runs
    are broken today, but it is a visible behaviour change. The error names the
    exact fields to set.

  13 tests, including the guard firing through the real attach path before any
  transport work happens.