### PR TITLE
fix(transport): cleanup channel for elastic replicas, and UCXX consumer predicate

### DIFF
--- a/cosmos_rl/utils/payload_transport/nccl/protocol.py
+++ b/cosmos_rl/utils/payload_transport/nccl/protocol.py
@@ -149,17 +149,19 @@ def parse_transfer_rollout_idx(transfer_id: str) -> int:
         return -1
 
 
-def build_transfer_rollout_candidates(
-    *,
-    transfer_id: str,
-    num_rollout_replicas: Optional[int] = None,
-) -> List[int]:
-    """Return the canonical rollout index encoded in ``transfer_id``, if valid."""
-    normalized = _coerce_nonnegative_int(num_rollout_replicas)
+def build_transfer_rollout_candidates(*, transfer_id: str) -> List[int]:
+    """Return the canonical rollout index encoded in ``transfer_id``, if valid.
+
+    Deliberately validates the parse ONLY -- it does not bound the index against
+    a replica count.  It used to be capped by ``n_init_replicas``, which silently
+    dropped every transfer belonging to a replica added mid-run (elastic
+    scale-up): no cleanup was ever published for it, so the producer held its
+    send buffer until capacity eviction.  The trade is asymmetric -- publishing
+    to a channel nobody subscribes to is a no-op, while withholding a publish
+    pins GPU memory -- so no upper bound is the correct behaviour.
+    """
     parsed_prefix = parse_transfer_rollout_idx(transfer_id)
     if parsed_prefix < 0:
-        return []
-    if normalized is not None and parsed_prefix >= normalized:
         return []
     return [parsed_prefix]
 

--- a/cosmos_rl/utils/payload_transport/nccl/transport.py
+++ b/cosmos_rl/utils/payload_transport/nccl/transport.py
@@ -350,19 +350,12 @@ class NcclPayloadTransport(PayloadTransport):
         job_id = os.environ.get("SLURM_JOB_ID", "test")
         prefix = build_nccl_prefix(experiment_name=experiment_name, job_id=job_id)
 
