### PR TITLE
test(ci): make CI and job status report what actually happened

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -26,7 +26,10 @@ jobs:
 
       - name: Build image
         run: |
-          docker build -t ${{ steps.vars.outputs.image_tag }} .
+          # The ucxx extra must be on THIS image, not just the -vla one
+          # below: this is the image that runs tests/run_test.sh, and the
+          # UCXX suites self-skip without ucxx importable (46 tests).
+          docker build -t ${{ steps.vars.outputs.image_tag }} --build-arg COSMOS_RL_EXTRAS=ucxx .
           docker build -t ${{ steps.vars.outputs.image_tag }}-vla --build-arg COSMOS_RL_EXTRAS=vla,wfm,rl,ucxx .
 
       - name: Run vla tests

--- a/cosmos_rl/launcher/launch_all.py
+++ b/cosmos_rl/launcher/launch_all.py
@@ -16,6 +16,7 @@
 #!/usr/bin/env python3
 
 import http.client
+import signal
 import subprocess
 import sys
 import time
@@ -28,6 +29,7 @@ from typing import Dict, Optional, Any
 import toml
 from cosmos_rl.policy.config.wfm import CosmosVisionGenConfig
 from cosmos_rl.launcher.launch_vision import launch_vision_gen
+from cosmos_rl.utils.constant import COSMOS_SHUTDOWN_ON_NO_POLICY_REPLICAS
 from cosmos_rl.launcher.utility import (
     get_available_gpus,
     get_non_lepton_args,
@@ -390,6 +392,34 @@ def get_hostname_from_host(ip):
     except Exception as e:
         logger.error(f"Error: {e}")
         return None
+
+
+def _is_coordinated_controller_exit(
+    proc_index: int, controller_id: int, returncode: int
+) -> bool:
+    """Is this the controller ending via its own deliberate SIGTERM?
+
+    ``COSMOS_SHUTDOWN_ON_NO_POLICY_REPLICAS`` makes the controller
+    ``os.kill(os.getpid(), SIGTERM)`` once the last policy replica unregisters,
+    so the scheduling layer reclaims the allocation immediately rather than
+    idling until wall-clock.  That is a *successful* end of a run, but it
+    surfaces here as a non-zero return code and was previously indistinguishable
+    from a crash.
+
+    Deliberately narrow -- only the controller, only SIGTERM, and only when the
+    feature that produces it is enabled -- so a SIGTERM from anywhere else (a
+    scheduler pre-emption, an operator ``scancel``, a replica killed by the OOM
+    reaper) still fails the job loudly.
+
+    A signalled child reports ``-SIGTERM`` via :mod:`subprocess`, but these are
+    launched through a shell wrapper that exits ``128 + SIGTERM`` instead;
+    accept both rather than depend on which layer relays it.
+    """
+    if controller_id < 0 or proc_index != controller_id:
+        return False
+    if not COSMOS_SHUTDOWN_ON_NO_POLICY_REPLICAS:
+        return False
+    return returncode in (-signal.SIGTERM, 128 + signal.SIGTERM)
 
 
 def main():
@@ -936,6 +966,19 @@ cosmos-rl --config config.toml"""
                     returncode = process.returncode
                     if returncode == 0:
                         logger.info(f"Process {i} completed successfully")
+                    elif _is_coordinated_controller_exit(i, controller_id, returncode):
+                        # Not a failure: the controller SIGTERMs ITSELF once the
+                        # last policy replica unregisters, so the scheduler can
+                        # release the allocation instead of idling to wall-clock
+                        # (see COSMOS_SHUTDOWN_ON_NO_POLICY_REPLICAS in
+                        # run_web_panel).  Treating that as a crash made every
+                        # successful run report FAILED to SLURM, which is worse
+                        # than cosmetic -- it leaves no way to tell a completed
+                        # job from a broken one without reading the logs.
+                        logger.info(
+                            f"Process {i} (controller) exited via the coordinated "
+                            f"shutdown path (rc={returncode}); treating as success"
+                        )
                     else:
                         logger.error(
                             f"Process {i} failed with return code {returncode}"

--- a/tests/run_test.sh
+++ b/tests/run_test.sh
@@ -14,13 +14,42 @@ set -uo pipefail
 
 FAILED=()
 
+SKIPPED=()
+RUN_IDX=0
+# Per-suite logs land here and are KEPT.  Override with TEST_LOG_DIR to put
+# them somewhere the scheduler collects; the default sits beside the repo so a
+# local run keeps them too.
+TEST_LOG_DIR="${TEST_LOG_DIR:-${PWD}/test-logs}"
+mkdir -p "${TEST_LOG_DIR}"
+echo "Per-suite logs: ${TEST_LOG_DIR}"
 run() {
+    RUN_IDX=$((RUN_IDX + 1))
+    local rc log slug
+    # Every suite's output goes to its OWN file, always, in full.  Nothing is
+    # buffered in memory and nothing is filtered on the way in: a suite killed
+    # by the outer timeout must still leave everything it printed on disk, and
+    # what turns out to matter is never known in advance.  An earlier version
+    # captured into a shell variable and echoed it afterwards -- the echo never
+    # runs when the process is killed, so a 2h timeout produced a log
+    # containing nothing but the RUN banner.
+    slug="$(printf '%s' "$*" | tr -cs 'A-Za-z0-9_.-' '_' | cut -c1-80)"
+    log="${TEST_LOG_DIR}/$(printf '%03d' "${RUN_IDX}")_${slug}.log"
+
     echo
     echo "================ RUN: $* ================"
-    if "$@"; then
-        echo "---- PASS: $* ----"
+    echo "---- log: ${log} ----"
+    "$@" 2>&1 | tee "${log}"
+    rc=${PIPESTATUS[0]}
+
+    # Classify by reading the FILE, not a copy held in memory.
+    if (( rc == 0 )); then
+        if grep -qE "OK \(skipped=[0-9]+\)|^Ran 0 tests" "${log}"; then
+            echo "---- SKIP: $* ----"
+            SKIPPED+=("$*")
+        else
+            echo "---- PASS: $* ----"
+        fi
     else
-        local rc=$?
         echo "---- FAIL(rc=${rc}): $* ----"
         FAILED+=("$*")
     fi
@@ -70,6 +99,36 @@ run python tests/test_parallel_map.py
 run python tests/test_policy_to_policy.py
 run python tests/test_policy_to_rollout.py
 run python tests/test_multirank_shutdown.py
+
+# Only end-to-end guard for the NCCL payload transport; it was referenced by no
+# workflow, so it had never executed anywhere until a targeted Slurm probe, where
+# it PASSED. It self-skips unless it finds >=2 GPUs and a Redis, and starts its
+# own redis-server when nothing is listening -- so it needs no setup here.
+run python tests/test_nccl_e2e.py
+
+# The payload transport's CPU unit tests.  run_test.sh names every file it
+# runs, and these 16 were never named -- so ~340 tests covering the wire
+# format, rendezvous, comm cache, buffer registry, slot rotation and both
+# consumer/producer paths have never executed in CI, including the ones added
+# alongside the transport itself.  They are fast and CPU-only; the cost of
+# listing them is far below the cost of a silent gap this size.
+run python tests/test_comm_base_attach.py
+run python tests/test_nccl_addressing.py
+run python tests/test_nccl_buffer_registry.py
+run python tests/test_nccl_comm_cache.py
+run python tests/test_nccl_data_packer_mixin.py
+run python tests/test_nccl_rendezvous.py
+run python tests/test_nccl_rollout_mixin.py
+run python tests/test_nccl_streams.py
+run python tests/test_nccl_transport.py
+run python tests/test_payload_rotation.py
+run python tests/test_payload_transport.py
+run python tests/test_profiler_ucxx.py
+run python tests/test_ucxx_data_packer_mixin.py
+run python tests/test_ucxx_fetch_engine.py
+run python tests/test_ucxx_rollout_mixin.py
+run python tests/test_ucxx_transport.py
+run python tests/test_launcher_shutdown.py
 run python tests/test_process_flow.py
 run python tests/test_custom_class.py
 run python tests/test_math_verify.py
@@ -108,6 +167,12 @@ run /bin/bash -c "torchrun --nproc_per_node=8 tests/test_data_loader.py"
 # run python tests/test_wfm_dpo.py
 # run python tests/test_wfm_nft.py
 # run python tests/test_refactor_contracts.py
+
+if (( ${#SKIPPED[@]} > 0 )); then
+    echo
+    echo "================ SUMMARY: ${#SKIPPED[@]} suite(s) SKIPPED (ran nothing) ================"
+    printf '  - %s\n' "${SKIPPED[@]}"
+fi
 
 if (( ${#FAILED[@]} > 0 )); then
     echo

--- a/tests/test_launcher_shutdown.py
+++ b/tests/test_launcher_shutdown.py
@@ -1,0 +1,96 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""A coordinated controller shutdown is a success, not a job failure.
+
+``COSMOS_SHUTDOWN_ON_NO_POLICY_REPLICAS`` makes the controller SIGTERM *itself*
+once the last policy replica unregisters, so the scheduler reclaims the
+allocation instead of idling to wall-clock.  The launcher used to treat that
+non-zero return code as a crash, so a completed run reported FAILED to SLURM --
+leaving no way to tell a finished job from a broken one without reading logs.
+
+The predicate under test is what draws that line, so these check both
+directions.  Excusing too much would be worse than the original bug: a real
+SIGTERM (pre-emption, ``scancel``, an OOM reaper) must still fail loudly.
+"""
+
+import signal
+import unittest
+from unittest import mock
+
+from cosmos_rl.launcher import launch_all
+
+SIGTERM_RC = 128 + signal.SIGTERM  # 143, as relayed by the shell wrapper
+
+
+class TestCoordinatedControllerExit(unittest.TestCase):
+    @staticmethod
+    def _predicate(enabled: bool):
+        return mock.patch.object(
+            launch_all, "COSMOS_SHUTDOWN_ON_NO_POLICY_REPLICAS", enabled
+        )
+
+    # -- the case that motivated this -------------------------------------
+
+    def test_controller_sigterm_is_success_when_the_reap_is_enabled(self):
+        with self._predicate(True):
+            self.assertTrue(
+                launch_all._is_coordinated_controller_exit(0, 0, SIGTERM_RC)
+            )
+
+    def test_negative_signal_form_is_also_accepted(self):
+        """subprocess reports -SIGTERM directly when no shell wrapper relays it."""
+        with self._predicate(True):
+            self.assertTrue(
+                launch_all._is_coordinated_controller_exit(0, 0, -signal.SIGTERM)
+            )
+
+    # -- everything that must still fail loudly ---------------------------
+
+    def test_a_real_crash_is_still_a_failure(self):
+        with self._predicate(True):
+            self.assertFalse(launch_all._is_coordinated_controller_exit(0, 0, 1))
+
+    def test_sigkill_is_still_a_failure(self):
+        """SIGKILL is never the coordinated path -- it is the OOM reaper etc."""
+        with self._predicate(True):
+            self.assertFalse(
+                launch_all._is_coordinated_controller_exit(0, 0, 128 + signal.SIGKILL)
+            )
+
+    def test_a_replica_sigterm_is_still_a_failure(self):
+        """Only the controller self-terminates; a SIGTERMed replica is a problem."""
+        with self._predicate(True):
+            self.assertFalse(
+                launch_all._is_coordinated_controller_exit(1, 0, SIGTERM_RC)
+            )
+
+    def test_sigterm_is_a_failure_when_the_reap_is_disabled(self):
+        """Without the feature there is nothing to self-terminate, so this is
+        an external kill -- e.g. scheduler pre-emption -- and must fail."""
+        with self._predicate(False):
+            self.assertFalse(
+                launch_all._is_coordinated_controller_exit(0, 0, SIGTERM_RC)
+            )
+
+    def test_no_controller_means_nothing_to_excuse(self):
+        with self._predicate(True):
+            self.assertFalse(
+                launch_all._is_coordinated_controller_exit(0, -1, SIGTERM_RC)
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_nccl_e2e.py
+++ b/tests/test_nccl_e2e.py
@@ -17,12 +17,14 @@
 
 Spawns two processes on two GPUs (rank 0 = rollout producer, rank 1 =
 trainer consumer) that rendezvous over a real Redis and move one
-trajectory GPU→GPU via ``nccl_send`` / ``nccl_recv``.  Self-skips unless
-CUDA is available with ``>= 2`` devices and a Redis is reachable — so it is
-a no-op on CPU-only / single-GPU CI and only runs where the full path can
-actually be exercised.
+trajectory GPU→GPU via ``nccl_send`` / ``nccl_recv``.  Self-skips unless CUDA
+is available with ``>= 2`` devices — so it is a no-op on CPU-only / single-GPU
+CI and only runs where the full path can actually be exercised.
 
-Run explicitly on a 2-GPU box with Redis on localhost:6379:
+Redis is *not* a precondition: if nothing is listening, :func:`_ensure_redis`
+starts a throwaway ``redis-server`` on a free port (see its docstring for why
+depending on an ambient one silently disabled this test).  Point it at an
+existing instance with ``COSMOS_TEST_REDIS_HOST`` / ``COSMOS_TEST_REDIS_PORT``.
 
     pytest tests/test_nccl_e2e.py -q
 """
@@ -166,11 +168,70 @@ except Exception:  # pragma: no cover - import guarded for CPU-only collection
     _ConsumerPacker = None
 
 
+def _ensure_redis() -> bool:
+    """Make a Redis available, starting a throwaway one if nothing is listening.
+
+    Without this the test only ran where a Redis happened to already be bound
+    to :data:`REDIS_PORT`, and self-skipped everywhere else -- including CI,
+    where nothing binds 6379 (the dispatcher starts its own server on a *free*
+    port).  A skip there is indistinguishable from a pass, so the transport's
+    only end-to-end guard would have been silently absent.
+
+    ``redis-server`` ships in the CI image, so start one rather than depend on
+    ambient state.  The chosen port is exported so the spawned ranks -- which
+    re-import this module -- connect to the same instance instead of each
+    starting another; that env var is also why re-entry here is a no-op in the
+    children.
+    """
+    global REDIS_PORT
+
+    if _redis_reachable():
+        return True
+
+    import atexit
+    import shutil
+    import socket
+    import subprocess
+
+    exe = shutil.which("redis-server")
+    if exe is None:
+        return False
+
+    with socket.socket() as probe:
+        probe.bind((REDIS_HOST, 0))
+        port = probe.getsockname()[1]
+
+    try:
+        proc = subprocess.Popen(
+            [exe, "--port", str(port), "--save", "", "--appendonly", "no"],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+    except OSError:
+        return False
+
+    REDIS_PORT = port
+    os.environ["COSMOS_TEST_REDIS_PORT"] = str(port)
+    atexit.register(lambda: (proc.terminate(), proc.wait(timeout=10)))
+
+    deadline = time.time() + 15.0
+    while time.time() < deadline:
+        if proc.poll() is not None:  # died on startup; nothing to wait for
+            return False
+        if _redis_reachable():
+            return True
+        time.sleep(0.1)
+    return False
+
+
 @unittest.skipUnless(
     torch.cuda.is_available() and torch.cuda.device_count() >= 2,
     "requires >= 2 CUDA devices for NCCL P2P",
 )
-@unittest.skipUnless(_redis_reachable(), f"requires Redis at {REDIS_HOST}:{REDIS_PORT}")
+@unittest.skipUnless(
+    _ensure_redis(),
+    f"requires Redis at {REDIS_HOST}:{REDIS_PORT} (and no redis-server)",
+)
 class TestNcclE2E(unittest.TestCase):
     def setUp(self):
         import redis

--- a/tests/test_policy_overfit.py
+++ b/tests/test_policy_overfit.py
@@ -85,15 +85,36 @@ class TestPolicyOverfit(unittest.TestCase):
             env=policy_env,
         )
 
-        processes = [controller_process, policy_process]
-
-        # Wait for process to complete
-        for process in processes:
-            stdout, stderr = process.communicate()
-            # Check if process completed successfully
-            assert process.returncode == 0, (
-                f"Process failed with code: {process.returncode}"
+        # Wait on the POLICY, not the controller.  The controller is an HTTP
+        # server: it exits only when training completes normally, so waiting on
+        # it first turns *any* policy-side failure into an unbounded hang --
+        # the policy dies, the controller never sees completion, never exits,
+        # and communicate() blocks forever.  Observed twice on an 8-GPU node,
+        # each time consuming the suite's entire remaining budget (a 2h
+        # ceiling, and 29 later suites that never ran).
+        timeout_s = float(os.environ.get("COSMOS_TEST_OVERFIT_TIMEOUT_S", "1800"))
+        try:
+            policy_process.communicate(timeout=timeout_s)
+        except subprocess.TimeoutExpired:
+            policy_process.kill()
+            policy_process.communicate()
+            raise AssertionError(
+                f"policy did not finish within {timeout_s:.0f}s; killed it. "
+                "Set COSMOS_TEST_OVERFIT_TIMEOUT_S to raise the budget."
             )
+        finally:
+            # The controller has no reason to exit if the policy failed, so
+            # never wait on it -- just reap it.
+            controller_process.terminate()
+            try:
+                controller_process.communicate(timeout=30)
+            except subprocess.TimeoutExpired:
+                controller_process.kill()
+                controller_process.communicate()
+
+        assert policy_process.returncode == 0, (
+            f"policy process failed with code: {policy_process.returncode}"
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Three ways a run could look fine while telling you nothing.

## 1. Tests that never ran

`run_test.sh` names every file it runs, and the payload transport's were never named. `build_and_test` invokes only this script, so **~340 CPU tests across 16 files had never executed in CI** — wire format, rendezvous, comm cache, buffer registry, slot rotation, endpoint quarantine, and both the consumer and producer paths, **including the tests added alongside the transport itself**. A green run on those PRs never meant their tests had run.

They are fast and CPU-only (~4s for all 16), and pass against current `main`: **337 passed**.

Also adds `tests/test_nccl_e2e.py`, the transport's only end-to-end guard, which had executed **nowhere at all**. It now starts its own `redis-server` when nothing is listening rather than requiring an ambient one — `redis-server` ships in the image, but nothing *runs* it on 6379 (the dispatcher starts its own on a free port). All three paths of that helper were exercised: starts a server when the port is empty, re-entry from a spawned rank starts no second server, and a missing binary yields a clean skip rather than a raise.

## 2. A suite that skipped everything, reported as PASS

`run()` branched on exit code alone, and unittest exits 0 when every test in a module skips. It now inspects the output, classifies a zero exit carrying `OK (skipped=N)` or `Ran 0 tests` as SKIP, and lists those separately.

**That caught a real one on its first CI run:**

```
SUMMARY: 1 suite(s) SKIPPED (ran nothing)
  - python tests/test_ucxx_transport.py
```

All 46 of its tests were skipping because CI builds two images and only the `-vla` one carried the `ucxx` extra, while `run_test.sh` runs in the other. This builds the test image with the extra too — a single leaf package (`ucxx-cu12`), and the `-vla` image already proves it coexists. Those 46 now run.

## 3. A completed job reported as FAILED

`COSMOS_SHUTDOWN_ON_NO_POLICY_REPLICAS` makes the controller SIGTERM *itself* once the last policy replica unregisters, so the scheduler reclaims the allocation instead of idling to wall-clock. That is the **normal** end of a successful run — but the launcher treated the non-zero return code as a crash and exited 1, so SLURM recorded FAILED for every run that finished.

Observed on a real job: 80/80 steps completed, clean teardown, still `FAILED` — leaving no way to tell it from a broken run without reading 182 KB of logs.

`_is_coordinated_controller_exit` draws the line deliberately narrowly: **only** the controller, **only** SIGTERM, and **only** when the feature that produces it is enabled. Excusing more would be worse than the original bug — a real SIGTERM from pre-emption, `scancel`, or an OOM reaper must still fail loudly.

| case | verdict |
|---|---|
| controller, 143 / −15, reap on | success |
| controller, rc=1 | fails |
| controller, SIGKILL | fails |
| replica SIGTERM | fails |
| controller SIGTERM, reap off | fails |
| no controller | fails |

Covered in both directions by `tests/test_launcher_shutdown.py` (7 tests).