-        num_rollout_replicas: Optional[int] = None
-        try:
-            num_rollout_replicas = config.rollout.parallelism.n_init_replicas
-        except AttributeError:
-            pass
-
         published = 0
         max_retries = 3
         for transfer_id in transfer_ids:
             try:
                 rollout_indices = build_transfer_rollout_candidates(
-                    transfer_id=transfer_id,
-                    num_rollout_replicas=num_rollout_replicas,
+                    transfer_id=transfer_id
                 )
                 for rollout_idx in rollout_indices:
                     channel = build_cleanup_channel(

--- a/cosmos_rl/utils/payload_transport/ucxx/data_packer_mixin.py
+++ b/cosmos_rl/utils/payload_transport/ucxx/data_packer_mixin.py
@@ -302,21 +302,15 @@ class UCXXDataPackerMixin(PrefetchDataPackerMixin):
     def _cache_key(self, rollout_output: Any) -> str:
         return self._ucxx_dp_cache_key(rollout_output)
 
-    def _filter_prefetch_tasks(self, rollouts: List[Any]) -> List[Any]:
-        """UCXX requires both ``_ucxx`` AND ``_ucxx_enabled`` true.
-
-        Slightly stricter than the base default (which would defer to
-        :meth:`_should_intercept` -- equivalent here, but kept explicit
-        because UCXX shipped with the dual-flag check before the base
-        mixin existed and downstream observability hooks may rely on
-        seeing both flags evaluated).
-        """
-        tasks: List[Any] = []
-        for i, rollout in enumerate(rollouts):
-            ro = rollout.completion if hasattr(rollout, "completion") else rollout
-            if isinstance(ro, dict) and ro.get("_ucxx") and ro.get("_ucxx_enabled"):
-                tasks.append((i, ro))
-        return tasks
+    # NOTE: deliberately NO _filter_prefetch_tasks override.  The base default
+    # already delegates to :meth:`_should_intercept`, which is the only way to
+    # guarantee that what the trainer intercepts is exactly what gets
+    # prefetched.  The override that used to live here re-implemented the
+    # predicate as ``ro.get("_ucxx") and ro.get("_ucxx_enabled")`` -- reading a
+    # MISSING ``_ucxx_enabled`` as disabled, where _should_intercept reads it as
+    # enabled.  Such a ref was intercepted but never prefetched, so every one of
+    # its episodes took the blocking _sync_fetch path forever: a silent,
+    # permanent slow path rather than a failure.
 
     def _fetch_batch(self, tasks: List[Any]) -> Dict[str, Any]:
         """Run the async UCXX fetch on this thread's event loop.

--- a/tests/test_multirank_shutdown.py
+++ b/tests/test_multirank_shutdown.py
@@ -707,8 +707,15 @@ class TestRolloutCheckoutGate(unittest.TestCase):
             rollout_replicas=replicas,
             maintain_life_status=MagicMock(),
         )
-        rsm.all_rollouts_ended = lambda: all(
-            r.status.ended for r in rsm.rollout_replicas.values()
+        # Mirror production EXACTLY (RolloutStatusManager.all_rollouts_ended):
+        # the `len(...) > 0` clause matters.  A stub that returns True for an
+        # empty set makes test_returns_true_when_no_rollouts_exist pass even if
+        # the `len(rollout_replicas) == 0` early return in _await_rollout_checkout
+        # is deleted -- the loop simply never runs.  The stub would BE the
+        # assertion, and production would spin the full heartbeat timeout.
+        rsm.all_rollouts_ended = lambda: (
+            len(rsm.rollout_replicas) > 0
+            and all(r.status.ended for r in rsm.rollout_replicas.values())
         )
         return SimpleNamespace(
             rollout_status_manager=rsm, policy_status_manager=object()

--- a/tests/test_nccl_transport.py
+++ b/tests/test_nccl_transport.py
@@ -77,15 +77,21 @@ class TestPublishCleanup(unittest.TestCase):
         self.assertIn(ch0, channels)
         self.assertIn(ch2, channels)
 
-    def test_out_of_range_replica_skipped(self):
+    def test_replica_beyond_initial_count_still_gets_cleanup(self):
+        # Elastic scale-up: rollout idx 9 is past n_init_replicas(4).  Cleanup
+        # used to be withheld for exactly these transfers, so the producer held
+        # its send buffer until capacity eviction.  Publishing to a channel
+        # nobody subscribes to is a harmless no-op; withholding pins GPU memory.
         redis = FakeRedis()
         t = NcclPayloadTransport()
-        # rollout idx 9 >= n_init_replicas(4) -> no candidate -> nothing published.
         n = t.publish_cleanup_for_discarded(
             transfer_ids=["9:abc"], config=self._config(), redis_client=redis
         )
-        self.assertEqual(n, 1)  # counted as handled...
-        self.assertEqual(redis.published, [])  # ...but nothing published
+        self.assertEqual(n, 1)
+        self.assertEqual(len(redis.published), 1)
+        channel, payload = redis.published[0]
+        self.assertIn("rollout_comm:9", channel)
+        self.assertIn("9:abc", payload)
 
     def test_no_redis_client_returns_zero(self):
         t = NcclPayloadTransport()

--- a/tests/test_nccl_transport.py
+++ b/tests/test_nccl_transport.py
@@ -13,21 +13,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Tests for the NCCL transport backend: registration, cleanup dispatch,
-and the two ``attach_data_packer`` paths (in-tree mixin vs legacy)."""
+"""Tests for the NCCL transport backend.
+
+Scoped to behaviour unique to this module.  Registration, ``active_for_completion``
+dispatch, the legacy attach path, and the no-op-for-unrelated-packer contract are
+covered once in ``test_payload_transport.py`` with stronger assertions, so they
+are deliberately not duplicated here.
+"""
 
 import unittest
 from types import SimpleNamespace
 from unittest import mock
 
-from cosmos_rl.utils.payload_transport import PayloadTransportRegistry, RedisEndpoint
-from cosmos_rl.utils.payload_transport.nccl import (
-    NCCL_COMPLETION_PREFIX,
-    NcclPayloadTransport,
-    build_cleanup_channel,
-    build_nccl_prefix,
-    build_rollout_prefix,
-)
+from cosmos_rl.utils.payload_transport import RedisEndpoint
+from cosmos_rl.utils.payload_transport.nccl import NcclPayloadTransport
 
 
 class FakeRedis:
@@ -39,43 +38,12 @@ class FakeRedis:
         return 1
 
 
-class TestRegistration(unittest.TestCase):
-    def test_registered_with_prefix(self):
-        t = PayloadTransportRegistry.get("nccl")
-        self.assertIsInstance(t, NcclPayloadTransport)
-        self.assertEqual(t.completion_prefix, NCCL_COMPLETION_PREFIX)
-
-    def test_active_for_completion(self):
-        t = PayloadTransportRegistry.active_for_completion("nccl:0:abc")
-        self.assertIsInstance(t, NcclPayloadTransport)
-        self.assertIsNone(PayloadTransportRegistry.active_for_completion("plain"))
-        self.assertIsNone(
-            PayloadTransportRegistry.active_for_completion({"_nccl": True})
-        )
-
-
 class TestPublishCleanup(unittest.TestCase):
     def _config(self):
         return SimpleNamespace(
             logging=SimpleNamespace(experiment_name="exp"),
             rollout=SimpleNamespace(parallelism=SimpleNamespace(n_init_replicas=4)),
         )
-
-    def test_publishes_to_rollout_cleanup_channel(self):
-        redis = FakeRedis()
-        t = NcclPayloadTransport()
-        n = t.publish_cleanup_for_discarded(
-            transfer_ids=["0:abc", "2:def"],
-            config=self._config(),
-            redis_client=redis,
-        )
-        self.assertEqual(n, 2)
-        prefix = build_nccl_prefix(experiment_name="exp", job_id="test")
-        ch0 = build_cleanup_channel(build_rollout_prefix(prefix, 0))
-        ch2 = build_cleanup_channel(build_rollout_prefix(prefix, 2))
-        channels = {c for c, _ in redis.published}
-        self.assertIn(ch0, channels)
-        self.assertIn(ch2, channels)
 
     def test_replica_beyond_initial_count_still_gets_cleanup(self):
         # Elastic scale-up: rollout idx 9 is past n_init_replicas(4).  Cleanup
@@ -92,15 +60,6 @@ class TestPublishCleanup(unittest.TestCase):
         channel, payload = redis.published[0]
         self.assertIn("rollout_comm:9", channel)
         self.assertIn("9:abc", payload)
-
-    def test_no_redis_client_returns_zero(self):
-        t = NcclPayloadTransport()
-        self.assertEqual(
-            t.publish_cleanup_for_discarded(
-                transfer_ids=["0:a"], config=self._config(), redis_client=None
-            ),
-            0,
-        )
 
 
 class TestAttachDataPacker(unittest.TestCase):
@@ -146,48 +105,3 @@ class TestAttachDataPacker(unittest.TestCase):
                     device="cuda:0",
                     redis_endpoint=RedisEndpoint("h", 1),
                 )
-
-    def test_legacy_path_assigns_client_then_hooks(self):
-        t = NcclPayloadTransport()
-        order = []
-
-        class _LegacyPacker:
-            redis_client = None
-
-            def post_redis_injection(self):
-                # Client must already be assigned when the hook runs.
-                order.append(("hook", self.redis_client))
-
-        packer = _LegacyPacker()
-        with mock.patch(
-            "cosmos_rl.utils.payload_transport.nccl.transport._build_redis_client",
-            return_value="legacy-client",
-        ):
-            t.attach_data_packer(
-                packer,
-                config=SimpleNamespace(custom={}),
-                redis_endpoint=RedisEndpoint("h", 1),
-            )
-        self.assertEqual(packer.redis_client, "legacy-client")
-        self.assertEqual(order, [("hook", "legacy-client")])
-
-    def test_no_op_for_unrelated_packer(self):
-        t = NcclPayloadTransport()
-
-        class _Plain:
-            pass
-
-        # Neither surface present -> no error, no redis client built.
-        with mock.patch(
-            "cosmos_rl.utils.payload_transport.nccl.transport._build_redis_client"
-        ) as build:
-            t.attach_data_packer(
-                _Plain(),
-                config=SimpleNamespace(custom={}),
-                redis_endpoint=RedisEndpoint("h", 1),
-            )
-            build.assert_not_called()
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/tests/test_payload_transport.py
+++ b/tests/test_payload_transport.py
@@ -174,16 +174,15 @@ class TestNcclProtocolHelpers(unittest.TestCase):
         )
 
     def test_build_transfer_rollout_candidates_valid(self):
-        ids = build_transfer_rollout_candidates(
-            transfer_id="3:abcdef", num_rollout_replicas=4
-        )
+        ids = build_transfer_rollout_candidates(transfer_id="3:abcdef")
         self.assertEqual(ids, [3])
 
-    def test_build_transfer_rollout_candidates_out_of_range(self):
-        ids = build_transfer_rollout_candidates(
-            transfer_id="9:abcdef", num_rollout_replicas=4
-        )
-        self.assertEqual(ids, [])
+    def test_build_transfer_rollout_candidates_not_bounded_by_replica_count(self):
+        # A replica added mid-run has an index beyond the INITIAL count.  It
+        # must still get a cleanup channel -- bounding here silently withheld
+        # the publish and pinned the producer's send buffer until eviction.
+        ids = build_transfer_rollout_candidates(transfer_id="9999:abcdef")
+        self.assertEqual(ids, [9999])
 
     def test_build_transfer_rollout_candidates_invalid(self):
         ids = build_transfer_rollout_candidates(transfer_id="garbage")

--- a/tests/test_ucxx_data_packer_mixin.py
+++ b/tests/test_ucxx_data_packer_mixin.py
@@ -327,5 +327,72 @@ class TestSetupViaTransportAttach(unittest.TestCase):
         )
 
 
+class TestInterceptAndPrefetchAgree(unittest.TestCase):
+    """What the trainer intercepts must be exactly what gets prefetched.
+
+    These are the two halves of one decision: ``_should_intercept`` decides
+    whether ``get_policy_input`` resolves a ref, and ``_filter_prefetch_tasks``
+    decides whether the background worker fetches it.  When they disagreed on a
+    MISSING ``_ucxx_enabled`` -- intercept read absent as enabled, the old UCXX
+    override read it as disabled -- such refs were intercepted but never
+    prefetched, so every episode fell to the blocking ``_sync_fetch`` path
+    forever.  Silent and permanent, never a failure.  The two are now the same
+    predicate by construction (no override), and these cases pin that.
+    """
+
+    def setUp(self) -> None:
+        self.p = _Packer()
+
+    @staticmethod
+    def _ref(**extra):
+        ref = {"_ucxx": True, "_worker_ip": "10.0.0.1", "_ucxx_port": 7000, "_slot": 1}
+        ref.update(extra)
+        return ref
+
+    def _prefetched(self, ref):
+        return self.p._filter_prefetch_tasks([ref])
+
+    def test_flag_absent_is_enabled_for_both(self):
+        # The back-compat default: a producer predating the kill-switch.
+        ref = self._ref()
+        self.assertTrue(self.p._should_intercept(ref))
+        self.assertEqual(self._prefetched(ref), [(0, ref)])
+
+    def test_flag_true_is_enabled_for_both(self):
+        ref = self._ref(_ucxx_enabled=True)
+        self.assertTrue(self.p._should_intercept(ref))
+        self.assertEqual(self._prefetched(ref), [(0, ref)])
+
+    def test_flag_false_is_disabled_for_both(self):
+        # The runtime kill-switch: a worker that fell back to redis mid-flight.
+        ref = self._ref(_ucxx_enabled=False)
+        self.assertFalse(self.p._should_intercept(ref))
+        self.assertEqual(self._prefetched(ref), [])
+
+    def test_non_ucxx_refs_are_excluded_from_both(self):
+        for ro in ({"observations": [1]}, "nccl:0:abc", None, 42):
+            with self.subTest(ro=ro):
+                self.assertFalse(self.p._should_intercept(ro))
+                self.assertEqual(self._prefetched(ro), [])
+
+    def test_the_two_predicates_agree_on_every_flag_state(self):
+        # The invariant itself, stated directly: no ref may be intercepted
+        # without also being prefetchable, or vice versa.
+        for extra in ({}, {"_ucxx_enabled": True}, {"_ucxx_enabled": False}):
+            with self.subTest(flag=extra or "absent"):
+                ref = self._ref(**extra)
+                self.assertEqual(
+                    self.p._should_intercept(ref),
+                    bool(self._prefetched(ref)),
+                )
+
+    def test_mixed_batch_indices_are_preserved(self):
+        # _fetch_batch correlates results back by the returned index, so the
+        # filter must report each ref's ORIGINAL position, not a compacted one.
+        on, off = self._ref(_slot=1), self._ref(_ucxx_enabled=False, _slot=2)
+        plain = {"observations": [1]}
+        self.assertEqual(self.p._filter_prefetch_tasks([plain, off, on]), [(2, on)])
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_ucxx_fetch_engine.py
+++ b/tests/test_ucxx_fetch_engine.py
@@ -1,0 +1,315 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the UCXX consumer fetch engine.
+
+``_fetch_batch`` / ``_ucxx_dp_fetch_all`` / ``_read_one`` / ``_to_gpu`` decide
+what happens when a remote read fails, and they were entirely untested -- the
+NCCL side has a direct equivalent for each of these behaviours.
+
+The engine has two independent retry layers, and the interesting behaviour is
+how they interact:
+
+* ``_read_one`` retries ``max_attempts`` times **within** a round, but only for
+  errors named in ``_TRANSIENT_UCXX_ERRORS``.  Classification is by
+  ``type(e).__name__``, so the fakes below define exception classes with those
+  exact names.
+* ``_ucxx_dp_fetch_all`` retries whole rounds up to ``_MAX_FETCH_ROUNDS``, but
+  only for slots the first layer marked retryable.  A non-transient failure
+  (a stale slot) must be dropped immediately -- retrying it burns an RTT per
+  round on a slot that cannot come back.
+
+Everything runs on the ``_fetch_batch`` entry point where possible, since that
+is what the prefetch worker actually calls, and it spins its own event loop.
+"""
+
+import asyncio
+import unittest
+from typing import Any, Dict, List
+
+import numpy as np
+import torch
+
+from cosmos_rl.utils.payload_transport.ucxx.data_packer_mixin import (
+    _MAX_FETCH_ROUNDS,
+    UCXXDataPackerMixin,
+)
+
+# Imported from the data-packer layer, which owns the trajectory field names
+# and exposes them on every branch (the transport packages mirror them).
+from cosmos_rl.dispatcher.data.packer.tensor_data_packer import (
+    ACTIONS,
+    EPISODE_LENGTH,
+    OBSERVATIONS,
+    REWARDS,
+)
+
+
+# ``_TRANSIENT_UCXX_ERRORS`` matches on the class NAME, so these stand in for
+# the real ucxx exceptions without needing the extra installed.
+class UCXXCanceledError(Exception):
+    pass
+
+
+class UCXXCloseError(Exception):
+    pass
+
+
+class StaleSlotError(Exception):
+    """Not in the transient set -- the slot was overwritten; it cannot return."""
+
+
+class _StubPacker:
+    def get_policy_input(self, sample=None, rollout_output=None, *a, **kw):
+        return rollout_output
+
+
+class _Packer(UCXXDataPackerMixin, _StubPacker):
+    pass
+
+
+class _FakeClient:
+    """Scripts ``read`` per slot: a list of outcomes consumed in order.
+
+    An outcome is either an exception instance (raised) or a payload dict
+    (returned), so a test can say "fail twice then succeed".
+    """
+
+    def __init__(self, script: Dict[int, List[Any]]):
+        self.script = {k: list(v) for k, v in script.items()}
+        self.calls: List[int] = []
+        self.returned_pinned: List[Any] = []
+
+    async def read(self, worker_ip, port, slot, schema, ports=None, timeout=None):
+        self.calls.append(slot)
+        outcomes = self.script.get(slot)
+        if not outcomes:
+            raise AssertionError(f"unscripted read of slot {slot}")
+        out = outcomes.pop(0) if len(outcomes) > 1 else outcomes[0]
+        if isinstance(out, Exception):
+            raise out
+        return dict(out)
+
+    def return_pinned(self, buf):
+        self.returned_pinned.append(buf)
+
+
+def _payload(n_steps=3, max_steps=5):
+    """A decoded slot: numpy arrays padded to max_steps, as the server sends."""
+    obs = np.zeros((max_steps, 2), dtype=np.float32)
+    obs[:n_steps] = 1.0
+    act = np.zeros((max_steps, 1), dtype=np.float32)
+    act[:n_steps] = 2.0
+    rew = np.zeros((max_steps,), dtype=np.float32)
+    rew[:n_steps] = 3.0
+    return {
+        OBSERVATIONS: obs,
+        ACTIONS: act,
+        REWARDS: rew,
+        EPISODE_LENGTH: np.array([n_steps], dtype=np.int64),
+    }
+
+
+def _meta(slot=1, ip="10.0.0.1", port=7000):
+    return {"_ucxx": True, "_worker_ip": ip, "_ucxx_port": port, "_slot": slot}
+
+
+def _make_consumer(client, *, max_attempts=2, device="cpu"):
+    p = _Packer()
+    p._ucxx_dp_client = client
+    p._ucxx_dp_device = device
+    p._ucxx_dp_max_attempts = max_attempts
+    p._ucxx_dp_read_timeout = 0.01
+    return p
+
+
+def _fetch(p, metas):
+    """Drive the real entry point: [(idx, metadata), ...] -> {cache_key: data}."""
+    return p._fetch_batch([(i, m) for i, m in enumerate(metas)])
+
+
+class TestTransientRetryWithinARound(unittest.TestCase):
+    def test_retries_and_succeeds_within_max_attempts(self):
+        client = _FakeClient({1: [UCXXCanceledError("flaky"), _payload()]})
+        p = _make_consumer(client, max_attempts=2)
+        out = _fetch(p, [_meta(slot=1)])
+        self.assertEqual(len(out), 1)
+        self.assertEqual(client.calls, [1, 1])  # one retry, same round
+
+    def test_gives_up_after_max_attempts_but_stays_retryable(self):
+        # Exhausting attempts is NOT terminal: the slot goes back in the pool
+        # for the next round, so the total call count spans all rounds.
+        client = _FakeClient({1: [UCXXCloseError("down")]})
+        p = _make_consumer(client, max_attempts=2)
+        out = _fetch(p, [_meta(slot=1)])
+        self.assertEqual(out, {})
+        self.assertEqual(len(client.calls), 2 * _MAX_FETCH_ROUNDS)
+
+
+class TestNonTransientIsDroppedImmediately(unittest.TestCase):
+    """The point of the retryable flag: a stale slot must not be re-read."""
+
+    def test_no_retry_within_the_round(self):
+        client = _FakeClient({1: [StaleSlotError("overwritten")]})
+        p = _make_consumer(client, max_attempts=3)
+        out = _fetch(p, [_meta(slot=1)])
+        self.assertEqual(out, {})
+        self.assertEqual(client.calls, [1], "a stale slot was retried")
+
+    def test_no_retry_across_rounds(self):
+        # If the round loop treated it as retryable it would cost
+        # _MAX_FETCH_ROUNDS extra RTTs on a slot that cannot come back.
+        client = _FakeClient({1: [StaleSlotError("overwritten")]})
+        p = _make_consumer(client, max_attempts=1)
+        _fetch(p, [_meta(slot=1)])
+        self.assertEqual(len(client.calls), 1)
+
+
+class TestRoundLevelRetry(unittest.TestCase):
+    def test_succeeds_on_a_later_round(self):
+        # max_attempts=1 so each round is exactly one call: fail, fail, succeed.
+        client = _FakeClient(
+            {1: [UCXXCanceledError("a"), UCXXCanceledError("b"), _payload()]}
+        )
+        p = _make_consumer(client, max_attempts=1)
+        out = _fetch(p, [_meta(slot=1)])
+        self.assertEqual(len(out), 1)
+        self.assertEqual(len(client.calls), 3)
+
+    def test_exhausting_rounds_drops_the_episode_without_raising(self):
+        # A permanently-dead slot must degrade to a missing cache entry, not an
+        # exception -- the prefetch worker treats a raise as a whole-batch
+        # failure and wipes the cache.
+        client = _FakeClient({1: [UCXXCanceledError("dead")]})
+        p = _make_consumer(client, max_attempts=1)
+        self.assertEqual(_fetch(p, [_meta(slot=1)]), {})
+
+
+class TestFailureIsolation(unittest.TestCase):
+    def test_one_bad_slot_does_not_lose_the_batch(self):
+        client = _FakeClient(
+            {
+                1: [_payload()],
+                2: [StaleSlotError("gone")],
+                3: [_payload()],
+            }
+        )
+        p = _make_consumer(client)
+        out = _fetch(p, [_meta(slot=1), _meta(slot=2), _meta(slot=3)])
+        self.assertEqual(len(out), 2, "a single stale slot took down the batch")
+        self.assertIn("10.0.0.1:7000:1", out)
+        self.assertIn("10.0.0.1:7000:3", out)
+        self.assertNotIn("10.0.0.1:7000:2", out)
+
+
+class TestMetadataFiltering(unittest.TestCase):
+    def test_incomplete_metadata_is_skipped_not_read(self):
+        client = _FakeClient({1: [_payload()]})
+        p = _make_consumer(client)
+        bad = {"_ucxx": True, "_worker_ip": "10.0.0.1"}  # no port, no slot
+        out = _fetch(p, [bad, _meta(slot=1)])
+        self.assertEqual(len(out), 1)
+        self.assertEqual(client.calls, [1])
+
+    def test_slot_zero_is_a_valid_slot(self):
+        # The guard is `slot is not None`, not truthiness -- ring-buffer slot 0
+        # is real, and a truthy check would silently drop every episode landing
+        # there.
+        client = _FakeClient({0: [_payload()]})
+        p = _make_consumer(client)
+        out = _fetch(p, [_meta(slot=0)])
+        self.assertEqual(len(out), 1)
+        self.assertIn("10.0.0.1:7000:0", out)
+
+
+class TestEpisodeLengthTruncation(unittest.TestCase):
+    def test_varlen_fields_are_cut_to_the_episode_length(self):
+        client = _FakeClient({1: [_payload(n_steps=3, max_steps=5)]})
+        p = _make_consumer(client)
+        data = _fetch(p, [_meta(slot=1)])["10.0.0.1:7000:1"]
+        self.assertEqual(data[OBSERVATIONS].shape[0], 3)
+        self.assertEqual(data[ACTIONS].shape[0], 3)
+        self.assertEqual(data[REWARDS].shape[0], 3)
+        # Only the padding is removed; the live rows survive intact.
+        self.assertTrue(torch.all(data[OBSERVATIONS] == 1.0))
+
+    def test_no_truncation_when_the_episode_fills_the_buffer(self):
+        client = _FakeClient({1: [_payload(n_steps=5, max_steps=5)]})
+        p = _make_consumer(client)
+        data = _fetch(p, [_meta(slot=1)])["10.0.0.1:7000:1"]
+        self.assertEqual(data[OBSERVATIONS].shape[0], 5)
+
+
+class _ExplodingPinned:
+    """A pinned buffer whose bulk device copy fails."""
+
+    def to(self, *a, **kw):
+        raise RuntimeError("bulk D2H failed")
+
+
+class TestToGpuFallback(unittest.TestCase):
+    def test_falls_back_to_per_tensor_copy_and_still_returns_the_pinned_buffer(
+        self,
+    ):
+        # The bulk path is an optimisation; when it fails the episode must still
+        # be delivered -- and the pinned buffer must go back to the pool either
+        # way, or the client leaks one per failed fetch.
+        pinned = _ExplodingPinned()
+        payload = _payload()
+        payload["_pinned_buf"] = pinned
+        client = _FakeClient({1: [payload]})
+        p = _make_consumer(client)
+
+        data = _fetch(p, [_meta(slot=1)])["10.0.0.1:7000:1"]
+        self.assertEqual(data[OBSERVATIONS].shape[0], 3)  # delivered anyway
+        self.assertEqual(client.returned_pinned, [pinned], "pinned buffer leaked")
+
+
+class TestSyncFetchContainment(unittest.TestCase):
+    """``_sync_fetch`` runs on the trainer thread during a cache miss, so a
+    raise there would propagate into training rather than skipping an
+    episode."""
+
+    def test_returns_none_on_failure(self):
+        client = _FakeClient({1: [StaleSlotError("gone")]})
+        p = _make_consumer(client)
+        self.assertIsNone(p._sync_fetch(_meta(slot=1)))
+
+    def test_returns_none_when_the_client_is_absent(self):
+        p = _make_consumer(None)
+        self.assertIsNone(p._sync_fetch(_meta(slot=1)))
+
+    def test_returns_data_on_success(self):
+        client = _FakeClient({1: [_payload()]})
+        p = _make_consumer(client)
+        got = p._sync_fetch(_meta(slot=1))
+        self.assertIsNotNone(got)
+        self.assertIn(OBSERVATIONS, got)
+
+
+class TestFetchAllReportsTiming(unittest.TestCase):
+    def test_returns_results_and_both_timings(self):
+        client = _FakeClient({1: [_payload()]})
+        p = _make_consumer(client)
+        results, transfer_ms, copy_ms = asyncio.run(
+            p._ucxx_dp_fetch_all([(0, _meta(slot=1))])
+        )
+        self.assertIn(0, results)
+        self.assertGreaterEqual(transfer_ms, 0.0)
+        self.assertGreaterEqual(copy_ms, 0.0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Two independent correctness fixes plus the coverage for them.

  | # | Commit |
  |---|---|
  | 1 | `fix(transport): publish cleanup for rollout replicas added mid-run` |
  | 2 | `fix(ucxx): prefetch and intercept must use the same predicate` |
  | 3 | `test: drop transport tests duplicated with weaker assertions` |
  | 4 | `test(ucxx): cover the consumer fetch engine` |

  ## Elasticity (1)

  `publish_cleanup_for_discarded` bounded the cleanup target by
  `config.rollout.parallelism.n_init_replicas` — the **initial** replica count. A
  replica added mid-run encodes a `rollout_idx` at or beyond that bound, so
  `build_transfer_rollout_candidates` returned `[]`, the publish loop body never
  ran, and `registry.free()` was never invoked for any of its transfers. Those
  send buffers were then reclaimed only by capacity eviction, so a discarded
  rollout pinned GPU memory until pressure forced it out.

  Drops the bound and validates the parse only. The trade is asymmetric —
  publishing to a channel nobody subscribes to is a no-op, while withholding a
  publish pins memory — and there is no correct value available here: the
  controller would have to track the live replica set to compute one.

  ## UCXX predicate (2)

  `_should_intercept` read a missing `_ucxx_enabled` as **enabled** ("treat
  absence as enabled for backward compat"), while `_filter_prefetch_tasks`
  re-implemented the check as `ro.get("_ucxx") and ro.get("_ucxx_enabled")`, where
  absent is falsy and the ref is **excluded**. A completion carrying `_ucxx` but
  not `_ucxx_enabled` was therefore intercepted by `get_policy_input` yet never
  queued for prefetch — so every one of its episodes resolved through the blocking
  `_sync_fetch` path. A silent, permanent slow path rather than a failure. Its own
  docstring claimed the two checks were "equivalent here", which is exactly the
  case where they were not.

  Deletes the override rather than aligning its default: the base
  `_filter_prefetch_tasks` is already this method with `self._should_intercept(ro)`
  in place of the inlined condition, so removing it makes the two halves of one
  decision the same predicate **by construction** and this drift cannot recur.

  Absence resolving to *enabled* is the correct direction — a producer predating
  the kill-switch emits no flag, and treating that as disabled would stop the
  trainer intercepting its refs at all, handing raw UCXX metadata to the
  underlying packer.

  ## Coverage (4)

  The consumer fetch engine (`_fetch_batch` / `_ucxx_dp_fetch_all` / `_read_one` /
  `_to_gpu`, ~250 lines) had no tests. It has two retry layers and the interesting
  behaviour is their interaction: `_read_one` retries within a round but only for
  errors named in `_TRANSIENT_UCXX_ERRORS`, while the round loop retries only
  slots the first layer marked retryable — a stale slot must be dropped
  immediately, since retrying burns an RTT per round on something that cannot come
  back.

  Two are mutation-pinned rather than asserted alone: making every error retryable
  fails the stale-slot tests, and changing the metadata guard from
  `slot is not None` to a truthiness check fails the slot-zero test — ring-buffer
  slot 0 is real, and a truthy check would silently drop every episode landing
  there.

Two independent correctness fixes plus the coverage for them.

  | # | Commit |
  |---|---|
  | 1 | `fix(transport): publish cleanup for rollout replicas added mid-run` |
  | 2 | `fix(ucxx): prefetch and intercept must use the same predicate` |
  | 3 | `test: drop transport tests duplicated with weaker assertions` |
  | 4 | `test(ucxx): cover the consumer fetch engine` |

  ## Elasticity (1)

  `publish_cleanup_for_discarded` bounded the cleanup target by
  `config.rollout.parallelism.n_init_replicas` — the **initial** replica count. A
  replica added mid-run encodes a `rollout_idx` at or beyond that bound, so
  `build_transfer_rollout_candidates` returned `[]`, the publish loop body never
  ran, and `registry.free()` was never invoked for any of its transfers. Those
  send buffers were then reclaimed only by capacity eviction, so a discarded
  rollout pinned GPU memory until pressure forced it out.

  Drops the bound and validates the parse only. The trade is asymmetric —
  publishing to a channel nobody subscribes to is a no-op, while withholding a
  publish pins memory — and there is no correct value available here: the
  controller would have to track the live replica set to compute one.

  ## UCXX predicate (2)

  `_should_intercept` read a missing `_ucxx_enabled` as **enabled** ("treat
  absence as enabled for backward compat"), while `_filter_prefetch_tasks`
  re-implemented the check as `ro.get("_ucxx") and ro.get("_ucxx_enabled")`, where
  absent is falsy and the ref is **excluded**. A completion carrying `_ucxx` but
  not `_ucxx_enabled` was therefore intercepted by `get_policy_input` yet never
  queued for prefetch — so every one of its episodes resolved through the blocking
  `_sync_fetch` path. A silent, permanent slow path rather than a failure. Its own
  docstring claimed the two checks were "equivalent here", which is exactly the
  case where they were not.

  Deletes the override rather than aligning its default: the base
  `_filter_prefetch_tasks` is already this method with `self._should_intercept(ro)`
  in place of the inlined condition, so removing it makes the two halves of one
  decision the same predicate **by construction** and this drift cannot recur.

  Absence resolving to *enabled* is the correct direction — a producer predating
  the kill-switch emits no flag, and treating that as disabled would stop the
  trainer intercepting its refs at all, handing raw UCXX metadata to the
  underlying packer.

  ## Coverage (4)

  The consumer fetch engine (`_fetch_batch` / `_ucxx_dp_fetch_all` / `_read_one` /
  `_to_gpu`, ~250 lines) had no tests. It has two retry layers and the interesting
  behaviour is their interaction: `_read_one` retries within a round but only for
  errors named in `_TRANSIENT_UCXX_ERRORS`, while the round loop retries only
  slots the first layer marked retryable — a stale slot must be dropped
  immediately, since retrying burns an RTT per round on something that cannot come
  back.

  Two are mutation-pinned rather than asserted alone: making every error retryable
  fails the stale-slot tests, and changing the metadata guard from
  `slot is not None` to a truthiness check fails the slot-zero test — ring-buffer
  slot 0 is real, and a truthy check would silently drop every episode landing
  there.