### PR TITLE
refactor(transport): let a packer compose a transport instead of subclassing one

### DIFF
--- a/cosmos_rl/utils/payload_transport/nccl/data_packer_mixin.py
+++ b/cosmos_rl/utils/payload_transport/nccl/data_packer_mixin.py
@@ -13,159 +13,46 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""NCCLDataPackerMixin -- NCCL-specific subclass of PrefetchDataPackerMixin.
+"""NCCL consumer packer: scheduling from the base mixin, transport from a strategy.
 
-Like :class:`UCXXDataPackerMixin`, this file is intentionally thin: the
-prefetch + double-buffer + early-train-ack scheduling is owned by
-:class:`cosmos_rl.utils.payload_transport.prefetch_mixin.PrefetchDataPackerMixin`,
-and this subclass plugs in the NCCL-specific bits:
-
-* the wire-format predicate (:meth:`_should_intercept`) — accepts either
-  the on-wire completion string ``"nccl:<transfer_id>"`` (the same string
-  the controller's discard-cleanup dispatch keys on) *or* a richer dict
-  ``{"_nccl": True, ...}`` reference; both normalize to one internal ref.
-* the cache key (:meth:`_cache_key` -> ``transfer_id``).
-* the actual recv path (:meth:`_fetch_all`): for the batch, run the
-  per-transfer Redis rendezvous, then issue each ``nccl_recv`` STANDALONE
-  (one per 2-rank pair comm — NOT wrapped in a cross-communicator
-  ``ncclGroupStart/End``, which would couple independent producers into one
-  completion unit whose ``ncclGroupEnd`` blocks if any producer is slow), on
-  a transfer stream from the per-process pool, recording a recv-complete
-  event that gates downstream training consumption.
-* layered retry, all inside a single ``_fetch_batch``: per-ref
-  ``max_attempts`` fresh rendezvous calls plus per-pair UID
-  renegotiation.  (The base mixin drives ONE ``_fetch_batch`` per
-  prefetch round and adds NO in-batch multi-round layer.  A ref the
-  prefetch batch misses is retried ONCE synchronously by
-  ``get_policy_input`` via ``_sync_fetch``; if that also misses, it is
-  surfaced through ``_on_resolve_failed`` and the episode falls back --
-  it is NOT rescheduled for a later prefetch round.)
-
-Usage::
-
-    class NCCLSimpleRLDataPacker(NCCLDataPackerMixin, SimpleRLDataPacker):
-        pass
-
-MRO ensures :meth:`PrefetchDataPackerMixin.get_policy_input` (inherited)
-intercepts before delegating to the concrete packer.
+Kept as a mixin because that is the contract ``attach_data_packer`` dispatches
+on (it duck-types ``_setup_nccl_data_packer``) and because the out-of-tree
+consumer still subclasses it.  The NCCL logic itself now lives in
+:class:`NCCLTransportStrategy`, which this class composes -- so the same
+transport is reachable without subclassing anything (see
+:meth:`PrefetchDataPackerMixin.set_transport_strategy`).
 """
 
 from __future__ import annotations
 
-import threading
-from typing import Any, Dict, List, Optional, Tuple
-
-import numpy as np
-import torch
+from typing import Any, Dict, Optional
 
 from cosmos_rl.utils.logging import logger
-from cosmos_rl.utils.payload_transport.nccl.comm_cache import (
-    CommCache,
-    RECEIVER_LOCAL_RANK,
-    SENDER_LOCAL_RANK,
+from cosmos_rl.utils.payload_transport.nccl.strategy import (
+    NCCLTransportStrategy,
+    compose_nccl_transport,
 )
-from cosmos_rl.utils.payload_transport.nccl.context import (
-    resolve_global_rank as _resolve_global_rank,
-    resolve_max_live_comms as _resolve_max_live_comms,
-    resolve_prefix as _resolve_prefix,
-)
-from cosmos_rl.utils.payload_transport.nccl.protocol import (
-    NCCL_COMPLETION_PREFIX,
-    build_sender_request_channel,
-    parse_transfer_rollout_idx,
-)
-from cosmos_rl.utils.payload_transport.nccl.rendezvous import (
-    NcclRendezvous,
-    TransferStatus,
-)
-from cosmos_rl.utils.trajectory import (
-    EPISODE_LENGTH,
-    VARLEN_FIELDS as _VARLEN_FIELDS,
-    build_trajectory_schema,
-    deserialize_schema,
-    schema_layout,
-)
-from cosmos_rl.utils.payload_transport.nccl.streams import (
-    bind_thread_device,
-    get_transfer_stream_pool,
-    record_event,
-    wait_event,
-)
-from cosmos_rl.utils.payload_transport.prefetch_mixin import (
-    PrefetchDataPackerMixin,
-    get_trace_time,
-)
+from cosmos_rl.utils.payload_transport.prefetch_mixin import PrefetchDataPackerMixin
 
-
-_LOG_INTERVAL = 50
-
-_NP_TO_TORCH = {
-    np.dtype("float32"): torch.float32,
-    np.dtype("float64"): torch.float64,
-    np.dtype("float16"): torch.float16,
-    np.dtype("int64"): torch.int64,
-    np.dtype("int32"): torch.int32,
-    np.dtype("int16"): torch.int16,
-    np.dtype("int8"): torch.int8,
-    np.dtype("uint8"): torch.uint8,
-    np.dtype("bool"): torch.bool,
-}
+__all__ = ["NCCLDataPackerMixin"]
 
 
 class NCCLDataPackerMixin(PrefetchDataPackerMixin):
-    """NCCL subclass of :class:`PrefetchDataPackerMixin`.
+    """Mix into a DataPacker to resolve NCCL payload references.
 
-    Place **before** the concrete DataPacker in the MRO::
-
-        class NCCLSimpleRLDataPacker(NCCLDataPackerMixin, SimpleRLDataPacker):
-            pass
+    Thin by design: it owns the *wiring* -- build the strategy, attach it, run
+    the scheduler's lifecycle -- while every transport decision belongs to
+    :class:`NCCLTransportStrategy`.
     """
 
-    # NCCL-specific state.  Scheduling state (queues, thread, cache,
-    # double-buffer, step counter) is owned by the base mixin.
-    _nccl_dp_device: Optional[torch.device] = None
-    _nccl_dp_redis: Any = None
-    _nccl_dp_config: Any = None
-    _nccl_dp_rendezvous: Optional[NcclRendezvous] = None
-    _nccl_dp_comm_cache: Optional[CommCache] = None
-    _nccl_dp_streams: Any = None
-    # Serializes the NCCL recv LAUNCH region (mirrors the producer's
-    # _nccl_send_lock).  Both the prefetch worker and a trainer-thread cache-miss
-    # _sync_fetch can reach _fetch_all; concurrent multi-comm recv launches on one
-    # device deadlock natively.  Set in setup; lazily created in _fetch_all for
-    # bare test harnesses that skip setup.
-    _nccl_dp_recv_lock: Any = None
-    _nccl_dp_receiver_rank: int = 0
-    # Globally-unique policy-replica identity (this worker's ``replica_name``),
-    # assigned by ``CommMixin._attach_payload_transport`` before setup.  Keys
-    # the per-pair UID + producer comm cache so multiple policy replicas that
-    # share ``receiver_rank`` never cross-wire.  See build_pair_uid_key.
+    # ``_attach_payload_transport`` assigns this BEFORE calling setup, keyed on
+    # ``hasattr``, to disambiguate policy replicas that share a receiver_rank.
+    # It must therefore exist on the class and survive until setup consumes it.
     _nccl_dp_receiver_replica: Optional[str] = None
-    _nccl_dp_prefix: str = ""
-    _nccl_dp_max_attempts: int = 2
-    _nccl_dp_recv_timeout: float = 5.0
-    # Larger budget for the first (comm-creating) transfer of a pair, so a
-    # slow cold-start comm build isn't cancelled + falsely quarantined.
-    _nccl_dp_first_transfer_timeout: float = 30.0
-    # Pairs that have completed >=1 successful transfer ("warm").  Until a pair
-    # is warm we treat it patiently: long timeouts + NO abort/quarantine on
-    # failure, so a healthy-but-slow comm survives the cold-start storm instead
-    # of being torn down and rebuilt (churn).  Set in setup.
-    _nccl_dp_warm_pairs: Any = None
-    _nccl_dp_schema: Optional[list] = None
-
-    # Cumulative stats for periodic INFO summaries.
-    _nccl_dp_total_nccl: int = 0
-    _nccl_dp_total_fallback: int = 0
-    _nccl_dp_total_bytes: int = 0
-    _nccl_dp_total_latency_ms: float = 0.0
-    _nccl_dp_last_bytes: int = 0
-    _nccl_dp_last_count: int = 0
 
     # ------------------------------------------------------------------
-    # Backward-compat alias (parity with UCXXDataPackerMixin) so shared
-    # test / observability code can read the prefetch cache via the
-    # transport-prefixed name.
+    # Backward-compat aliases (parity with UCXXDataPackerMixin) so shared
+    # test / observability code can read state via the transport-prefixed name.
     # ------------------------------------------------------------------
 
     @property
@@ -175,6 +62,11 @@ class NCCLDataPackerMixin(PrefetchDataPackerMixin):
     @_nccl_dp_prefetch_cache.setter
     def _nccl_dp_prefetch_cache(self, value: Dict[str, Any]) -> None:
         self._prefetch_cache = value
+
+    @property
+    def _nccl_dp_strategy(self) -> Optional[NCCLTransportStrategy]:
+        """The composed transport, or None before setup."""
+        return self._transport_strategy
 
     # ------------------------------------------------------------------
     # Setup / teardown
@@ -191,671 +83,45 @@ class NCCLDataPackerMixin(PrefetchDataPackerMixin):
         recv_timeout: float = 5.0,
         first_transfer_timeout: float = 30.0,
     ) -> None:
-        """Initialise NCCL rendezvous / comm cache + start the prefetch thread.
+        """Build the NCCL strategy, attach it, and start the prefetch thread.
 
-        Normally invoked automatically by
-        :meth:`NcclPayloadTransport.attach_data_packer`.  Direct calls are
-        only needed in tests or unusual lifecycle setups.
+        Normally invoked by ``NcclPayloadTransport.attach_data_packer``; direct
+        calls are only needed in tests or unusual lifecycle setups.
 
         Args:
             device: Target GPU device for fetched tensors.
             redis_client: Live Redis client for the control plane.
-            config: The run :class:`Config`; supplies the experiment name
-                (for the Redis key prefix) and ``custom`` schema tunables.
-            prefetch_timeout: Per-batch wait ceiling (seconds).
-            max_attempts: Total attempts per transfer (initial + transient
-                retries).
-            recv_timeout: Per-``nccl_recv`` / per-rendezvous wall-clock
-                budget so a wedged sender engages retry / quarantine fast.
+            config: The run Config; supplies the experiment name (Redis key
+                prefix) and ``custom`` schema tunables.
+            prefetch_timeout: Per-batch wait ceiling (seconds).  Belongs to the
+                scheduler, not the transport, so it stops here.
+            max_attempts: Total attempts per transfer (initial + retries).
+            recv_timeout: Per-recv / per-rendezvous wall-clock budget so a
+                wedged sender engages retry / quarantine fast.
+            first_transfer_timeout: Cold-start budget, which must absorb the
+                comm-init storm.
         """
-        self._nccl_dp_device = device
-        self._nccl_dp_redis = redis_client
-        self._nccl_dp_config = config
-        self._nccl_dp_max_attempts = max(1, max_attempts)
-        self._nccl_dp_recv_timeout = recv_timeout
-        self._nccl_dp_first_transfer_timeout = max(recv_timeout, first_transfer_timeout)
-        self._nccl_dp_recv_lock = threading.Lock()
-        self._nccl_dp_warm_pairs = set()
-        self._nccl_dp_receiver_rank = _resolve_global_rank()
-        # ``_attach_payload_transport`` sets ``_nccl_dp_receiver_replica`` to
-        # this worker's ``replica_name`` before setup.  Fall back to a
-        # rank-derived id for standalone/test setups (unique within a single
-        # replica, which is all such setups have).
-        if not self._nccl_dp_receiver_replica:
-            self._nccl_dp_receiver_replica = f"recv{self._nccl_dp_receiver_rank}"
-        self._nccl_dp_prefix = _resolve_prefix(config)
-        self._nccl_dp_schema = build_trajectory_schema(_resolve_schema_dims(config))
-
-        # The per-pair UID key must outlive a cold-start request: it is
-        # published when the receiver initiates and read by the sender when it
-        # finally serves (up to first_transfer_timeout later, behind the
-        # comm-init storm).  If the UID's TTL expired first, the sender would
-        # see a truthy uid_key, ACCEPT, but read_uid() -> None, build from an
-        # empty UID, and the two comm halves would never join.  Keep the TTL
-        # comfortably above the cold-start budget.
-        uid_ttl_s = max(60, int(self._nccl_dp_first_transfer_timeout) + 30)
-        self._nccl_dp_rendezvous = NcclRendezvous(
-            redis_client, self._nccl_dp_prefix, uid_ttl_s=uid_ttl_s
-        )
-        # Cap sized from the peer fan-out (this side talks to rollout replicas),
-        # never below the historical default.  A blind cap is what makes LRU
-        # eviction dangerous: at the wrong scale every transfer rebuilds a comm.
-        self._nccl_dp_comm_cache = CommCache(
-            max_live=_resolve_max_live_comms(config, peer_role="rollout"),
-            quarantine_cooldown=max(1.0, recv_timeout * 6.0),
-        )
-        self._nccl_dp_streams = get_transfer_stream_pool(size=1, device=device)
-
-        self._setup_prefetch(
+        compose_nccl_transport(
+            self,
+            device=device,
+            redis_client=redis_client,
+            config=config,
             prefetch_timeout=prefetch_timeout,
-            thread_name="NCCLDataPackerPrefetch",
+            max_attempts=max_attempts,
+            recv_timeout=recv_timeout,
+            first_transfer_timeout=first_transfer_timeout,
         )
-
-        logger.info(
-            "[NCCLDataPackerMixin] Initialised: device=%s, rank=%d, timeout=%ss, "
-            "max_attempts=%d, recv_timeout=%ss",
-            device,
-            self._nccl_dp_receiver_rank,
-            prefetch_timeout,
-            self._nccl_dp_max_attempts,
-            recv_timeout,
-        )
-
-    def _abort_nccl_dp_comms(self) -> None:
-        """Abort every cached comm so an in-flight ``nccl_recv`` returns.
-
-        Used as ``shutdown_prefetch``'s ``before_join`` hook: the prefetch
-        worker only checks the shutdown event *between* batches, so a recv
-        parked on a departed peer would otherwise hold the join for the full
-        first-transfer budget rather than the join timeout.
-        """
-        if self._nccl_dp_comm_cache is not None:
-            try:
-                self._nccl_dp_comm_cache.abort_all()
-            except Exception as e:  # pragma: no cover - teardown best-effort
-                logger.warning("[NCCLDataPackerMixin] comm abort failed: %s", e)
 
     def shutdown_nccl_data_packer(self) -> None:
-        """Stop the prefetch thread and abort all cached communicators.
+        """Stop the prefetch thread, then release the transport.
 
-        Aborts BEFORE joining -- mirroring the producer's ``cleanup_nccl`` --
-        so the worker's wedged recv fails fast instead of the join waiting on
-        work only the abort can unwedge.
+        ``shutdown_prefetch`` aborts the strategy's comms before joining -- it
+        defaults ``before_join`` to the attached strategy -- so a worker parked
+        in a recv fails fast instead of the join waiting on work only the abort
+        can unwedge.
         """
-        self.shutdown_prefetch(before_join=self._abort_nccl_dp_comms)
-        if self._prefetch_step_count > 0:
-            avg_ms = self._nccl_dp_total_latency_ms / self._prefetch_step_count
-            logger.info(
-                "[NCCLDataPackerMixin] Final: %d iters, %d NCCL / %d fallback, "
-                "%.1f MB, avg %.0f ms/iter",
-                self._prefetch_step_count,
-                self._nccl_dp_total_nccl,
-                self._nccl_dp_total_fallback,
-                self._nccl_dp_total_bytes / 1e6,
-                avg_ms,
-            )
+        self.shutdown_prefetch()
+        strategy = self._transport_strategy
+        if strategy is not None:
+            strategy.shutdown()
         logger.info("[NCCLDataPackerMixin] Shut down")
-
-    # ------------------------------------------------------------------
-    # PrefetchDataPackerMixin hook implementations
-    # ------------------------------------------------------------------
-
-    def _should_intercept(self, rollout_output: Any) -> bool:
-        """NCCL wire-format predicate (string completion or dict ref)."""
-        if isinstance(rollout_output, str):
-            return rollout_output.startswith(NCCL_COMPLETION_PREFIX)
-        if isinstance(rollout_output, dict):
-            return bool(rollout_output.get("_nccl"))
-        return False
-
-    def _cache_key(self, rollout_output: Any) -> str:
-        return self._nccl_dp_cache_key(rollout_output)
-
-    def _fetch_batch(self, tasks: List[Any]) -> Dict[str, Any]:
-        """Resolve a batch of NCCL references via rendezvous + standalone per-pair recvs."""
-        refs: List[Tuple[Any, dict]] = []
-        for idx, ro in tasks:
-            ref = _parse_ref(ro, default_schema=self._nccl_dp_schema)
-            if ref is not None:
-                refs.append((idx, ref))
-
-        results, total_bytes, transfer_ms = self._fetch_all(refs)
-
-        cache_results: Dict[str, Any] = {}
-        for idx, gpu_data in results.items():
-            key = _cache_key_from_task(tasks, idx)
-            cache_results[key] = gpu_data
-
-        self._nccl_dp_last_bytes = total_bytes
-        self._nccl_dp_last_count = len(results)
-        if results:
-            logger.debug(
-                "[Trace] thread=nccl_prefetch op=nccl_fetch transfer_ms=%.1f "
-                "count=%d bytes=%d",
-                transfer_ms,
-                len(results),
-                total_bytes,
-            )
-        return cache_results
-
-    def _sync_fetch(self, rollout_output: Any) -> Optional[Dict[str, torch.Tensor]]:
-        """Blocking single-episode NCCL fetch (cache-miss fallback).
-
-        Returns ``None`` on any failure rather than propagating: the base
-        mixin calls this on the cache-miss path inside ``get_policy_input``
-        without its own containment, so a raised rendezvous/recv error would
-        crash the training step instead of degrading to the packer's fallback.
-        Mirrors the UCXX consumer's sync-fallback contract.
-        """
-        try:
-            # Parse inside the guard too: a malformed dict ref (e.g. a corrupt
-            # ``_schema``) raises from deserialize_schema, and this path has no
-            # containment above it in the base get_policy_input.
-            ref = _parse_ref(rollout_output, default_schema=self._nccl_dp_schema)
-            if ref is None:
-                return None
-            results, _, _ = self._fetch_all([(0, ref)])
-        except Exception as e:
-            logger.warning("[NCCLDataPackerMixin] Sync fallback failed: %s", e)
-            return None
-        return results.get(0)
-
-    def _on_prefetch_complete(
-        self, batch_id: int, n_results: int, fetch_ms: float
-    ) -> None:
-        self._nccl_dp_total_nccl += getattr(self, "_nccl_dp_last_count", n_results)
-        self._nccl_dp_total_bytes += getattr(self, "_nccl_dp_last_bytes", 0)
-        self._nccl_dp_total_latency_ms += fetch_ms
-        step = self._prefetch_step_count
-        if step == 1 or step % _LOG_INTERVAL == 0:
-            avg_ms = self._nccl_dp_total_latency_ms / step
-            logger.info(
-                "[NCCLDataPackerMixin] Iteration %d: %d NCCL, %.1f MB total, "
-                "avg %.0f ms/iter",
-                step,
-                self._nccl_dp_total_nccl,
-                self._nccl_dp_total_bytes / 1e6,
-                avg_ms,
-            )
-
-    def _on_resolve_failed(self, rollout_output: Any, cache_key: str) -> None:
-        self._nccl_dp_total_fallback += 1
-
-    # get_policy_input is inherited unchanged from PrefetchDataPackerMixin.
-
-    # ------------------------------------------------------------------
-    # NCCL recv path
-    # ------------------------------------------------------------------
-
-    def _fetch_all(self, refs: List[Tuple[Any, dict]]) -> Tuple[dict, int, float]:
-        """Rendezvous + grouped ``nccl_recv`` for every ref.
-
-        Returns ``(results_by_idx, total_bytes, transfer_ms)``.  Each ref
-        is negotiated over Redis first (so we know which recvs will
-        actually happen and on which comm), then each accepted recv is
-        issued as a STANDALONE ``nccl_recv`` on its own 2-rank pair comm
-        (deliberately NOT wrapped in a cross-communicator
-        ``ncclGroupStart/End``, which would couple independent producers
-        into one completion unit -- the N_POLICY>=2 wedge).  A per-ref
-        ``max_attempts`` fresh-call retry wraps the rendezvous; a ref that
-        still fails to resolve is dropped and re-attempted on the next
-        prefetch round (there is no in-batch multi-round layer above this).
-        """
-        from cosmos_rl.utils import pynccl
-
-        rv = self._nccl_dp_rendezvous
-        cache = self._nccl_dp_comm_cache
-        device = self._nccl_dp_device
-        if rv is None or cache is None:
-            return {}, 0, 0.0
-        # The prefetch worker runs off the main thread; bind it to our GPU so
-        # comm creation + recvs target the right device (thread-local).
-        bind_thread_device(device)
-
-        t0 = get_trace_time()
-        # Declared OUTSIDE the try so the finally can always read it.
-        recvs: List[Tuple[Any, dict, int, torch.Tensor]] = []
-        # Pins taken during phase 1 must be released on EVERY exit path,
-        # including the early returns and any raise below.
-        try:
-            # Phase 1: rendezvous (control plane) — sequential Redis round-trips.
-            for idx, ref in refs:
-                prepared = self._rendezvous_one(ref, pynccl)
-                if prepared is None:
-                    continue
-                comm_idx, recv_buf = prepared
-                recvs.append((idx, ref, comm_idx, recv_buf))
-
-            if not recvs:
-                return {}, 0, get_trace_time() - t0
-
-            # A batch is "warming" until every pair in it has transferred at least
-            # once; give its recvs the long cold-start budget so a slow (storm-
-            # contended) send isn't cancelled -> comm torn down -> rebuilt into the
-            # same storm.
-            receiver_rank = self._nccl_dp_receiver_rank
-            warm = self._nccl_dp_warm_pairs
-            batch_warming = any(
-                _pair_key(ref, receiver_rank) not in warm for _i, ref, _c, _b in recvs
-            )
-            recv_timeout_ms = int(
-                (
-                    self._nccl_dp_first_transfer_timeout
-                    if batch_warming
-                    else self._nccl_dp_recv_timeout
-                )
-                * 1000
-            )
-
-            # Phase 2: issue ONE STANDALONE recv per pair communicator -- NOT a
-            # cross-communicator NCCL group.  Each comm is a distinct 2-rank pair
-            # with a single send/recv, so grouping adds no overlap; it only turns
-            # independent producers into one completion unit whose native
-            # ncclGroupEnd blocks -- with NO pynccl watchdog (run_task arms its
-            # deadline only AFTER the native call returns) -- if any producer has
-            # not yet posted its matching send (its send lock is busy serving the
-            # other policy replica).  That coupling was the N_POLICY>=2 residual
-            # wedge.  Ungrouped, a slow/serialized producer only delays its own
-            # recv; the others complete independently.
-            results: Dict[int, dict] = {}
-            total_bytes = 0
-            posted: List[Tuple[Any, dict, int, torch.Tensor]] = []
-            # Serialize the NCCL recv LAUNCH on this consumer's GPU, mirroring the
-            # producer's _nccl_send_lock.  Both the prefetch worker (_fetch_all off the
-            # prefetch thread) and a trainer-thread cache-miss _sync_fetch can reach
-            # here; concurrent multi-comm recv launches on one device deadlock
-            # natively -- and because run_task arms its deadline only AFTER the native
-            # call returns, the recv timeout can't rescue a launch deadlock.  Only the
-            # async ENQUEUE + event record run under the lock (every op is a stream
-            # enqueue); the blocking synchronize() below stays lock-free so real
-            # transfers still overlap across the two callers.
-            recv_lock = self._nccl_dp_recv_lock
-            if recv_lock is None:  # bare test harness that skipped setup
-                recv_lock = self._nccl_dp_recv_lock = threading.Lock()
-            with recv_lock:
-                stream = (
-                    self._nccl_dp_streams.acquire() if self._nccl_dp_streams else None
-                )
-                for idx, ref, comm_idx, recv_buf in recvs:
-                    try:
-                        pynccl.nccl_recv(
-                            recv_buf,
-                            SENDER_LOCAL_RANK,  # peer in the 2-rank comm is the sender
-                            comm_idx,
-                            stream=stream,
-                            timeout_ms=recv_timeout_ms,
-                        )
-                    except Exception as exc:
-                        logger.warning(
-                            "[NCCLDataPackerMixin] recv failed for %s: %s",
-                            ref["transfer_id"],
-                            exc,
-                        )
-                        # Isolate the failure to this pair (quarantine only if warm).
-                        self._quarantine_recv_failures(
-                            [(idx, ref, comm_idx, recv_buf)], cache
-                        )
-                        continue
-                    posted.append((idx, ref, comm_idx, recv_buf))
-
-                if not posted:
-                    return {}, 0, get_trace_time() - t0
-
-                # Recv-complete event gates downstream training consumption.
-                done = record_event(stream)
-
-            wait_event(None, done)  # current (compute) stream waits before reads
-            if torch.cuda.is_available():
-                try:
-                    torch.cuda.current_stream().synchronize()
-                except Exception as exc:
-                    # A recv that ENQUEUED cleanly but whose peer never sent (dead /
-                    # hung producer) surfaces HERE at completion, not at the enqueue
-                    # try/except above.  Do NOT let it propagate: an uncaught raise
-                    # unwinds _fetch_all -> the prefetch worker marks the WHOLE batch
-                    # failed -> wait_prefetch wipes the cache -> every episode drops to
-                    # fallback AND the offending pair is never quarantined (quarantine
-                    # is only reachable from the enqueue path).  A single stream sync
-                    # can't attribute the failure to one recv, so conservatively
-                    # quarantine every posted (warm) pair and drop just this batch to
-                    # fallback; the dead pair(s) now cool down instead of re-storming.
-                    logger.warning(
-                        "[NCCLDataPackerMixin] recv completion sync failed "
-                        "(%d posted pairs): %s; quarantining posted pairs",
-                        len(posted),
-                        exc,
-                    )
-                    self._quarantine_recv_failures(posted, cache)
-                    return {}, 0, get_trace_time() - t0
-
-            for idx, ref, _comm_idx, recv_buf in posted:
-                gpu_data = _unpack(recv_buf, ref["schema"], device)
-                results[idx] = gpu_data
-                total_bytes += recv_buf.numel() * recv_buf.element_size()
-                # First successful transfer -> this pair is warm (tight timeouts +
-                # normal quarantine from here on).
-                warm.add(_pair_key(ref, receiver_rank))
-
-            return results, total_bytes, get_trace_time() - t0
-        finally:
-            # Release the eviction pins taken by _rendezvous_one.  The comm
-            # was leased from build through recv completion (the
-            # synchronize above), so unpinning earlier would reopen the
-            # mid-collective eviction window.
-            receiver_rank = self._nccl_dp_receiver_rank
-            for _i, _ref, _c, _b in recvs:
-                cache.unpin(_pair_key(_ref, receiver_rank))
-
-    def _quarantine_endpoint(self, cache: Any, health_key: Any, pair: Any) -> None:
-        """Quarantine a warm endpoint AND demote its pair back to 'warming'.
-
-        Clearing the warm marker (comm-generation recovery) means the
-        post-cooldown rebuild is treated as a cold start: it gets the generous
-        ``first_transfer_timeout`` budget instead of the tight ``recv_timeout``,
-        so the freshly-renegotiated comm isn't immediately re-quarantined by the
-        very short window that caused the original failure.  Pairs with the
-        producer's stale comm-half are also torn down by ``quarantine`` (abort),
-        and the producer rebuilds its half on the next fresh UID.
-        """
-        try:
-            cache.quarantine(health_key)
-        except Exception as exc:  # pragma: no cover - best-effort teardown
-            logger.debug(
-                "[NCCLDataPackerMixin] quarantine %s raised %s; continuing",
-                health_key,
-                type(exc).__name__,
-            )
-        if pair is not None:
-            self._nccl_dp_warm_pairs.discard(pair)
-
-    def _quarantine_recv_failures(
-        self, recvs: List[Tuple[Any, dict, int, torch.Tensor]], cache: Any
-    ) -> None:
-        """After a recv failure, quarantine only the WARM pairs.
-
-        A warm pair (has transferred before) that fails is a genuine problem ->
-        quarantine + abort its comm (``CommCache.quarantine`` prefix-matches
-        the ``(sender_replica, sender_rank, receiver_rank)`` comm).  A pair that
-        is still WARMING is just storm-contended -> keep its built comm and let
-        it retry next round; tearing it down here is what churned N_POLICY>=2.
-        """
-        receiver_rank = self._nccl_dp_receiver_rank
-        warm = self._nccl_dp_warm_pairs
-        for _idx, ref, _comm_idx, _buf in recvs:
-            pair = _pair_key(ref, receiver_rank)
-            if pair not in warm:
-                continue  # still warming -> keep the comm, retry
-            self._quarantine_endpoint(
-                cache, (ref["sender_replica"], ref["sender_rank"]), pair
-            )
-
-    def _rendezvous_one(
-        self, ref: dict, pynccl: Any
-    ) -> Optional[Tuple[int, torch.Tensor]]:
-        """Negotiate one transfer; return ``(comm_idx, recv_buf)`` or None.
-
-        Applies the per-ref fresh-call retry and health-aware quarantine.
-        """
-        rv = self._nccl_dp_rendezvous
-        cache = self._nccl_dp_comm_cache
-        transfer_id = ref["transfer_id"]
-        sender_rank = ref["sender_rank"]
-        sender_replica = ref["sender_replica"]
-        receiver_rank = self._nccl_dp_receiver_rank
-        receiver_replica = self._nccl_dp_receiver_replica
-        # Pair key + health key are keyed on the globally-unique sender
-        # replica identity so distinct rollout replicas never collide.
-        pair = _pair_key(ref, receiver_rank)
-        health_key = (sender_replica, sender_rank)
-        # "warming" until this pair completes its first successful transfer.
-        warming = pair not in self._nccl_dp_warm_pairs
-
-        if cache.is_quarantined(health_key):
-            logger.debug(
-                "[NCCLDataPackerMixin] endpoint %s quarantined; skipping %s",
-                health_key,
-                transfer_id,
-            )
-            return None
-
-        request_channel = build_sender_request_channel(self._nccl_dp_prefix, ref)
-
-        for attempt in range(1, self._nccl_dp_max_attempts + 1):
-            need_uid = pair not in cache
-            # Until the pair is warm, give it the long cold-start budget so the
-            # comm-init storm doesn't cancel a healthy-but-slow transfer; a warm
-            # pair uses the tight steady-state budget.
-            timeout = (
-                self._nccl_dp_first_transfer_timeout
-                if warming
-                else self._nccl_dp_recv_timeout
-            )
-            result = rv.initiate(
-                transfer_id=transfer_id,
-                sender_replica=sender_replica,
-                sender_rank=sender_rank,
-                receiver_replica=receiver_replica,
-                receiver_rank=receiver_rank,
-                request_channel=request_channel,
-                need_uid=need_uid,
-                timeout=timeout,
-                attempt=attempt,
-            )
-            if result.status is TransferStatus.ACCEPTED:
-                try:
-                    # PIN the comm: the caller holds this comm_idx until its
-                    # recv completes, so an unpinned entry could be evicted +
-                    # aborted mid-collective by a concurrent build for another
-                    # pair.  _fetch_all releases it in a finally.
-                    comm_idx = cache.get_or_create(
-                        pair,
-                        uid_chars=result.uid_chars or [],
-                        local_rank=RECEIVER_LOCAL_RANK,
-                        pin=True,
-                    )
-                except Exception as e:
-                    logger.warning(
-                        "[NCCLDataPackerMixin] comm build failed for %s: %s%s",
-                        transfer_id,
-                        e,
-                        "; retry next round (warming)" if warming else "; quarantining",
-                    )
-                    if not warming:
-                        self._quarantine_endpoint(cache, health_key, pair)
-                    return None
-                try:
-                    recv_buf = _alloc_recv_buffer(ref["schema"], self._nccl_dp_device)
-                except Exception:
-                    # Never returned to the caller -> nothing will unpin it here.
-                    cache.unpin(pair)
-                    raise
-                return comm_idx, recv_buf
-            if result.status is TransferStatus.MISSING:
-                # Producer recycled the buffer — non-retryable, drop now.
-                logger.debug(
-                    "[NCCLDataPackerMixin] transfer %s missing (recycled)",
-                    transfer_id,
-                )
-                return None
-            if result.status is TransferStatus.NEED_UID:
-                # The sender evicted its side of the comm; our cached comm is
-                # now half-open.  Drop it and retry -- the next attempt has
-                # need_uid=True and mints a fresh uid so BOTH sides rebuild.
-                logger.debug(
-                    "[NCCLDataPackerMixin] transfer %s: sender needs a fresh "
-                    "uid; dropping stale comm and renegotiating",
-                    transfer_id,
-                )
-                cache.abort(pair)
-                continue
-            # CANCELLED (timeout).
-            if attempt == self._nccl_dp_max_attempts:
-                if not warming:
-                    # A WARM pair (has transferred before) that stops
-                    # rendezvousing -> the sender likely died mid-run;
-                    # quarantine so we stop hammering it (and abort the comm).
-                    logger.warning(
-                        "[NCCLDataPackerMixin] transfer %s cancelled after %d "
-                        "attempts on a warm comm; quarantining %s",
-                        transfer_id,
-                        self._nccl_dp_max_attempts,
-                        health_key,
-                    )
-                    self._quarantine_endpoint(cache, health_key, pair)
-                else:
-                    # Still warming: the sender is warming up / storm-contended,
-                    # NOT unhealthy.  KEEP any built comm and retry next round
-                    # WITHOUT quarantining -- tearing it down here (and thus
-                    # rebuilding into the same storm) is what churned N_POLICY>=2
-                    # to 0 MB.
-                    logger.debug(
-                        "[NCCLDataPackerMixin] transfer %s still warming (%d "
-                        "attempts); keeping comm, retry next round",
-                        transfer_id,
-                        self._nccl_dp_max_attempts,
-                    )
-        return None
-
-    # ------------------------------------------------------------------
-    # Cache-key helpers (parity with UCXX; used by tests + _fetch_batch).
-    # ------------------------------------------------------------------
-
-    @staticmethod
-    def _nccl_dp_cache_key(rollout_output: Any) -> str:
-        ref = _parse_ref(rollout_output)
-        if ref is not None:
-            return ref["transfer_id"]
-        return str(rollout_output)
-
-
-# ---------------------------------------------------------------------------
-# Module-level helpers (ref parsing / buffer alloc / unpack)
-# ---------------------------------------------------------------------------
-
-
-def _parse_ref(
-    rollout_output: Any, *, default_schema: Optional[list] = None
-) -> Optional[dict]:
-    """Normalize a completion string or dict metadata into an internal ref.
-
-    Returns a dict with ``transfer_id``, ``sender_rank``, ``rollout_idx``,
-    and ``schema`` (a list of :class:`TensorSpec`), or ``None`` if the
-    input is not an NCCL reference.
-    """
-    if isinstance(rollout_output, str):
-        if not rollout_output.startswith(NCCL_COMPLETION_PREFIX):
-            return None
-        transfer_id = rollout_output[len(NCCL_COMPLETION_PREFIX) :]
-        rollout_idx = parse_transfer_rollout_idx(transfer_id)
-        # Bare "nccl:<id>" string carries no dict metadata, so there is no
-        # globally-unique replica identity -- fall back to the rollout-idx.
-        # (This form is single-node / testing only; the rl-gym producer
-        # returns dict metadata carrying _sender_replica.)
-        return {
-            "transfer_id": transfer_id,
-            "rollout_idx": rollout_idx,
-            "sender_rank": rollout_idx if rollout_idx >= 0 else 0,
-            "sender_replica": f"rollout-{rollout_idx if rollout_idx >= 0 else 0}",
-            "schema": default_schema,
-        }
-    if isinstance(rollout_output, dict) and rollout_output.get("_nccl"):
-        transfer_id = rollout_output.get("_transfer_id", "")
-        rollout_idx = rollout_output.get(
-            "_rollout_idx", parse_transfer_rollout_idx(transfer_id)
-        )
-        schema = default_schema
-        raw_schema = rollout_output.get("_schema")
-        if raw_schema:
-            schema = deserialize_schema(raw_schema)
-        sender_rank = rollout_output.get(
-            "_sender_rank", rollout_idx if rollout_idx >= 0 else 0
-        )
-        # Globally-unique sender identity: the producer's replica id/name.
-        # Falls back to the rollout-idx form only if the producer omitted it.
-        sender_replica = rollout_output.get("_sender_replica") or (
-            f"rollout-{rollout_idx if rollout_idx >= 0 else 0}"
-        )
-        return {
-            "transfer_id": transfer_id,
-            "rollout_idx": rollout_idx,
-            "sender_rank": sender_rank,
-            "sender_replica": sender_replica,
-            "schema": schema,
-        }
-    return None
-
-
-def _pair_key(ref: dict, receiver_rank: int):
-    """Globally-unique comm-cache pair key for a transfer.
-
-    ``(sender_replica, sender_rank, receiver_rank)`` -- keyed on the
-    rollout replica's globally-unique identity so two replicas sharing a
-    per-replica ``sender_rank`` (e.g. both 0) map to DISTINCT communicators.
-    """
-    return (ref["sender_replica"], ref["sender_rank"], receiver_rank)
-
-
-def _cache_key_from_task(tasks: List[Any], idx: int) -> str:
-    for task_idx, ro in tasks:
-        if task_idx == idx:
-            return NCCLDataPackerMixin._nccl_dp_cache_key(ro)
-    return str(idx)
-
-
-def _alloc_recv_buffer(schema: Optional[list], device: Any) -> torch.Tensor:
-    """Allocate a flat uint8 GPU buffer sized for ``schema``."""
-    if schema is None:
-        raise ValueError("cannot allocate NCCL recv buffer without a schema")
-    _, entry_size = schema_layout(schema)
-    return torch.empty(entry_size, dtype=torch.uint8, device=device)
-
-
-def _unpack(recv_buf: torch.Tensor, schema: Optional[list], device: Any) -> dict:
-    """Slice a flat recv buffer back into the named schema tensors."""
-    if schema is None:
-        return {}
-    offsets, _ = schema_layout(schema)
-    out: Dict[str, Any] = {}
-    for spec in schema:
-        td = _NP_TO_TORCH.get(np.dtype(spec.dtype))
-        if td is None:
-            raise ValueError(f"unsupported dtype {spec.dtype} for '{spec.name}'")
-        off = offsets[spec.name]
-        # Clone the byte slice BEFORE reinterpreting: a sub-tensor whose
-        # storage_offset is not a multiple of the target itemsize (e.g. the
-        # int64 episode_length landing at byte 300) cannot be ``view``-ed to
-        # the wider dtype.  Cloning yields fresh storage at offset 0, which
-        # is always aligned.  (Same reason UCXX clones before its view.)
-        raw = recv_buf[off : off + spec.nbytes].clone()
-        out[spec.name] = raw.view(td).reshape(spec.shape)
-    _truncate_to_episode_len(out)
-    return out
-
-
-def _truncate_to_episode_len(data: dict) -> None:
-    ep = data.get(EPISODE_LENGTH)
-    if ep is None:
-        return
-    try:
-        ep_len = int(ep.item()) if ep.numel() == 1 else int(ep[0].item())
-    except Exception:
-        return
-    for key in _VARLEN_FIELDS:
-        if key in data and data[key].shape[0] > ep_len:
-            data[key] = data[key][:ep_len]
-
-
-def _resolve_schema_dims(config: Any) -> dict:
-    custom = getattr(config, "custom", None) or {}
-
-    def _get(key, default):
-        try:
-            return int(custom.get(key, default))
-        except (TypeError, ValueError):
-            return default
-
-    return {
-        "max_steps": _get("nccl_max_steps", 100),
-        "obs_dim": _get("nccl_obs_dim", 4),
-        "action_dim": _get("nccl_action_dim", 2),
-    }

--- a/cosmos_rl/utils/payload_transport/nccl/strategy.py
+++ b/cosmos_rl/utils/payload_transport/nccl/strategy.py
@@ -1,0 +1,829 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""NCCL payload transport, expressed as a composable strategy.
+
+Holds everything about moving a trajectory GPU->GPU -- the Redis-backed
+rendezvous, the communicator cache, the transfer streams, retry and quarantine
+-- and nothing about *when* a fetch happens, which is the packer's job.
+
+This is the code the 8-GPU Slurm run and the 2-rank e2e probe validated, moved
+off ``NCCLDataPackerMixin`` unchanged apart from dropping the ``_nccl_dp_``
+prefix (its state no longer shares a namespace with a packer) and taking the
+iteration counter as an argument instead of reading it off one.
+"""
+
+from __future__ import annotations
+
+import threading
+from typing import Any, Dict, List, Optional, Tuple
+
+import numpy as np
+import torch
+
+from cosmos_rl.utils.logging import logger
+from cosmos_rl.utils.payload_transport.nccl.comm_cache import (
+    CommCache,
+    RECEIVER_LOCAL_RANK,
+    SENDER_LOCAL_RANK,
+)
+from cosmos_rl.utils.payload_transport.nccl.context import (
+    resolve_global_rank as _resolve_global_rank,
+    resolve_max_live_comms as _resolve_max_live_comms,
+    resolve_prefix as _resolve_prefix,
+)
+from cosmos_rl.utils.payload_transport.nccl.protocol import (
+    NCCL_COMPLETION_PREFIX,
+    build_sender_request_channel,
+    parse_transfer_rollout_idx,
+)
+from cosmos_rl.utils.payload_transport.nccl.rendezvous import (
+    NcclRendezvous,
+    TransferStatus,
+)
+from cosmos_rl.utils.trajectory import (
+    EPISODE_LENGTH,
+    VARLEN_FIELDS as _VARLEN_FIELDS,
+    build_trajectory_schema,
+    deserialize_schema,
+    schema_layout,
+)
+from cosmos_rl.utils.payload_transport.nccl.streams import (
+    bind_thread_device,
+    get_transfer_stream_pool,
+    record_event,
+    wait_event,
+)
+from cosmos_rl.utils.payload_transport.strategy import PayloadTransportStrategy
+from cosmos_rl.utils.trace import get_trace_time
+
+
+_LOG_INTERVAL = 50
+
+_NP_TO_TORCH = {
+    np.dtype("float32"): torch.float32,
+    np.dtype("float64"): torch.float64,
+    np.dtype("float16"): torch.float16,
+    np.dtype("int64"): torch.int64,
+    np.dtype("int32"): torch.int32,
+    np.dtype("int16"): torch.int16,
+    np.dtype("int8"): torch.int8,
+    np.dtype("uint8"): torch.uint8,
+    np.dtype("bool"): torch.bool,
+}
+
+
+class NCCLTransportStrategy(PayloadTransportStrategy):
+    """Resolve NCCL payload references for a single receiver.
+
+    :meth:`fetch_batch` runs on the packer's prefetch thread; everything else
+    runs on the caller's.  Each counter below is written from one side only,
+    which is what keeps that split safe without locking.
+    """
+
+    _device: Optional[torch.device] = None
+    _redis: Any = None
+    _config: Any = None
+    _rendezvous: Optional[NcclRendezvous] = None
+    _comm_cache: Optional[CommCache] = None
+    _streams: Any = None
+    _recv_lock: Any = None
+    _receiver_rank: int = 0
+    _receiver_replica: Optional[str] = None
+    _prefix: str = ""
+    _max_attempts: int = 2
+    _recv_timeout: float = 5.0
+    _first_transfer_timeout: float = 30.0
+    _warm_pairs: Any = None
+    _schema: Optional[list] = None
+    _total_nccl: int = 0
+    _total_fallback: int = 0
+    _total_bytes: int = 0
+    _total_latency_ms: float = 0.0
+    _last_bytes: int = 0
+    _last_count: int = 0
+    _steps: int = 0
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    def setup(
+        self,
+        *,
+        device: Any,
+        redis_client: Any,
+        config: Any = None,
+        max_attempts: int = 2,
+        recv_timeout: float = 5.0,
+        first_transfer_timeout: float = 30.0,
+        receiver_replica: Optional[str] = None,
+    ) -> None:
+        """Initialise the NCCL rendezvous, comm cache and transfer streams.
+
+        Normally invoked by the packer that composes this strategy.  Direct calls are
+        only needed in tests or unusual lifecycle setups.
+
+        Args:
+            device: Target GPU device for fetched tensors.
+            redis_client: Live Redis client for the control plane.
+            config: The run :class:`Config`; supplies the experiment name
+                (for the Redis key prefix) and ``custom`` schema tunables.
+            max_attempts: Total attempts per transfer (initial + transient
+                retries).
+            recv_timeout: Per-``nccl_recv`` / per-rendezvous wall-clock
+                budget so a wedged sender engages retry / quarantine fast.
+        """
+        self._device = device
+        self._redis = redis_client
+        self._config = config
+        self._max_attempts = max(1, max_attempts)
+        self._recv_timeout = recv_timeout
+        self._first_transfer_timeout = max(recv_timeout, first_transfer_timeout)
+        self._recv_lock = threading.Lock()
+        self._warm_pairs = set()
+        self._receiver_rank = _resolve_global_rank()
+        if receiver_replica:
+            self._receiver_replica = receiver_replica
+        # ``_attach_payload_transport`` sets ``_nccl_dp_receiver_replica`` to
+        # this worker's ``replica_name`` before setup.  Fall back to a
+        # rank-derived id for standalone/test setups (unique within a single
+        # replica, which is all such setups have).
+        if not self._receiver_replica:
+            self._receiver_replica = f"recv{self._receiver_rank}"
+        self._prefix = _resolve_prefix(config)
+        self._schema = build_trajectory_schema(_resolve_schema_dims(config))
+
+        # The per-pair UID key must outlive a cold-start request: it is
+        # published when the receiver initiates and read by the sender when it
+        # finally serves (up to first_transfer_timeout later, behind the
+        # comm-init storm).  If the UID's TTL expired first, the sender would
+        # see a truthy uid_key, ACCEPT, but read_uid() -> None, build from an
+        # empty UID, and the two comm halves would never join.  Keep the TTL
+        # comfortably above the cold-start budget.
+        uid_ttl_s = max(60, int(self._first_transfer_timeout) + 30)
+        self._rendezvous = NcclRendezvous(
+            redis_client, self._prefix, uid_ttl_s=uid_ttl_s
+        )
+        # Cap sized from the peer fan-out (this side talks to rollout replicas),
+        # never below the historical default.  A blind cap is what makes LRU
+        # eviction dangerous: at the wrong scale every transfer rebuilds a comm.
+        self._comm_cache = CommCache(
+            max_live=_resolve_max_live_comms(config, peer_role="rollout"),
+            quarantine_cooldown=max(1.0, recv_timeout * 6.0),
+        )
+        self._streams = get_transfer_stream_pool(size=1, device=device)
+
+        logger.info(
+            "[NCCLTransportStrategy] Initialised: device=%s, rank=%d, "
+            "max_attempts=%d, recv_timeout=%ss",
+            device,
+            self._receiver_rank,
+            self._max_attempts,
+            recv_timeout,
+        )
+
+    def before_join(self) -> None:
+        """Abort every cached comm so an in-flight ``nccl_recv`` returns.
+
+        Used as ``shutdown_prefetch``'s ``before_join`` hook: the prefetch
+        worker only checks the shutdown event *between* batches, so a recv
+        parked on a departed peer would otherwise hold the join for the full
+        first-transfer budget rather than the join timeout.
+        """
+        if self._comm_cache is not None:
+            try:
+                self._comm_cache.abort_all()
+            except Exception as e:  # pragma: no cover - teardown best-effort
+                logger.warning("[NCCLTransportStrategy] comm abort failed: %s", e)
+
+    def shutdown(self) -> None:
+        """Log the run summary and release the transport.
+
+        Does NOT abort here: ``shutdown_prefetch`` already ran
+        :meth:`before_join` (it defaults to the attached strategy) before the
+        join, which is the ordering that lets a parked recv fail fast.
+        Aborting again would just double-abort every cached comm.
+        """
+        if self._steps > 0:
+            avg_ms = self._total_latency_ms / self._steps
+            logger.info(
+                "[NCCLTransportStrategy] Final: %d iters, %d NCCL / %d fallback, "
+                "%.1f MB, avg %.0f ms/iter",
+                self._steps,
+                self._total_nccl,
+                self._total_fallback,
+                self._total_bytes / 1e6,
+                avg_ms,
+            )
+        logger.info("[NCCLTransportStrategy] Shut down")
+
+    # ------------------------------------------------------------------
+    # PrefetchDataPackerMixin hook implementations
+    # ------------------------------------------------------------------
+
+    def should_intercept(self, rollout_output: Any) -> bool:
+        """NCCL wire-format predicate (string completion or dict ref)."""
+        if isinstance(rollout_output, str):
+            return rollout_output.startswith(NCCL_COMPLETION_PREFIX)
+        if isinstance(rollout_output, dict):
+            return bool(rollout_output.get("_nccl"))
+        return False
+
+    def cache_key(self, rollout_output: Any) -> str:
+        return self._ref_cache_key(rollout_output)
+
+    def fetch_batch(self, tasks: List[Any]) -> Dict[str, Any]:
+        """Resolve a batch of NCCL references via rendezvous + standalone per-pair recvs."""
+        refs: List[Tuple[Any, dict]] = []
+        for idx, ro in tasks:
+            ref = _parse_ref(ro, default_schema=self._schema)
+            if ref is not None:
+                refs.append((idx, ref))
+
+        results, total_bytes, transfer_ms = self._fetch_all(refs)
+
+        cache_results: Dict[str, Any] = {}
+        for idx, gpu_data in results.items():
+            key = _cache_key_from_task(tasks, idx)
+            cache_results[key] = gpu_data
+
+        self._last_bytes = total_bytes
+        self._last_count = len(results)
+        if results:
+            logger.debug(
+                "[Trace] thread=nccl_prefetch op=nccl_fetch transfer_ms=%.1f "
+                "count=%d bytes=%d",
+                transfer_ms,
+                len(results),
+                total_bytes,
+            )
+        return cache_results
+
+    def sync_fetch(self, rollout_output: Any) -> Optional[Dict[str, torch.Tensor]]:
+        """Blocking single-episode NCCL fetch (cache-miss fallback).
+
+        Returns ``None`` on any failure rather than propagating: the base
+        mixin calls this on the cache-miss path inside ``get_policy_input``
+        without its own containment, so a raised rendezvous/recv error would
+        crash the training step instead of degrading to the packer's fallback.
+        Mirrors the UCXX consumer's sync-fallback contract.
+        """
+        try:
+            # Parse inside the guard too: a malformed dict ref (e.g. a corrupt
+            # ``_schema``) raises from deserialize_schema, and this path has no
+            # containment above it in the base get_policy_input.
+            ref = _parse_ref(rollout_output, default_schema=self._schema)
+            if ref is None:
+                return None
+            results, _, _ = self._fetch_all([(0, ref)])
+        except Exception as e:
+            logger.warning("[NCCLTransportStrategy] Sync fallback failed: %s", e)
+            return None
+        return results.get(0)
+
+    def on_prefetch_complete(
+        self, batch_id: int, n_results: int, fetch_ms: float, step: int
+    ) -> None:
+        # These are the batch's own figures, set by fetch_batch. Do NOT fall
+        # back to n_results: the base passes len(self._prefetch_cache), i.e.
+        # the whole double-buffered cache, which over-counts every step.
+        self._total_nccl += self._last_count
+        self._total_bytes += self._last_bytes
+        self._total_latency_ms += fetch_ms
+        self._steps = step
+        if step == 1 or step % _LOG_INTERVAL == 0:
+            avg_ms = self._total_latency_ms / step
+            logger.info(
+                "[NCCLTransportStrategy] Iteration %d: %d NCCL, %.1f MB total, "
+                "avg %.0f ms/iter",
+                step,
+                self._total_nccl,
+                self._total_bytes / 1e6,
+                avg_ms,
+            )
+
+    def on_resolve_failed(self, rollout_output: Any, cache_key: str) -> None:
+        self._total_fallback += 1
+
+    # get_policy_input is inherited unchanged from PrefetchDataPackerMixin.
+
+    # ------------------------------------------------------------------
+    # NCCL recv path
+    # ------------------------------------------------------------------
+
+    def _fetch_all(self, refs: List[Tuple[Any, dict]]) -> Tuple[dict, int, float]:
+        """Rendezvous + grouped ``nccl_recv`` for every ref.
+
+        Returns ``(results_by_idx, total_bytes, transfer_ms)``.  Each ref
+        is negotiated over Redis first (so we know which recvs will
+        actually happen and on which comm), then each accepted recv is
+        issued as a STANDALONE ``nccl_recv`` on its own 2-rank pair comm
+        (deliberately NOT wrapped in a cross-communicator
+        ``ncclGroupStart/End``, which would couple independent producers
+        into one completion unit -- the N_POLICY>=2 wedge).  A per-ref
+        ``max_attempts`` fresh-call retry wraps the rendezvous; a ref that
+        still fails to resolve is dropped and re-attempted on the next
+        prefetch round (there is no in-batch multi-round layer above this).
+        """
+        from cosmos_rl.utils import pynccl
+
+        rv = self._rendezvous
+        cache = self._comm_cache
+        device = self._device
+        if rv is None or cache is None:
+            return {}, 0, 0.0
+        # The prefetch worker runs off the main thread; bind it to our GPU so
+        # comm creation + recvs target the right device (thread-local).
+        bind_thread_device(device)
+
+        t0 = get_trace_time()
+        # Declared OUTSIDE the try so the finally can always read it.
+        recvs: List[Tuple[Any, dict, int, torch.Tensor]] = []
+        # Pins taken during phase 1 must be released on EVERY exit path,
+        # including the early returns and any raise below.
+        try:
+            # Phase 1: rendezvous (control plane) — sequential Redis round-trips.
+            for idx, ref in refs:
+                prepared = self._rendezvous_one(ref, pynccl)
+                if prepared is None:
+                    continue
+                comm_idx, recv_buf = prepared
+                recvs.append((idx, ref, comm_idx, recv_buf))
+
+            if not recvs:
+                return {}, 0, get_trace_time() - t0
+
+            # A batch is "warming" until every pair in it has transferred at least
+            # once; give its recvs the long cold-start budget so a slow (storm-
+            # contended) send isn't cancelled -> comm torn down -> rebuilt into the
+            # same storm.
+            receiver_rank = self._receiver_rank
+            warm = self._warm_pairs
+            batch_warming = any(
+                _pair_key(ref, receiver_rank) not in warm for _i, ref, _c, _b in recvs
+            )
+            recv_timeout_ms = int(
+                (self._first_transfer_timeout if batch_warming else self._recv_timeout)
+                * 1000
+            )
+
+            # Phase 2: issue ONE STANDALONE recv per pair communicator -- NOT a
+            # cross-communicator NCCL group.  Each comm is a distinct 2-rank pair
+            # with a single send/recv, so grouping adds no overlap; it only turns
+            # independent producers into one completion unit whose native
+            # ncclGroupEnd blocks -- with NO pynccl watchdog (run_task arms its
+            # deadline only AFTER the native call returns) -- if any producer has
+            # not yet posted its matching send (its send lock is busy serving the
+            # other policy replica).  That coupling was the N_POLICY>=2 residual
+            # wedge.  Ungrouped, a slow/serialized producer only delays its own
+            # recv; the others complete independently.
+            results: Dict[int, dict] = {}
+            total_bytes = 0
+            posted: List[Tuple[Any, dict, int, torch.Tensor]] = []
+            # Serialize the NCCL recv LAUNCH on this consumer's GPU, mirroring the
+            # producer's _nccl_send_lock.  Both the prefetch worker (_fetch_all off the
+            # prefetch thread) and a trainer-thread cache-miss _sync_fetch can reach
+            # here; concurrent multi-comm recv launches on one device deadlock
+            # natively -- and because run_task arms its deadline only AFTER the native
+            # call returns, the recv timeout can't rescue a launch deadlock.  Only the
+            # async ENQUEUE + event record run under the lock (every op is a stream
+            # enqueue); the blocking synchronize() below stays lock-free so real
+            # transfers still overlap across the two callers.
+            recv_lock = self._recv_lock
+            if recv_lock is None:  # bare test harness that skipped setup
+                recv_lock = self._recv_lock = threading.Lock()
+            with recv_lock:
+                stream = self._streams.acquire() if self._streams else None
+                for idx, ref, comm_idx, recv_buf in recvs:
+                    try:
+                        pynccl.nccl_recv(
+                            recv_buf,
+                            SENDER_LOCAL_RANK,  # peer in the 2-rank comm is the sender
+                            comm_idx,
+                            stream=stream,
+                            timeout_ms=recv_timeout_ms,
+                        )
+                    except Exception as exc:
+                        logger.warning(
+                            "[NCCLTransportStrategy] recv failed for %s: %s",
+                            ref["transfer_id"],
+                            exc,
+                        )
+                        # Isolate the failure to this pair (quarantine only if warm).
+                        self._quarantine_recv_failures(
+                            [(idx, ref, comm_idx, recv_buf)], cache
+                        )
+                        continue
+                    posted.append((idx, ref, comm_idx, recv_buf))
+
+                if not posted:
+                    return {}, 0, get_trace_time() - t0
+
+                # Recv-complete event gates downstream training consumption.
+                done = record_event(stream)
+
+            wait_event(None, done)  # current (compute) stream waits before reads
+            if torch.cuda.is_available():
+                try:
+                    torch.cuda.current_stream().synchronize()
+                except Exception as exc:
+                    # A recv that ENQUEUED cleanly but whose peer never sent (dead /
+                    # hung producer) surfaces HERE at completion, not at the enqueue
+                    # try/except above.  Do NOT let it propagate: an uncaught raise
+                    # unwinds _fetch_all -> the prefetch worker marks the WHOLE batch
+                    # failed -> wait_prefetch wipes the cache -> every episode drops to
+                    # fallback AND the offending pair is never quarantined (quarantine
+                    # is only reachable from the enqueue path).  A single stream sync
+                    # can't attribute the failure to one recv, so conservatively
+                    # quarantine every posted (warm) pair and drop just this batch to
+                    # fallback; the dead pair(s) now cool down instead of re-storming.
+                    logger.warning(
+                        "[NCCLTransportStrategy] recv completion sync failed "
+                        "(%d posted pairs): %s; quarantining posted pairs",
+                        len(posted),
+                        exc,
+                    )
+                    self._quarantine_recv_failures(posted, cache)
+                    return {}, 0, get_trace_time() - t0
+
+            for idx, ref, _comm_idx, recv_buf in posted:
+                gpu_data = _unpack(recv_buf, ref["schema"], device)
+                results[idx] = gpu_data
+                total_bytes += recv_buf.numel() * recv_buf.element_size()
+                # First successful transfer -> this pair is warm (tight timeouts +
+                # normal quarantine from here on).
+                warm.add(_pair_key(ref, receiver_rank))
+
+            return results, total_bytes, get_trace_time() - t0
+        finally:
+            # Release the eviction pins taken by _rendezvous_one.  The comm
+            # was leased from build through recv completion (the
+            # synchronize above), so unpinning earlier would reopen the
+            # mid-collective eviction window.
+            receiver_rank = self._receiver_rank
+            for _i, _ref, _c, _b in recvs:
+                cache.unpin(_pair_key(_ref, receiver_rank))
+
+    def _quarantine_endpoint(self, cache: Any, health_key: Any, pair: Any) -> None:
+        """Quarantine a warm endpoint AND demote its pair back to 'warming'.
+
+        Clearing the warm marker (comm-generation recovery) means the
+        post-cooldown rebuild is treated as a cold start: it gets the generous
+        ``first_transfer_timeout`` budget instead of the tight ``recv_timeout``,
+        so the freshly-renegotiated comm isn't immediately re-quarantined by the
+        very short window that caused the original failure.  Pairs with the
+        producer's stale comm-half are also torn down by ``quarantine`` (abort),
+        and the producer rebuilds its half on the next fresh UID.
+        """
+        try:
+            cache.quarantine(health_key)
+        except Exception as exc:  # pragma: no cover - best-effort teardown
+            logger.debug(
+                "[NCCLTransportStrategy] quarantine %s raised %s; continuing",
+                health_key,
+                type(exc).__name__,
+            )
+        if pair is not None:
+            self._warm_pairs.discard(pair)
+
+    def _quarantine_recv_failures(
+        self, recvs: List[Tuple[Any, dict, int, torch.Tensor]], cache: Any
+    ) -> None:
+        """After a recv failure, quarantine only the WARM pairs.
+
+        A warm pair (has transferred before) that fails is a genuine problem ->
+        quarantine + abort its comm (``CommCache.quarantine`` prefix-matches
+        the ``(sender_replica, sender_rank, receiver_rank)`` comm).  A pair that
+        is still WARMING is just storm-contended -> keep its built comm and let
+        it retry next round; tearing it down here is what churned N_POLICY>=2.
+        """
+        receiver_rank = self._receiver_rank
+        warm = self._warm_pairs
+        for _idx, ref, _comm_idx, _buf in recvs:
+            pair = _pair_key(ref, receiver_rank)
+            if pair not in warm:
+                continue  # still warming -> keep the comm, retry
+            self._quarantine_endpoint(
+                cache, (ref["sender_replica"], ref["sender_rank"]), pair
+            )
+
+    def _rendezvous_one(
+        self, ref: dict, pynccl: Any
+    ) -> Optional[Tuple[int, torch.Tensor]]:
+        """Negotiate one transfer; return ``(comm_idx, recv_buf)`` or None.
+
+        Applies the per-ref fresh-call retry and health-aware quarantine.
+        """
+        rv = self._rendezvous
+        cache = self._comm_cache
+        transfer_id = ref["transfer_id"]
+        sender_rank = ref["sender_rank"]
+        sender_replica = ref["sender_replica"]
+        receiver_rank = self._receiver_rank
+        receiver_replica = self._receiver_replica
+        # Pair key + health key are keyed on the globally-unique sender
+        # replica identity so distinct rollout replicas never collide.
+        pair = _pair_key(ref, receiver_rank)
+        health_key = (sender_replica, sender_rank)
+        # "warming" until this pair completes its first successful transfer.
+        warming = pair not in self._warm_pairs
+
+        if cache.is_quarantined(health_key):
+            logger.debug(
+                "[NCCLTransportStrategy] endpoint %s quarantined; skipping %s",
+                health_key,
+                transfer_id,
+            )
+            return None
+
+        request_channel = build_sender_request_channel(self._prefix, ref)
+
+        for attempt in range(1, self._max_attempts + 1):
+            need_uid = pair not in cache
+            # Until the pair is warm, give it the long cold-start budget so the
+            # comm-init storm doesn't cancel a healthy-but-slow transfer; a warm
+            # pair uses the tight steady-state budget.
+            timeout = self._first_transfer_timeout if warming else self._recv_timeout
+            result = rv.initiate(
+                transfer_id=transfer_id,
+                sender_replica=sender_replica,
+                sender_rank=sender_rank,
+                receiver_replica=receiver_replica,
+                receiver_rank=receiver_rank,
+                request_channel=request_channel,
+                need_uid=need_uid,
+                timeout=timeout,
+                attempt=attempt,
+            )
+            if result.status is TransferStatus.ACCEPTED:
+                try:
+                    # PIN the comm: the caller holds this comm_idx until its
+                    # recv completes, so an unpinned entry could be evicted +
+                    # aborted mid-collective by a concurrent build for another
+                    # pair.  _fetch_all releases it in a finally.
+                    comm_idx = cache.get_or_create(
+                        pair,
+                        uid_chars=result.uid_chars or [],
+                        local_rank=RECEIVER_LOCAL_RANK,
+                        pin=True,
+                    )
+                except Exception as e:
+                    logger.warning(
+                        "[NCCLTransportStrategy] comm build failed for %s: %s%s",
+                        transfer_id,
+                        e,
+                        "; retry next round (warming)" if warming else "; quarantining",
+                    )
+                    if not warming:
+                        self._quarantine_endpoint(cache, health_key, pair)
+                    return None
+                try:
+                    recv_buf = _alloc_recv_buffer(ref["schema"], self._device)
+                except Exception:
+                    # Never returned to the caller -> nothing will unpin it here.
+                    cache.unpin(pair)
+                    raise
+                return comm_idx, recv_buf
+            if result.status is TransferStatus.MISSING:
+                # Producer recycled the buffer — non-retryable, drop now.
+                logger.debug(
+                    "[NCCLTransportStrategy] transfer %s missing (recycled)",
+                    transfer_id,
+                )
+                return None
+            if result.status is TransferStatus.NEED_UID:
+                # The sender evicted its side of the comm; our cached comm is
+                # now half-open.  Drop it and retry -- the next attempt has
+                # need_uid=True and mints a fresh uid so BOTH sides rebuild.
+                logger.debug(
+                    "[NCCLTransportStrategy] transfer %s: sender needs a fresh "
+                    "uid; dropping stale comm and renegotiating",
+                    transfer_id,
+                )
+                cache.abort(pair)
+                continue
+            # CANCELLED (timeout).
+            if attempt == self._max_attempts:
+                if not warming:
+                    # A WARM pair (has transferred before) that stops
+                    # rendezvousing -> the sender likely died mid-run;
+                    # quarantine so we stop hammering it (and abort the comm).
+                    logger.warning(
+                        "[NCCLTransportStrategy] transfer %s cancelled after %d "
+                        "attempts on a warm comm; quarantining %s",
+                        transfer_id,
+                        self._max_attempts,
+                        health_key,
+                    )
+                    self._quarantine_endpoint(cache, health_key, pair)
+                else:
+                    # Still warming: the sender is warming up / storm-contended,
+                    # NOT unhealthy.  KEEP any built comm and retry next round
+                    # WITHOUT quarantining -- tearing it down here (and thus
+                    # rebuilding into the same storm) is what churned N_POLICY>=2
+                    # to 0 MB.
+                    logger.debug(
+                        "[NCCLTransportStrategy] transfer %s still warming (%d "
+                        "attempts); keeping comm, retry next round",
+                        transfer_id,
+                        self._max_attempts,
+                    )
+        return None
+
+    # ------------------------------------------------------------------
+    # Cache-key helpers (parity with UCXX; used by tests + _fetch_batch).
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _ref_cache_key(rollout_output: Any) -> str:
+        ref = _parse_ref(rollout_output)
+        if ref is not None:
+            return ref["transfer_id"]
+        return str(rollout_output)
+
+
+# ---------------------------------------------------------------------------
+# Module-level helpers (ref parsing / buffer alloc / unpack)
+# ---------------------------------------------------------------------------
+
+
+def _parse_ref(
+    rollout_output: Any, *, default_schema: Optional[list] = None
+) -> Optional[dict]:
+    """Normalize a completion string or dict metadata into an internal ref.
+
+    Returns a dict with ``transfer_id``, ``sender_rank``, ``rollout_idx``,
+    and ``schema`` (a list of :class:`TensorSpec`), or ``None`` if the
+    input is not an NCCL reference.
+    """
+    if isinstance(rollout_output, str):
+        if not rollout_output.startswith(NCCL_COMPLETION_PREFIX):
+            return None
+        transfer_id = rollout_output[len(NCCL_COMPLETION_PREFIX) :]
+        rollout_idx = parse_transfer_rollout_idx(transfer_id)
+        # Bare "nccl:<id>" string carries no dict metadata, so there is no
+        # globally-unique replica identity -- fall back to the rollout-idx.
+        # (This form is single-node / testing only; the rl-gym producer
+        # returns dict metadata carrying _sender_replica.)
+        return {
+            "transfer_id": transfer_id,
+            "rollout_idx": rollout_idx,
+            "sender_rank": rollout_idx if rollout_idx >= 0 else 0,
+            "sender_replica": f"rollout-{rollout_idx if rollout_idx >= 0 else 0}",
+            "schema": default_schema,
+        }
+    if isinstance(rollout_output, dict) and rollout_output.get("_nccl"):
+        transfer_id = rollout_output.get("_transfer_id", "")
+        rollout_idx = rollout_output.get(
+            "_rollout_idx", parse_transfer_rollout_idx(transfer_id)
+        )
+        schema = default_schema
+        raw_schema = rollout_output.get("_schema")
+        if raw_schema:
+            schema = deserialize_schema(raw_schema)
+        sender_rank = rollout_output.get(
+            "_sender_rank", rollout_idx if rollout_idx >= 0 else 0
+        )
+        # Globally-unique sender identity: the producer's replica id/name.
+        # Falls back to the rollout-idx form only if the producer omitted it.
+        sender_replica = rollout_output.get("_sender_replica") or (
+            f"rollout-{rollout_idx if rollout_idx >= 0 else 0}"
+        )
+        return {
+            "transfer_id": transfer_id,
+            "rollout_idx": rollout_idx,
+            "sender_rank": sender_rank,
+            "sender_replica": sender_replica,
+            "schema": schema,
+        }
+    return None
+
+
+def _pair_key(ref: dict, receiver_rank: int):
+    """Globally-unique comm-cache pair key for a transfer.
+
+    ``(sender_replica, sender_rank, receiver_rank)`` -- keyed on the
+    rollout replica's globally-unique identity so two replicas sharing a
+    per-replica ``sender_rank`` (e.g. both 0) map to DISTINCT communicators.
+    """
+    return (ref["sender_replica"], ref["sender_rank"], receiver_rank)
+
+
+def _cache_key_from_task(tasks: List[Any], idx: int) -> str:
+    for task_idx, ro in tasks:
+        if task_idx == idx:
+            return NCCLTransportStrategy._ref_cache_key(ro)
+    return str(idx)
+
+
+def _alloc_recv_buffer(schema: Optional[list], device: Any) -> torch.Tensor:
+    """Allocate a flat uint8 GPU buffer sized for ``schema``."""
+    if schema is None:
+        raise ValueError("cannot allocate NCCL recv buffer without a schema")
+    _, entry_size = schema_layout(schema)
+    return torch.empty(entry_size, dtype=torch.uint8, device=device)
+
+
+def _unpack(recv_buf: torch.Tensor, schema: Optional[list], device: Any) -> dict:
+    """Slice a flat recv buffer back into the named schema tensors."""
+    if schema is None:
+        return {}
+    offsets, _ = schema_layout(schema)
+    out: Dict[str, Any] = {}
+    for spec in schema:
+        td = _NP_TO_TORCH.get(np.dtype(spec.dtype))
+        if td is None:
+            raise ValueError(f"unsupported dtype {spec.dtype} for '{spec.name}'")
+        off = offsets[spec.name]
+        # Clone the byte slice BEFORE reinterpreting: a sub-tensor whose
+        # storage_offset is not a multiple of the target itemsize (e.g. the
+        # int64 episode_length landing at byte 300) cannot be ``view``-ed to
+        # the wider dtype.  Cloning yields fresh storage at offset 0, which
+        # is always aligned.  (Same reason UCXX clones before its view.)
+        raw = recv_buf[off : off + spec.nbytes].clone()
+        out[spec.name] = raw.view(td).reshape(spec.shape)
+    _truncate_to_episode_len(out)
+    return out
+
+
+def _truncate_to_episode_len(data: dict) -> None:
+    ep = data.get(EPISODE_LENGTH)
+    if ep is None:
+        return
+    try:
+        ep_len = int(ep.item()) if ep.numel() == 1 else int(ep[0].item())
+    except Exception:
+        return
+    for key in _VARLEN_FIELDS:
+        if key in data and data[key].shape[0] > ep_len:
+            data[key] = data[key][:ep_len]
+
+
+def _resolve_schema_dims(config: Any) -> dict:
+    custom = getattr(config, "custom", None) or {}
+
+    def _get(key, default):
+        try:
+            return int(custom.get(key, default))
+        except (TypeError, ValueError):
+            return default
+
+    return {
+        "max_steps": _get("nccl_max_steps", 100),
+        "obs_dim": _get("nccl_obs_dim", 4),
+        "action_dim": _get("nccl_action_dim", 2),
+    }
+
+
+def compose_nccl_transport(
+    packer: Any,
+    *,
+    device: Any,
+    redis_client: Any,
+    config: Any = None,
+    prefetch_timeout: float = 30.0,
+    max_attempts: int = 2,
+    recv_timeout: float = 5.0,
+    first_transfer_timeout: float = 30.0,
+) -> None:
+    """Attach a fresh NCCL strategy to ``packer`` and start its prefetch worker.
+
+    The one place that wiring lives, so the mixin and the composed attach path
+    cannot drift: ``NCCLDataPackerMixin._setup_nccl_data_packer`` is a call to
+    this, and ``NcclPayloadTransport`` uses it for packers that compose rather
+    than subclass.
+
+    ``packer`` need only provide ``set_transport_strategy`` and
+    ``_setup_prefetch`` -- i.e. be a ``PrefetchDataPackerMixin``; no NCCL
+    ancestry is required.
+    """
+    strategy = NCCLTransportStrategy()
+    strategy.setup(
+        device=device,
+        redis_client=redis_client,
+        config=config,
+        max_attempts=max_attempts,
+        recv_timeout=recv_timeout,
+        first_transfer_timeout=first_transfer_timeout,
+        # Set by _attach_payload_transport before setup to disambiguate policy
+        # replicas sharing a receiver_rank; absent on standalone/test packers.
+        receiver_replica=getattr(packer, "_nccl_dp_receiver_replica", None),
+    )
+    packer.set_transport_strategy(strategy)
+    packer._setup_prefetch(
+        prefetch_timeout=prefetch_timeout,
+        thread_name="NCCLDataPackerPrefetch",
+    )

--- a/cosmos_rl/utils/payload_transport/nccl/transport.py
+++ b/cosmos_rl/utils/payload_transport/nccl/transport.py
@@ -64,6 +64,8 @@ as a deprecated alias.
 
 from __future__ import annotations
 
+import functools
+
 import json
 import os
 import time
@@ -167,7 +169,12 @@ class NcclPayloadTransport(PayloadTransport):
              must wait out the cold-start comm-init storm; floored at
              ``nccl_recv_timeout``.
 
-        2. **Legacy fallback** (deprecated).  Packers exposing a
+        2. **Composed** -- a packer that only schedules (exposes
+           ``set_transport_strategy``) gets a strategy built and attached,
+           which is how a transport can be chosen from config without
+           subclassing a per-transport packer class.
+
+        3. **Legacy fallback** (deprecated).  Packers exposing a
            ``redis_client`` attribute get a live client assigned followed
            by an optional ``post_redis_injection()`` call, in that order
            (PR #670 contract).  Superseded by the mixin path; retained
@@ -176,6 +183,19 @@ class NcclPayloadTransport(PayloadTransport):
         No-op for packers that expose neither surface.
         """
         setup = getattr(packer, "_setup_nccl_data_packer", None)
+        if not callable(setup) and callable(
+            getattr(packer, "set_transport_strategy", None)
+        ):
+            # Composed packer: it schedules (PrefetchDataPackerMixin) but has no
+            # NCCL ancestry, so synthesise the same setup signature the mixin
+            # exposes.  Reusing _attach_via_mixin verbatim is deliberate -- the
+            # tunable resolution below it (cold-start floors, batch hint) is
+            # subtle enough that a second copy would drift.
+            from cosmos_rl.utils.payload_transport.nccl.strategy import (
+                compose_nccl_transport,
+            )
+
+            setup = functools.partial(compose_nccl_transport, packer)
         if callable(setup):
             self._attach_via_mixin(
                 setup, config=config, device=device, redis_endpoint=redis_endpoint

--- a/cosmos_rl/utils/payload_transport/prefetch_mixin.py
+++ b/cosmos_rl/utils/payload_transport/prefetch_mixin.py
@@ -83,6 +83,7 @@ import threading
 from typing import Any, Callable, Dict, List, Optional
 
 from cosmos_rl.utils.logging import logger
+from cosmos_rl.utils.payload_transport.strategy import PayloadTransportStrategy
 from cosmos_rl.utils.trace import get_trace_time
 
 
@@ -93,12 +94,26 @@ class PrefetchDataPackerMixin:
     """Transport-agnostic prefetch + double-buffer + early-ack scheduler.
 
     See module docstring for the subclass-hook contract.
+
+    Transport behaviour arrives one of two ways:
+
+    * **Composed** -- attach a :class:`PayloadTransportStrategy` via
+      :meth:`set_transport_strategy`.  The hooks below then delegate to it,
+      which lets the transport be chosen from config at runtime.
+    * **Subclassed** -- override the ``_``-prefixed hooks directly, the
+      original contract.  Still fully supported.
+
+    They are alternatives, not layers.  An override *replaces* the delegating
+    implementation, so a subclass that overrides a hook wins for that hook even
+    if a strategy is also attached; mixing the two on the same hook is
+    therefore legal but almost never what you want.
     """
 
     # ------------------------------------------------------------------
     # Scheduling state (owned by the base; subclasses should not touch
     # these directly -- use the public API or override the hooks).
     # ------------------------------------------------------------------
+    _transport_strategy: Optional[PayloadTransportStrategy] = None
     _prefetch_enabled: bool = False
     _prefetch_request_queue: Optional[queue.Queue] = None
     _prefetch_result_queue: Optional[queue.Queue] = None
@@ -198,10 +213,16 @@ class PrefetchDataPackerMixin:
                 once ``before_join`` has unblocked in-flight I/O.
             before_join: Optional transport teardown invoked between setting
                 the shutdown event and joining.  Exceptions are logged and
-                swallowed -- teardown proceeds regardless.
+                swallowed -- teardown proceeds regardless.  Defaults to the
+                attached strategy's ``before_join``, so a composed transport
+                unwedges its own I/O without the caller arranging it; pass an
+                explicit callable to override.
         """
         if self._prefetch_shutdown is not None:
             self._prefetch_shutdown.set()
+
+        if before_join is None and self._transport_strategy is not None:
+            before_join = self._transport_strategy.before_join
 
         if before_join is not None:
             try:
@@ -231,18 +252,38 @@ class PrefetchDataPackerMixin:
     # Subclass hooks (override in transport-specific mixin)
     # ------------------------------------------------------------------
 
+    def set_transport_strategy(
+        self, strategy: Optional[PayloadTransportStrategy]
+    ) -> None:
+        """Compose in a transport, replacing any previously attached one.
+
+        Call before :meth:`_setup_prefetch`: the strategy decides what the
+        worker fetches, and swapping it under a running worker would leave
+        already-queued tasks being resolved by the outgoing transport.  Pass
+        ``None`` to detach (the hooks fall back to their pass-through defaults).
+        """
+        self._transport_strategy = strategy
+
     def _should_intercept(self, rollout_output: Any) -> bool:
         """Return True if ``rollout_output`` is a transport reference.
 
-        Default: never intercept (the mixin becomes a no-op pass-through).
+        Delegates to the attached strategy; without one, never intercepts (the
+        mixin becomes a no-op pass-through).
         """
+        strategy = self._transport_strategy
+        if strategy is not None:
+            return strategy.should_intercept(rollout_output)
         return False
 
     def _cache_key(self, rollout_output: Any) -> str:
         """Stable string key for the resolved payload of ``rollout_output``.
 
-        Subclasses must override when ``_should_intercept`` can return True.
+        Delegates to the attached strategy.  Subclasses must override this when
+        they implement ``_should_intercept`` themselves.
         """
+        strategy = self._transport_strategy
+        if strategy is not None:
+            return strategy.cache_key(rollout_output)
         raise NotImplementedError(
             "Subclass must override _cache_key when _should_intercept may return True"
         )
@@ -256,6 +297,9 @@ class PrefetchDataPackerMixin:
         layer and just propagates back to ``_fetch_batch`` so subclass
         implementations can correlate batch indices with sources.
         """
+        strategy = self._transport_strategy
+        if strategy is not None:
+            return strategy.filter_prefetch_tasks(rollouts)
         tasks: List[Any] = []
         for i, rollout in enumerate(rollouts):
             ro = rollout.completion if hasattr(rollout, "completion") else rollout
@@ -266,8 +310,12 @@ class PrefetchDataPackerMixin:
     def _fetch_batch(self, tasks: List[Any]) -> Dict[str, Any]:
         """Fetch a batch of references; return ``{cache_key: payload}``.
 
-        Runs on the background prefetch thread.  Subclasses must implement.
+        Runs on the background prefetch thread.  Delegates to the attached
+        strategy; subclasses without one must implement it.
         """
+        strategy = self._transport_strategy
+        if strategy is not None:
+            return strategy.fetch_batch(tasks)
         raise NotImplementedError(
             "Subclass must implement _fetch_batch to provide the actual "
             "transport-specific fetch logic"
@@ -280,6 +328,9 @@ class PrefetchDataPackerMixin:
         skip the episode).  Subclasses may override to provide a
         synchronous transport fetch for the not-yet-prefetched case.
         """
+        strategy = self._transport_strategy
+        if strategy is not None:
+            return strategy.sync_fetch(rollout_output)
         return None
 
     def _on_prefetch_complete(
@@ -291,8 +342,15 @@ class PrefetchDataPackerMixin:
         """Hook called after each ``wait_prefetch`` populates the cache.
 
         Default: no-op.  Subclasses can use this to emit periodic INFO
-        summaries, increment cumulative counters, etc.
+        summaries, increment cumulative counters, etc.  The strategy form also
+        receives the iteration counter, which it would otherwise have to read
+        off the packer.
         """
+        strategy = self._transport_strategy
+        if strategy is not None:
+            return strategy.on_prefetch_complete(
+                batch_id, n_results, fetch_ms, self._prefetch_step_count
+            )
         return None
 
     def _on_resolve_failed(self, rollout_output: Any, cache_key: str) -> None:
@@ -304,6 +362,9 @@ class PrefetchDataPackerMixin:
         emit transport-specific telemetry without having to override
         the entire dispatch.
         """
+        strategy = self._transport_strategy
+        if strategy is not None:
+            return strategy.on_resolve_failed(rollout_output, cache_key)
         return None
 
     # ------------------------------------------------------------------

--- a/cosmos_rl/utils/payload_transport/registry.py
+++ b/cosmos_rl/utils/payload_transport/registry.py
@@ -18,9 +18,21 @@
 from __future__ import annotations
 
 from abc import ABC
-from typing import Any, Dict, Iterable, List, NamedTuple, Optional, Type
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Dict,
+    Iterable,
+    List,
+    NamedTuple,
+    Optional,
+    Type,
+)
 
 from cosmos_rl.utils.logging import logger
+
+if TYPE_CHECKING:  # pragma: no cover - typing only, avoids an import cycle
+    from cosmos_rl.utils.payload_transport.strategy import PayloadTransportStrategy
 
 
 # Canonical TOML keys read from the experiment ``[custom]`` section.
@@ -511,6 +523,41 @@ def _maybe_autoload_backend(name: str) -> None:
             )
 
 
+def make_transport_strategy(config: Any) -> Optional["PayloadTransportStrategy"]:
+    """Build the transport strategy this config selects, or None for redis.
+
+    The point of the strategy seam: a consumer composes a transport from config
+    instead of picking a packer *class* per transport at import time.
+
+    Returns None for the default ``redis`` mode, which moves payloads through
+    the control plane and needs no strategy at all -- so ``None`` means "no
+    interception", exactly what an unattached packer already does.
+
+    The guard runs first, for the same reason ``CommMixin`` calls it outside
+    its attach try/except: ``nccl`` and ``ucxx`` each deliver a payload to
+    exactly one receiver, and a topology that violates that must fail loudly
+    here rather than be discovered as a hang mid-run.
+
+    Imports are deferred so this module stays importable where a backend's
+    optional dependency is missing -- ``ucxx`` in particular is an extra.
+    """
+    mode = get_payload_transfer_mode(config)
+    if mode not in P2P_TRANSFER_MODES:
+        return None
+    validate_single_receiver_topology(config, mode)
+
+    if mode == "nccl":
+        from cosmos_rl.utils.payload_transport.nccl.strategy import (
+            NCCLTransportStrategy,
+        )
+
+        return NCCLTransportStrategy()
+
+    from cosmos_rl.utils.payload_transport.ucxx.strategy import UCXXTransportStrategy
+
+    return UCXXTransportStrategy()
+
+
 __all__ = [
     "DEFAULT_TRANSFER_MODE",
     "LEGACY_NCCL_KEY",
@@ -521,5 +568,6 @@ __all__ = [
     "RedisEndpoint",
     "get_payload_transfer_mode",
     "is_payload_transfer_mode_explicit",
+    "make_transport_strategy",
     "validate_single_receiver_topology",
 ]

--- a/cosmos_rl/utils/payload_transport/strategy.py
+++ b/cosmos_rl/utils/payload_transport/strategy.py
@@ -1,0 +1,170 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Transport behaviour as a composed object rather than a subclass mixin.
+
+``PrefetchDataPackerMixin`` owns *scheduling* -- the background worker, the
+double-buffered cache, the early-ack handshake -- and delegates every
+*transport-specific* decision to six hooks.  Historically those hooks were
+supplied by mixing a transport class into the packer, which forces the choice
+to compile time: a consumer must pick ``NCCLSimpleRLDataPacker`` or
+``UCXXSimpleRLDataPacker`` before it has read any config.
+
+This module turns that same six-hook contract into an object the packer
+*holds*, so the transport can be chosen from config at runtime like every other
+knob.  The hook set is identical in shape to the mixin's, deliberately: the two
+paths are the same contract expressed two ways, and the mixin path stays
+supported (see :class:`PrefetchDataPackerMixin` for how the two interact).
+
+Naming drops the leading underscore -- these are the strategy's public API,
+whereas the mixin's ``_``-prefixed methods are protected members of the packer.
+"""
+
+from abc import ABC, abstractmethod
+from typing import Any, Dict, List, Optional
+
+__all__ = ["PayloadTransportStrategy"]
+
+
+class PayloadTransportStrategy(ABC):
+    """The transport-shaped half of a prefetching data packer.
+
+    Implementations own everything about moving a payload -- connections,
+    buffers, rendezvous, telemetry -- and nothing about *when* it happens.
+
+    Lifetime is ``setup()`` -> many fetches -> ``shutdown()``.  The scheduling
+    layer calls :meth:`fetch_batch` on a background thread and everything else
+    on the caller's thread, so implementations must make any state shared
+    between the two safe (the two shipped strategies keep their counters
+    single-writer for this reason).
+    """
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    def setup(self, **kwargs: Any) -> None:
+        """Acquire connections/buffers.  Keyword-only; transports differ wildly.
+
+        NCCL needs a redis client, a comm cache, rendezvous state and CUDA
+        streams; UCXX needs only a client.  Rather than invent a lowest common
+        denominator, each implementation documents its own keywords.
+        """
+        return None
+
+    def shutdown(self) -> None:
+        """Release everything acquired by :meth:`setup`.  Must be idempotent."""
+        return None
+
+    def before_join(self) -> None:
+        """Force in-flight I/O to fail fast, called during teardown.
+
+        The scheduling layer sets its shutdown event, calls this, and only then
+        joins the worker.  A worker parked inside :meth:`fetch_batch` observes
+        the event only *between* batches, so without this the join would wait
+        out a transfer that only the transport can unwedge -- NCCL aborts its
+        comms here, UCXX closes its client.  Default: nothing to unwedge.
+        """
+        return None
+
+    # ------------------------------------------------------------------
+    # Wire-format recognition
+    # ------------------------------------------------------------------
+
+    @abstractmethod
+    def should_intercept(self, rollout_output: Any) -> bool:
+        """Return True if ``rollout_output`` is a reference this transport owns.
+
+        Must be cheap and total: it runs on every rollout, including payloads
+        belonging to other transports, and must not raise on shapes it does not
+        recognise.
+        """
+
+    @abstractmethod
+    def cache_key(self, rollout_output: Any) -> str:
+        """Stable key for the payload behind ``rollout_output``.
+
+        Only called where :meth:`should_intercept` returned True.  Must agree
+        with the keys :meth:`fetch_batch` returns, or every fetch reports a
+        cache miss and silently degrades to :meth:`sync_fetch`.
+        """
+
+    def filter_prefetch_tasks(self, rollouts: List[Any]) -> List[Any]:
+        """Pick the prefetchable subset of a batch as ``(idx, ref)`` pairs.
+
+        ``idx`` is opaque to the scheduling layer and simply propagates to
+        :meth:`fetch_batch` so implementations can correlate results with their
+        source slot.  The default -- everything :meth:`should_intercept`
+        accepts -- is what both shipped transports want; overriding it to
+        anything narrower means the excluded rollouts take the synchronous
+        path on every step, which is a permanent slowdown rather than a
+        one-time cost.
+        """
+        tasks: List[Any] = []
+        for i, rollout in enumerate(rollouts):
+            ro = rollout.completion if hasattr(rollout, "completion") else rollout
+            if self.should_intercept(ro):
+                tasks.append((i, ro))
+        return tasks
+
+    # ------------------------------------------------------------------
+    # Fetching
+    # ------------------------------------------------------------------
+
+    @abstractmethod
+    def fetch_batch(self, tasks: List[Any]) -> Dict[str, Any]:
+        """Resolve ``tasks`` in bulk; return ``{cache_key: payload}``.
+
+        Runs on the background prefetch thread.  Raising is permitted and is
+        how :meth:`before_join` unblocks teardown; the scheduling layer
+        contains the exception and the batch resolves as misses.
+        """
+
+    def sync_fetch(self, rollout_output: Any) -> Optional[Any]:
+        """Blocking single-reference fallback used on a cache miss.
+
+        Returning ``None`` makes the packer skip that episode, which is the
+        safe default.  Implementations must not raise: this runs inside
+        ``get_policy_input`` with no containment above it, so an escaping
+        rendezvous error would abort the training step rather than degrade to
+        the packer's fallback.
+        """
+        return None
+
+    # ------------------------------------------------------------------
+    # Telemetry
+    # ------------------------------------------------------------------
+
+    def on_prefetch_complete(
+        self,
+        batch_id: int,
+        n_results: int,
+        fetch_ms: float,
+        step: int,
+    ) -> None:
+        """Called after each completed prefetch populates the cache.
+
+        ``step`` is the scheduling layer's iteration counter, passed in rather
+        than read off the packer so implementations stay independent of it.
+        """
+        return None
+
+    def on_resolve_failed(self, rollout_output: Any, cache_key: str) -> None:
+        """Called when both the cache and :meth:`sync_fetch` came up empty.
+
+        The scheduling layer already logs a warning; this exists for
+        transport-specific counters.
+        """
+        return None

--- a/cosmos_rl/utils/payload_transport/ucxx/data_packer_mixin.py
+++ b/cosmos_rl/utils/payload_transport/ucxx/data_packer_mixin.py
@@ -12,132 +12,38 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+"""UCXX consumer packer: scheduling from the base mixin, transport from a strategy.
 
-"""UCXXDataPackerMixin -- UCXX-specific subclass of PrefetchDataPackerMixin.
-
-This file is intentionally **thin**: the prefetch + double-buffer +
-early-train-ack scheduling is owned by
-:class:`cosmos_rl.utils.payload_transport.prefetch_mixin.PrefetchDataPackerMixin`,
-and this subclass plugs in the UCXX-specific bits:
-
-* the wire-format predicate (``_should_intercept``: dict with
-  ``_ucxx: True``)
-* the cache key (``_cache_key``: ``"ip:port:slot"``)
-* the actual zero-copy fetch (``_fetch_batch`` -> async UCXXClient.read
-  with single-chunk-per-slot transfers, port rotation on transient
-  transport errors, and multi-round retry)
-* a sync-fallback fetch for cache misses
-* a periodic INFO summary of UCXX bytes / latency
-
-A future ``NCCLDataPackerMixin`` will subclass the same base and plug in
-its own predicates / cache keys / recv path -- they will share *all* of
-the scheduling code.
-
-Usage::
-
-    class UCXXMyDataPacker(UCXXDataPackerMixin, MyDataPacker):
-        pass
-
-MRO ensures :meth:`PrefetchDataPackerMixin.get_policy_input` (inherited)
-intercepts before delegating to ``MyDataPacker``.
+Kept as a mixin because that is the contract ``attach_data_packer`` dispatches
+on, and because downstream code subclasses it.  The UCXX logic itself now lives
+in :class:`UCXXTransportStrategy`, which this class composes -- so the same
+transport is reachable without subclassing anything.
 """
 
 from __future__ import annotations
 
-import asyncio
-from typing import Any, Dict, List, Optional
-
-import numpy as np
-import torch
+from typing import Any, Dict, Optional
 
 from cosmos_rl.utils.logging import logger
-from cosmos_rl.utils.trajectory import EPISODE_LENGTH, VARLEN_FIELDS
-from cosmos_rl.utils.payload_transport.prefetch_mixin import (
-    PrefetchDataPackerMixin,
-    get_trace_time,
-)
-from cosmos_rl.utils.payload_transport.ucxx.ucxx_buffer import (
-    UCXX_AVAILABLE,
-    UCXXClient,
+from cosmos_rl.utils.payload_transport.prefetch_mixin import PrefetchDataPackerMixin
+from cosmos_rl.utils.payload_transport.ucxx.strategy import (
+    UCXXTransportStrategy,
+    compose_ucxx_transport,
 )
 
-
-# Errors that are worth retrying at the data-packer layer.  Mirrors
-# the rotation set in :data:`ucxx_buffer._PORT_ROTATABLE_ERRORS` --
-# transport-class failures on a specific server thread can succeed on
-# the next attempt because :class:`UCXXClient` will rotate to a
-# different (worker_ip, port) endpoint internally.
-#
-# Deliberately excluded:
-#   * ``StaleSlotError`` -- the slot has been overwritten on the
-#     producer side; no amount of retrying brings it back.  The
-#     :class:`PrefetchDataPackerMixin` upper layer drops the episode
-#     via ``_on_resolve_failed`` on the very first attempt.
-_TRANSIENT_UCXX_ERRORS = frozenset(
-    {
-        "UCXXCanceledError",
-        "UCXXConnectionResetError",
-        "UCXXCloseError",
-        "TimeoutError",
-    }
-)
-
-_MAX_FETCH_ROUNDS = 3
-
-
-_LOG_INTERVAL = 50
-
-
-# Numpy → torch dtype map for the bulk pinned-buffer copy in
-# ``_to_gpu``.  Defined at module scope so it is built once at import
-# time rather than on every fetch.
-_NP_TO_TORCH = {
-    np.dtype("float32"): torch.float32,
-    np.dtype("float64"): torch.float64,
-    np.dtype("float16"): torch.float16,
-    np.dtype("int64"): torch.int64,
-    np.dtype("int32"): torch.int32,
-    np.dtype("int16"): torch.int16,
-    np.dtype("int8"): torch.int8,
-    np.dtype("uint8"): torch.uint8,
-    np.dtype("bool"): torch.bool,
-}
+__all__ = ["UCXXDataPackerMixin"]
 
 
 class UCXXDataPackerMixin(PrefetchDataPackerMixin):
-    """UCXX subclass of :class:`PrefetchDataPackerMixin`.
+    """Mix into a DataPacker to resolve UCXX payload references.
 
-    See :mod:`cosmos_rl.utils.payload_transport.prefetch_mixin` for the
-    transport-agnostic scheduling layer.  Place **before** the concrete
-    DataPacker in the MRO::
-
-        class UCXXSimpleRLDataPacker(UCXXDataPackerMixin, SimpleRLDataPacker):
-            pass
+    Thin by design: it owns the wiring, while every transport decision belongs
+    to :class:`UCXXTransportStrategy`.
     """
 
-    # UCXX-specific state.  Scheduling state (queues, thread, cache,
-    # double-buffer, step counter) is owned by the base mixin and must
-    # not be duplicated here.
-    _ucxx_dp_client: Optional[UCXXClient] = None
-    _ucxx_dp_device: Optional[torch.device] = None
-    _ucxx_dp_max_attempts: int = 2
-    _ucxx_dp_read_timeout: float = 30.0
-
-    # Cumulative stats for periodic INFO summaries (UCXX-specific so the
-    # base mixin's _on_prefetch_complete hook is the right place).
-    _ucxx_dp_total_ucxx: int = 0
-    _ucxx_dp_total_fallback: int = 0
-    _ucxx_dp_total_bytes: int = 0
-    _ucxx_dp_total_latency_ms: float = 0.0
-
-    # Captured by _fetch_batch each round, consumed in _on_prefetch_complete.
-    _ucxx_dp_last_bytes: int = 0
-
     # ------------------------------------------------------------------
-    # Backward-compat aliases for downstream / test code that referenced
-    # the old UCXX-prefixed internals.  Keep at least until the
-    # _setup_ucxx_data_packer -> _setup_prefetch migration is fully
-    # rolled out (>= two minor releases after MR5 lands).
+    # Backward-compat aliases so shared test / observability code can read
+    # state via the transport-prefixed name.
     # ------------------------------------------------------------------
 
     @property
@@ -168,74 +74,65 @@ class UCXXDataPackerMixin(PrefetchDataPackerMixin):
     # Setup / teardown
     # ------------------------------------------------------------------
 
+    @property
+    def _ucxx_dp_strategy(self) -> Optional[UCXXTransportStrategy]:
+        """The composed transport, or None before setup."""
+        return self._transport_strategy
+
+    @property
+    def _ucxx_dp_client(self) -> Any:
+        strategy = self._transport_strategy
+        return None if strategy is None else strategy._client
+
+    @property
+    def _ucxx_dp_read_timeout(self) -> float:
+        strategy = self._transport_strategy
+        return 30.0 if strategy is None else strategy.read_timeout
+
+    # ------------------------------------------------------------------
+    # Setup / teardown
+    # ------------------------------------------------------------------
+
     def _setup_ucxx_data_packer(
         self,
         *,
-        device: torch.device,
+        device: Any,
         prefetch_timeout: float = 300.0,
         max_attempts: int = 2,
         read_timeout: float = 30.0,
     ) -> None:
-        """Initialise UCXX client + start the (inherited) prefetch thread.
+        """Build the UCXX strategy, attach it, and start the prefetch thread.
 
-        NOTE: Normally invoked **automatically** by
-        :meth:`UCXXPayloadTransport.attach_data_packer` during
-        ``CommMixin.init_data_packer``.  Direct calls are only needed
-        in tests or unusual lifecycle setups.
-
-        The leading underscore signals "framework-internal" -- the
-        attach hook is the public surface.  A backward-compatible alias
-        ``setup_ucxx_data_packer`` is preserved below for in-flight
-        downstream code that calls the original public name.
+        Normally invoked by ``UCXXPayloadTransport.attach_data_packer``; direct
+        calls are only needed in tests or unusual lifecycle setups.
 
         Args:
             device: Target GPU device for fetched tensors.
-            prefetch_timeout: Per-batch wait ceiling (seconds) for the
-                prefetch worker thread's result queue.
+            prefetch_timeout: Per-batch wait ceiling (seconds).  A scheduling
+                knob, so it stops here rather than reaching the transport.
             max_attempts: Total attempts per remote slot read (initial +
-                retries on transient UCX errors).  Defaults to 2.
-            read_timeout: Per-await timeout (seconds) inside one
-                ``UCXXClient.read`` call -- bounds a single ``send`` /
-                ``recv`` operation, distinct from ``prefetch_timeout``.
+                retries on transient UCX errors).
+            read_timeout: Per-await timeout inside one ``UCXXClient.read``.
         """
-        if not UCXX_AVAILABLE:
-            raise RuntimeError(
-                "UCXX is required for UCXXDataPackerMixin. "
-                "Install with: pip install ucxx-cu12"
-            )
-
-        self._ucxx_dp_device = device
-        self._ucxx_dp_max_attempts = max(1, max_attempts)
-        self._ucxx_dp_read_timeout = read_timeout
-        self._ucxx_dp_client = UCXXClient()
-
-        self._setup_prefetch(
+        compose_ucxx_transport(
+            self,
+            device=device,
             prefetch_timeout=prefetch_timeout,
-            thread_name="UCXXDataPackerPrefetch",
-        )
-
-        logger.info(
-            "[UCXXDataPackerMixin] Initialised: device=%s, timeout=%ss, "
-            "max_attempts=%d, read_timeout=%ss",
-            device,
-            prefetch_timeout,
-            self._ucxx_dp_max_attempts,
-            read_timeout,
+            max_attempts=max_attempts,
+            read_timeout=read_timeout,
         )
 
     def setup_ucxx_data_packer(
         self,
-        device: torch.device,
+        device: Any,
         prefetch_timeout: float = 300.0,
         max_attempts: int = 2,
         read_timeout: float = 30.0,
     ) -> None:
         """DEPRECATED: use :meth:`_setup_ucxx_data_packer` (kwargs-only).
 
-        Kept as a thin shim because some downstream forks call the
-        original public name positionally.  Forwards to the new entry
-        point with keyword arguments.  Remove no earlier than two minor
-        releases after this PR lands.
+        Kept as a thin shim because some downstream forks call the original
+        public name positionally.
         """
         self._setup_ucxx_data_packer(
             device=device,
@@ -245,421 +142,21 @@ class UCXXDataPackerMixin(PrefetchDataPackerMixin):
         )
 
     def shutdown_ucxx_data_packer(self) -> None:
-        """Stop background thread and release UCXX resources.
+        """Stop the background thread, then release UCXX resources.
 
-        Unlike NCCL -- which passes ``before_join`` to abort its comms and make
-        the join immediate -- UCXX keeps its client close AFTER the join and
-        instead widens the join budget.  ``ncclCommAbort`` is explicitly
-        designed to be called while a peer thread is inside a collective;
-        closing a UCXX client from a different thread (the worker runs
-        ``_ucxx_dp_fetch_all`` on its own event loop) has no such guarantee.
-        Each ``_read_slot`` await is already bounded by ``read_timeout``, so
-        waiting that long is sufficient to let the worker unwind on its own.
+        Unlike NCCL -- which aborts its comms via ``before_join`` to make the
+        join immediate -- UCXX closes its client AFTER the join and instead
+        widens the join budget.  ``ncclCommAbort`` is explicitly designed to be
+        called while a peer thread is inside a collective; closing a UCXX client
+        from a different thread (the worker runs its fetch on its own event
+        loop) has no such guarantee.  Each read await is already bounded by
+        ``read_timeout``, so waiting that long lets the worker unwind on its
+        own.  The strategy therefore leaves ``before_join`` unimplemented.
         """
         self.shutdown_prefetch(
             join_timeout=max(5.0, float(self._ucxx_dp_read_timeout or 5.0))
         )
-
-        if self._ucxx_dp_client is not None:
-            try:
-                loop = asyncio.new_event_loop()
-                loop.run_until_complete(self._ucxx_dp_client.close())
-                loop.close()
-            except Exception as e:
-                logger.warning("[UCXXDataPackerMixin] Failed to close client: %s", e)
-            self._ucxx_dp_client = None
-
-        if self._prefetch_step_count > 0:
-            avg_ms = self._ucxx_dp_total_latency_ms / self._prefetch_step_count
-            logger.info(
-                "[UCXXDataPackerMixin] Final: %d iters, %d UCXX / %d fallback, "
-                "%.1f MB, avg %.0f ms/iter",
-                self._prefetch_step_count,
-                self._ucxx_dp_total_ucxx,
-                self._ucxx_dp_total_fallback,
-                self._ucxx_dp_total_bytes / 1e6,
-                avg_ms,
-            )
+        strategy = self._transport_strategy
+        if strategy is not None:
+            strategy.shutdown()
         logger.info("[UCXXDataPackerMixin] Shut down")
-
-    # ------------------------------------------------------------------
-    # PrefetchDataPackerMixin hook implementations
-    # ------------------------------------------------------------------
-
-    def _should_intercept(self, rollout_output: Any) -> bool:
-        """UCXX wire-format predicate.
-
-        UCXX-tagged completions are dicts produced by
-        :class:`UCXXRolloutMixin` carrying ``{_ucxx: True,
-        _ucxx_enabled: True, _worker_ip, _ucxx_port, _slot, ...}``.
-        Plain trajectories and ``"nccl:<id>"`` strings fall through
-        untouched (NCCL has its own intercept predicate in a sibling
-        mixin).
-        """
-        if not isinstance(rollout_output, dict):
-            return False
-        if not rollout_output.get("_ucxx"):
-            return False
-        # ``_ucxx_enabled`` is the runtime kill-switch on the rollout
-        # side; honor it on the trainer side too so a worker that
-        # disabled UCXX mid-flight (e.g. fallback to Redis) is handled
-        # correctly.  Treat absence as "enabled" for backward compat.
-        return rollout_output.get("_ucxx_enabled", True)
-
-    def _cache_key(self, rollout_output: Any) -> str:
-        return self._ucxx_dp_cache_key(rollout_output)
-
-    # NOTE: deliberately NO _filter_prefetch_tasks override.  The base default
-    # already delegates to :meth:`_should_intercept`, which is the only way to
-    # guarantee that what the trainer intercepts is exactly what gets
-    # prefetched.  The override that used to live here re-implemented the
-    # predicate as ``ro.get("_ucxx") and ro.get("_ucxx_enabled")`` -- reading a
-    # MISSING ``_ucxx_enabled`` as disabled, where _should_intercept reads it as
-    # enabled.  Such a ref was intercepted but never prefetched, so every one of
-    # its episodes took the blocking _sync_fetch path forever: a silent,
-    # permanent slow path rather than a failure.
-
-    def _fetch_batch(self, tasks: List[Any]) -> Dict[str, Any]:
-        """Run the async UCXX fetch on this thread's event loop.
-
-        Called by the base mixin's worker loop.  Returns
-        ``{cache_key: gpu_data}``.
-        """
-        loop = asyncio.new_event_loop()
-        try:
-            raw_results, transfer_ms, copy_ms = loop.run_until_complete(
-                self._ucxx_dp_fetch_all(tasks)
-            )
-        finally:
-            loop.close()
-
-        cache_results: Dict[str, Any] = {}
-        total_bytes = 0
-        ucxx_count = 0
-        for idx, gpu_data in raw_results.items():
-            key = self._ucxx_dp_cache_key_from_task(tasks, idx)
-            cache_results[key] = gpu_data
-            ucxx_count += 1
-            for val in gpu_data.values():
-                if isinstance(val, torch.Tensor):
-                    total_bytes += val.nelement() * val.element_size()
-
-        # Stash for _on_prefetch_complete (called from the trainer
-        # thread once wait_prefetch drains the result queue).  We
-        # intentionally don't accumulate counters here -- the base
-        # mixin guarantees _on_prefetch_complete sees exactly the
-        # results from this batch.
-        self._ucxx_dp_last_bytes = total_bytes
-        self._ucxx_dp_last_transfer_ms = transfer_ms
-        self._ucxx_dp_last_copy_ms = copy_ms
-        self._ucxx_dp_last_count = ucxx_count
-
-        # Decoupled trace event (actual I/O timestamps from the bg thread,
-        # not the trainer's wait_prefetch).
-        if ucxx_count > 0:
-            logger.debug(
-                "[Trace] thread=ucxx_prefetch op=ucxx_fetch "
-                "transfer_ms=%.1f copy_ms=%.1f count=%d bytes=%d",
-                transfer_ms,
-                copy_ms,
-                ucxx_count,
-                total_bytes,
-            )
-
-        return cache_results
-
-    def _sync_fetch(self, rollout_output: Any) -> Optional[Dict[str, torch.Tensor]]:
-        """Blocking single-episode UCXX fetch (cache-miss fallback)."""
-        if self._ucxx_dp_client is None:
-            return None
-        loop = asyncio.new_event_loop()
-        try:
-            results, _, _ = loop.run_until_complete(
-                self._ucxx_dp_fetch_all([(0, rollout_output)])
-            )
-            return results.get(0)
-        except Exception as e:
-            logger.warning("[UCXXDataPackerMixin] Sync fallback failed: %s", e)
-            return None
-        finally:
-            loop.close()
-
-    def _on_prefetch_complete(
-        self,
-        batch_id: int,
-        n_results: int,
-        fetch_ms: float,
-    ) -> None:
-        """Accumulate UCXX-specific stats; emit periodic INFO summaries."""
-        self._ucxx_dp_total_ucxx += getattr(self, "_ucxx_dp_last_count", n_results)
-        self._ucxx_dp_total_bytes += getattr(self, "_ucxx_dp_last_bytes", 0)
-        self._ucxx_dp_total_latency_ms += fetch_ms
-        step = self._prefetch_step_count
-        if step == 1 or step % _LOG_INTERVAL == 0:
-            avg_ms = self._ucxx_dp_total_latency_ms / step
-            logger.info(
-                "[UCXXDataPackerMixin] Iteration %d: %d UCXX, "
-                "%.1f MB total, avg %.0f ms/iter",
-                step,
-                self._ucxx_dp_total_ucxx,
-                self._ucxx_dp_total_bytes / 1e6,
-                avg_ms,
-            )
-
-    def _on_resolve_failed(self, rollout_output: Any, cache_key: str) -> None:
-        """Bump UCXX-specific fallback counter when an episode is skipped.
-
-        The base mixin already logs the warning; this hook just records
-        the event for the periodic INFO summary.
-        """
-        self._ucxx_dp_total_fallback += 1
-
-    # get_policy_input is inherited unchanged from PrefetchDataPackerMixin.
-
-    # ------------------------------------------------------------------
-    # Async fetch (UCXX-specific; unchanged from pre-refactor)
-    # ------------------------------------------------------------------
-
-    async def _ucxx_dp_fetch_all(self, ucxx_tasks: list) -> tuple:
-        """Fetch all episodes concurrently with multi-round retry.
-
-        Returns ``(results_dict, transfer_ms, copy_ms)`` where
-        ``results_dict`` maps task index -> GPU tensor dict.
-        """
-        client = self._ucxx_dp_client
-        device = self._ucxx_dp_device
-
-        async def _read_one(idx: int, metadata: dict):
-            worker_ip = metadata.get("_worker_ip")
-            ucxx_port = metadata.get("_ucxx_port")
-            slot = metadata.get("_slot")
-            handle = metadata.get("_buffer_handle")
-            ports = metadata.get("_ports") or (
-                handle.get("ucxx_ports") if handle else None
-            )
-
-            schema = None
-            schema_info = handle.get("schema") if handle else None
-            if schema_info:
-                from cosmos_rl.utils.trajectory import (
-                    TensorSpec,
-                )
-
-                schema = [
-                    TensorSpec(
-                        name=s["name"],
-                        shape=tuple(s["shape"]),
-                        dtype=np.dtype(s["dtype"]),
-                    )
-                    for s in schema_info
-                ]
-
-            max_attempts = max(1, self._ucxx_dp_max_attempts)
-            read_timeout = self._ucxx_dp_read_timeout
-            data = None
-            retryable = True
-            for attempt in range(1, max_attempts + 1):
-                try:
-                    data = await client.read(
-                        worker_ip,
-                        ucxx_port,
-                        slot,
-                        schema,
-                        ports=ports,
-                        timeout=read_timeout,
-                    )
-                    break
-                except Exception as e:
-                    if type(e).__name__ not in _TRANSIENT_UCXX_ERRORS:
-                        # Non-transient (e.g. ``StaleSlotError``,
-                        # protocol error from the server): retrying is
-                        # pointless.  Mark non-retryable so Layer C
-                        # skips the slot in subsequent rounds.
-                        logger.error(
-                            "[UCXXDataPackerMixin] Non-transient error reading "
-                            "%s:%s slot=%s: %s: %s",
-                            worker_ip,
-                            ucxx_port,
-                            slot,
-                            type(e).__name__,
-                            e,
-                        )
-                        retryable = False
-                        return idx, None, retryable
-                    if attempt == max_attempts:
-                        logger.warning(
-                            "[UCXXDataPackerMixin] All %d attempts failed for "
-                            "%s:%s slot=%s: %s: %s",
-                            max_attempts,
-                            worker_ip,
-                            ucxx_port,
-                            slot,
-                            type(e).__name__,
-                            e,
-                        )
-                        return idx, None, retryable
-                    logger.warning(
-                        "[UCXXDataPackerMixin] Transient error reading "
-                        "%s:%s slot=%s (attempt %d/%d): %s, retrying",
-                        worker_ip,
-                        ucxx_port,
-                        slot,
-                        attempt,
-                        max_attempts,
-                        type(e).__name__,
-                    )
-            return idx, data, retryable
-
-        def _to_gpu(result: dict) -> dict:
-            pinned_buf = result.pop("_pinned_buf", None)
-            if pinned_buf is not None:
-                try:
-                    raw_gpu = pinned_buf.to(device, non_blocking=True)
-                    torch.cuda.current_stream().synchronize()
-
-                    gpu_data: Dict[str, Any] = {}
-                    offset = 0
-                    for key, value in result.items():
-                        if not hasattr(value, "shape"):
-                            gpu_data[key] = value
-                            continue
-                        nbytes = value.nbytes
-                        td = _NP_TO_TORCH.get(value.dtype)
-                        if td is None:
-                            raise ValueError(
-                                f"Unsupported dtype {value.dtype} for key '{key}'"
-                            )
-                        gpu_data[key] = (
-                            raw_gpu[offset : offset + nbytes]
-                            .clone()
-                            .view(td)
-                            .reshape(value.shape)
-                        )
-                        offset += nbytes
-                except Exception as e:
-                    logger.error(
-                        "[UCXXDataPackerMixin] Bulk GPU copy failed (%s), "
-                        "falling back to per-tensor copy",
-                        e,
-                    )
-                    gpu_data = {}
-                    for key, value in result.items():
-                        if hasattr(value, "shape"):
-                            gpu_data[key] = torch.from_numpy(value.copy()).to(
-                                device, non_blocking=True
-                            )
-                        else:
-                            gpu_data[key] = value
-                finally:
-                    client.return_pinned(pinned_buf)
-            else:
-                gpu_data = {}
-                for key, value in result.items():
-                    if hasattr(value, "shape"):
-                        gpu_data[key] = torch.from_numpy(value).to(
-                            device, non_blocking=True
-                        )
-                    else:
-                        gpu_data[key] = value
-
-            ep_len_tensor = gpu_data.get(EPISODE_LENGTH)
-            if ep_len_tensor is not None:
-                ep_len = (
-                    int(ep_len_tensor.item())
-                    if ep_len_tensor.numel() == 1
-                    else int(ep_len_tensor[0].item())
-                )
-                for key in VARLEN_FIELDS:
-                    if key in gpu_data and gpu_data[key].shape[0] > ep_len:
-                        gpu_data[key] = gpu_data[key][:ep_len]
-            return gpu_data
-
-        meta_by_idx: dict = {}
-        for idx, metadata in ucxx_tasks:
-            worker_ip = metadata.get("_worker_ip")
-            ucxx_port = metadata.get("_ucxx_port")
-            slot = metadata.get("_slot")
-            if not (worker_ip and ucxx_port and slot is not None):
-                continue
-            meta_by_idx[idx] = metadata
-
-        pending = list(meta_by_idx.keys())
-        batch_results: dict = {}
-        total_transfer_ms = 0.0
-        total_copy_ms = 0.0
-
-        for round_num in range(_MAX_FETCH_ROUNDS):
-            if not pending:
-                break
-
-            tasks = [_read_one(idx, meta_by_idx[idx]) for idx in pending]
-            failed = []
-
-            for coro in asyncio.as_completed(tasks):
-                t0 = get_trace_time()
-                idx, result, retryable = await coro
-                t1 = get_trace_time()
-                total_transfer_ms += t1 - t0
-
-                if result is None:
-                    if retryable:
-                        failed.append(idx)
-                    # Non-retryable failures (e.g. stale slot): drop
-                    # immediately so the round-level retry doesn't
-                    # waste another ~RTT per round on a slot that
-                    # cannot be resurrected.
-                    continue
-
-                gpu_data = _to_gpu(result)
-                batch_results[idx] = gpu_data
-                t2 = get_trace_time()
-                total_copy_ms += t2 - t1
-
-            if failed:
-                logger.warning(
-                    "[UCXXDataPackerMixin] Fetch round %d/%d: "
-                    "%d/%d episodes failed, %s",
-                    round_num + 1,
-                    _MAX_FETCH_ROUNDS,
-                    len(failed),
-                    len(pending),
-                    "retrying" if round_num + 1 < _MAX_FETCH_ROUNDS else "giving up",
-                )
-            pending = failed
-
-        if pending:
-            logger.error(
-                "[UCXXDataPackerMixin] %d episodes failed after %d rounds: indices=%s",
-                len(pending),
-                _MAX_FETCH_ROUNDS,
-                pending,
-            )
-
-        return batch_results, total_transfer_ms, total_copy_ms
-
-    # ------------------------------------------------------------------
-    # Cache key helpers (kept as static methods for tests + the
-    # cross-task lookup helper used inside _fetch_batch).
-    # ------------------------------------------------------------------
-
-    @staticmethod
-    def _ucxx_dp_cache_key(metadata: dict) -> str:
-        return (
-            f"{metadata.get('_worker_ip')}:"
-            f"{metadata.get('_ucxx_port')}:"
-            f"{metadata.get('_slot')}"
-        )
-
-    @staticmethod
-    def _ucxx_dp_cache_key_from_task(
-        ucxx_tasks: list,
-        idx: int,
-    ) -> str:
-        for task_idx, metadata in ucxx_tasks:
-            if task_idx == idx:
-                return (
-                    f"{metadata.get('_worker_ip')}:"
-                    f"{metadata.get('_ucxx_port')}:"
-                    f"{metadata.get('_slot')}"
-                )
-        return str(idx)

--- a/cosmos_rl/utils/payload_transport/ucxx/strategy.py
+++ b/cosmos_rl/utils/payload_transport/ucxx/strategy.py
@@ -1,0 +1,586 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""UCXX payload transport, expressed as a composable strategy.
+
+Owns the UCXX client and the async read path; knows nothing about *when* a
+fetch happens, which is the packer's job.
+
+Moved off ``UCXXDataPackerMixin`` unchanged apart from dropping the
+``_ucxx_dp_`` prefix and taking the iteration counter as an argument.  Note it
+deliberately does NOT implement :meth:`before_join`: unlike ``ncclCommAbort``,
+closing a UCXX client from another thread while the worker is inside its own
+event loop has no such guarantee, so teardown widens the join budget and closes
+afterwards instead (see :meth:`shutdown`).
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any, Dict, List, Optional
+
+import numpy as np
+import torch
+
+from cosmos_rl.utils.logging import logger
+from cosmos_rl.utils.trajectory import EPISODE_LENGTH, VARLEN_FIELDS
+from cosmos_rl.utils.payload_transport.strategy import PayloadTransportStrategy
+from cosmos_rl.utils.trace import get_trace_time
+from cosmos_rl.utils.payload_transport.ucxx.ucxx_buffer import (
+    UCXX_AVAILABLE,
+    UCXXClient,
+)
+
+
+# Errors that are worth retrying at the data-packer layer.  Mirrors
+# the rotation set in :data:`ucxx_buffer._PORT_ROTATABLE_ERRORS` --
+# transport-class failures on a specific server thread can succeed on
+# the next attempt because :class:`UCXXClient` will rotate to a
+# different (worker_ip, port) endpoint internally.
+#
+# Deliberately excluded:
+#   * ``StaleSlotError`` -- the slot has been overwritten on the
+#     producer side; no amount of retrying brings it back.  The
+#     :class:`PrefetchDataPackerMixin` upper layer drops the episode
+#     via ``_on_resolve_failed`` on the very first attempt.
+
+_TRANSIENT_UCXX_ERRORS = frozenset(
+    {
+        "UCXXCanceledError",
+        "UCXXConnectionResetError",
+        "UCXXCloseError",
+        "TimeoutError",
+    }
+)
+
+_MAX_FETCH_ROUNDS = 3
+
+
+_LOG_INTERVAL = 50
+
+
+# Numpy → torch dtype map for the bulk pinned-buffer copy in
+# ``_to_gpu``.  Defined at module scope so it is built once at import
+# time rather than on every fetch.
+_NP_TO_TORCH = {
+    np.dtype("float32"): torch.float32,
+    np.dtype("float64"): torch.float64,
+    np.dtype("float16"): torch.float16,
+    np.dtype("int64"): torch.int64,
+    np.dtype("int32"): torch.int32,
+    np.dtype("int16"): torch.int16,
+    np.dtype("int8"): torch.int8,
+    np.dtype("uint8"): torch.uint8,
+    np.dtype("bool"): torch.bool,
+}
+
+
+class UCXXTransportStrategy(PayloadTransportStrategy):
+    """Resolve UCXX payload references for a single consumer."""
+
+    _client: Optional[UCXXClient] = None
+    _device: Optional[torch.device] = None
+    _max_attempts: int = 2
+    _read_timeout: float = 30.0
+    _total_ucxx: int = 0
+    _total_fallback: int = 0
+    _total_bytes: int = 0
+    _total_latency_ms: float = 0.0
+    _last_bytes: int = 0
+    _last_count: int = 0
+    _last_transfer_ms: float = 0.0
+    _last_copy_ms: float = 0.0
+    _steps: int = 0
+
+    @property
+    def read_timeout(self) -> float:
+        """Per-read budget; also sizes the packer's join wait during teardown."""
+        return self._read_timeout
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    def setup(
+        self,
+        *,
+        device: torch.device,
+        max_attempts: int = 2,
+        read_timeout: float = 30.0,
+    ) -> None:
+        """Create the UCXX client.
+
+        Normally invoked by the packer composing this strategy, which is itself
+        driven by :meth:`UCXXPayloadTransport.attach_data_packer` during
+        ``CommMixin.init_data_packer``.  Scheduling knobs such as
+        ``prefetch_timeout`` stop at the packer and never reach here.
+
+        Args:
+            device: Target GPU device for fetched tensors.
+            max_attempts: Total attempts per remote slot read (initial +
+                retries on transient UCX errors).  Defaults to 2.
+            read_timeout: Per-await timeout (seconds) inside one
+                ``UCXXClient.read`` call -- bounds a single ``send`` /
+                ``recv`` operation.
+        """
+        if not UCXX_AVAILABLE:
+            raise RuntimeError(
+                "UCXX is required for UCXXTransportStrategy. "
+                "Install with: pip install ucxx-cu12"
+            )
+
+        self._device = device
+        self._max_attempts = max(1, max_attempts)
+        self._read_timeout = read_timeout
+        self._client = UCXXClient()
+
+        logger.info(
+            "[UCXXTransportStrategy] Initialised: device=%s, "
+            "max_attempts=%d, read_timeout=%ss",
+            device,
+            self._max_attempts,
+            read_timeout,
+        )
+
+    def shutdown(self) -> None:
+        """Close the client and log the run summary.
+
+        Called AFTER the packer has joined its worker -- see the module
+        docstring for why UCXX closes late rather than aborting early.
+        """
+        if self._client is not None:
+            try:
+                loop = asyncio.new_event_loop()
+                loop.run_until_complete(self._client.close())
+                loop.close()
+            except Exception as e:
+                logger.warning("[UCXXTransportStrategy] Failed to close client: %s", e)
+            self._client = None
+
+        if self._steps > 0:
+            avg_ms = self._total_latency_ms / self._steps
+            logger.info(
+                "[UCXXTransportStrategy] Final: %d iters, %d UCXX / %d fallback, "
+                "%.1f MB, avg %.0f ms/iter",
+                self._steps,
+                self._total_ucxx,
+                self._total_fallback,
+                self._total_bytes / 1e6,
+                avg_ms,
+            )
+        logger.info("[UCXXTransportStrategy] Shut down")
+
+    def should_intercept(self, rollout_output: Any) -> bool:
+        """UCXX wire-format predicate.
+
+        UCXX-tagged completions are dicts produced by
+        :class:`UCXXRolloutMixin` carrying ``{_ucxx: True,
+        _ucxx_enabled: True, _worker_ip, _ucxx_port, _slot, ...}``.
+        Plain trajectories and ``"nccl:<id>"`` strings fall through
+        untouched (NCCL has its own intercept predicate in a sibling
+        mixin).
+        """
+        if not isinstance(rollout_output, dict):
+            return False
+        if not rollout_output.get("_ucxx"):
+            return False
+        # ``_ucxx_enabled`` is the runtime kill-switch on the rollout
+        # side; honor it on the trainer side too so a worker that
+        # disabled UCXX mid-flight (e.g. fallback to Redis) is handled
+        # correctly.  Treat absence as "enabled" for backward compat.
+        return rollout_output.get("_ucxx_enabled", True)
+
+    def cache_key(self, rollout_output: Any) -> str:
+        return self._ref_cache_key(rollout_output)
+
+    # NOTE: deliberately NO _filter_prefetch_tasks override.  The base default
+    # already delegates to :meth:`_should_intercept`, which is the only way to
+    # guarantee that what the trainer intercepts is exactly what gets
+    # prefetched.  The override that used to live here re-implemented the
+    # predicate as ``ro.get("_ucxx") and ro.get("_ucxx_enabled")`` -- reading a
+    # MISSING ``_ucxx_enabled`` as disabled, where _should_intercept reads it as
+    # enabled.  Such a ref was intercepted but never prefetched, so every one of
+    # its episodes took the blocking _sync_fetch path forever: a silent,
+    # permanent slow path rather than a failure.
+
+    def fetch_batch(self, tasks: List[Any]) -> Dict[str, Any]:
+        """Run the async UCXX fetch on this thread's event loop.
+
+        Called by the base mixin's worker loop.  Returns
+        ``{cache_key: gpu_data}``.
+        """
+        loop = asyncio.new_event_loop()
+        try:
+            raw_results, transfer_ms, copy_ms = loop.run_until_complete(
+                self._fetch_all(tasks)
+            )
+        finally:
+            loop.close()
+
+        cache_results: Dict[str, Any] = {}
+        total_bytes = 0
+        ucxx_count = 0
+        for idx, gpu_data in raw_results.items():
+            key = self._ref_cache_key_from_task(tasks, idx)
+            cache_results[key] = gpu_data
+            ucxx_count += 1
+            for val in gpu_data.values():
+                if isinstance(val, torch.Tensor):
+                    total_bytes += val.nelement() * val.element_size()
+
+        # Stash for _on_prefetch_complete (called from the trainer
+        # thread once wait_prefetch drains the result queue).  We
+        # intentionally don't accumulate counters here -- the base
+        # mixin guarantees _on_prefetch_complete sees exactly the
+        # results from this batch.
+        self._last_bytes = total_bytes
+        self._last_transfer_ms = transfer_ms
+        self._last_copy_ms = copy_ms
+        self._last_count = ucxx_count
+
+        # Decoupled trace event (actual I/O timestamps from the bg thread,
+        # not the trainer's wait_prefetch).
+        if ucxx_count > 0:
+            logger.debug(
+                "[Trace] thread=ucxx_prefetch op=ucxx_fetch "
+                "transfer_ms=%.1f copy_ms=%.1f count=%d bytes=%d",
+                transfer_ms,
+                copy_ms,
+                ucxx_count,
+                total_bytes,
+            )
+
+        return cache_results
+
+    def sync_fetch(self, rollout_output: Any) -> Optional[Dict[str, torch.Tensor]]:
+        """Blocking single-episode UCXX fetch (cache-miss fallback)."""
+        if self._client is None:
+            return None
+        loop = asyncio.new_event_loop()
+        try:
+            results, _, _ = loop.run_until_complete(
+                self._fetch_all([(0, rollout_output)])
+            )
+            return results.get(0)
+        except Exception as e:
+            logger.warning("[UCXXTransportStrategy] Sync fallback failed: %s", e)
+            return None
+        finally:
+            loop.close()
+
+    def on_prefetch_complete(
+        self,
+        batch_id: int,
+        n_results: int,
+        fetch_ms: float,
+        step: int,
+    ) -> None:
+        """Accumulate UCXX-specific stats; emit periodic INFO summaries."""
+        # Batch's own figures, set by fetch_batch -- not n_results, which the
+        # base passes as len(self._prefetch_cache) and would over-count.
+        self._total_ucxx += self._last_count
+        self._total_bytes += self._last_bytes
+        self._total_latency_ms += fetch_ms
+        self._steps = step
+        if step == 1 or step % _LOG_INTERVAL == 0:
+            avg_ms = self._total_latency_ms / step
+            logger.info(
+                "[UCXXTransportStrategy] Iteration %d: %d UCXX, "
+                "%.1f MB total, avg %.0f ms/iter",
+                step,
+                self._total_ucxx,
+                self._total_bytes / 1e6,
+                avg_ms,
+            )
+
+    def on_resolve_failed(self, rollout_output: Any, cache_key: str) -> None:
+        """Bump UCXX-specific fallback counter when an episode is skipped.
+
+        The base mixin already logs the warning; this hook just records
+        the event for the periodic INFO summary.
+        """
+        self._total_fallback += 1
+
+    # get_policy_input is inherited unchanged from PrefetchDataPackerMixin.
+
+    # ------------------------------------------------------------------
+    # Async fetch (UCXX-specific; unchanged from pre-refactor)
+    # ------------------------------------------------------------------
+
+    async def _fetch_all(self, ucxx_tasks: list) -> tuple:
+        """Fetch all episodes concurrently with multi-round retry.
+
+        Returns ``(results_dict, transfer_ms, copy_ms)`` where
+        ``results_dict`` maps task index -> GPU tensor dict.
+        """
+        client = self._client
+        device = self._device
+
+        async def _read_one(idx: int, metadata: dict):
+            worker_ip = metadata.get("_worker_ip")
+            ucxx_port = metadata.get("_ucxx_port")
+            slot = metadata.get("_slot")
+            handle = metadata.get("_buffer_handle")
+            ports = metadata.get("_ports") or (
+                handle.get("ucxx_ports") if handle else None
+            )
+
+            schema = None
+            schema_info = handle.get("schema") if handle else None
+            if schema_info:
+                from cosmos_rl.utils.trajectory import (
+                    TensorSpec,
+                )
+
+                schema = [
+                    TensorSpec(
+                        name=s["name"],
+                        shape=tuple(s["shape"]),
+                        dtype=np.dtype(s["dtype"]),
+                    )
+                    for s in schema_info
+                ]
+
+            max_attempts = max(1, self._max_attempts)
+            read_timeout = self._read_timeout
+            data = None
+            retryable = True
+            for attempt in range(1, max_attempts + 1):
+                try:
+                    data = await client.read(
+                        worker_ip,
+                        ucxx_port,
+                        slot,
+                        schema,
+                        ports=ports,
+                        timeout=read_timeout,
+                    )
+                    break
+                except Exception as e:
+                    if type(e).__name__ not in _TRANSIENT_UCXX_ERRORS:
+                        # Non-transient (e.g. ``StaleSlotError``,
+                        # protocol error from the server): retrying is
+                        # pointless.  Mark non-retryable so Layer C
+                        # skips the slot in subsequent rounds.
+                        logger.error(
+                            "[UCXXTransportStrategy] Non-transient error reading "
+                            "%s:%s slot=%s: %s: %s",
+                            worker_ip,
+                            ucxx_port,
+                            slot,
+                            type(e).__name__,
+                            e,
+                        )
+                        retryable = False
+                        return idx, None, retryable
+                    if attempt == max_attempts:
+                        logger.warning(
+                            "[UCXXTransportStrategy] All %d attempts failed for "
+                            "%s:%s slot=%s: %s: %s",
+                            max_attempts,
+                            worker_ip,
+                            ucxx_port,
+                            slot,
+                            type(e).__name__,
+                            e,
+                        )
+                        return idx, None, retryable
+                    logger.warning(
+                        "[UCXXTransportStrategy] Transient error reading "
+                        "%s:%s slot=%s (attempt %d/%d): %s, retrying",
+                        worker_ip,
+                        ucxx_port,
+                        slot,
+                        attempt,
+                        max_attempts,
+                        type(e).__name__,
+                    )
+            return idx, data, retryable
+
+        def _to_gpu(result: dict) -> dict:
+            pinned_buf = result.pop("_pinned_buf", None)
+            if pinned_buf is not None:
+                try:
+                    raw_gpu = pinned_buf.to(device, non_blocking=True)
+                    torch.cuda.current_stream().synchronize()
+
+                    gpu_data: Dict[str, Any] = {}
+                    offset = 0
+                    for key, value in result.items():
+                        if not hasattr(value, "shape"):
+                            gpu_data[key] = value
+                            continue
+                        nbytes = value.nbytes
+                        td = _NP_TO_TORCH.get(value.dtype)
+                        if td is None:
+                            raise ValueError(
+                                f"Unsupported dtype {value.dtype} for key '{key}'"
+                            )
+                        gpu_data[key] = (
+                            raw_gpu[offset : offset + nbytes]
+                            .clone()
+                            .view(td)
+                            .reshape(value.shape)
+                        )
+                        offset += nbytes
+                except Exception as e:
+                    logger.error(
+                        "[UCXXTransportStrategy] Bulk GPU copy failed (%s), "
+                        "falling back to per-tensor copy",
+                        e,
+                    )
+                    gpu_data = {}
+                    for key, value in result.items():
+                        if hasattr(value, "shape"):
+                            gpu_data[key] = torch.from_numpy(value.copy()).to(
+                                device, non_blocking=True
+                            )
+                        else:
+                            gpu_data[key] = value
+                finally:
+                    client.return_pinned(pinned_buf)
+            else:
+                gpu_data = {}
+                for key, value in result.items():
+                    if hasattr(value, "shape"):
+                        gpu_data[key] = torch.from_numpy(value).to(
+                            device, non_blocking=True
+                        )
+                    else:
+                        gpu_data[key] = value
+
+            ep_len_tensor = gpu_data.get(EPISODE_LENGTH)
+            if ep_len_tensor is not None:
+                ep_len = (
+                    int(ep_len_tensor.item())
+                    if ep_len_tensor.numel() == 1
+                    else int(ep_len_tensor[0].item())
+                )
+                for key in VARLEN_FIELDS:
+                    if key in gpu_data and gpu_data[key].shape[0] > ep_len:
+                        gpu_data[key] = gpu_data[key][:ep_len]
+            return gpu_data
+
+        meta_by_idx: dict = {}
+        for idx, metadata in ucxx_tasks:
+            worker_ip = metadata.get("_worker_ip")
+            ucxx_port = metadata.get("_ucxx_port")
+            slot = metadata.get("_slot")
+            if not (worker_ip and ucxx_port and slot is not None):
+                continue
+            meta_by_idx[idx] = metadata
+
+        pending = list(meta_by_idx.keys())
+        batch_results: dict = {}
+        total_transfer_ms = 0.0
+        total_copy_ms = 0.0
+
+        for round_num in range(_MAX_FETCH_ROUNDS):
+            if not pending:
+                break
+
+            tasks = [_read_one(idx, meta_by_idx[idx]) for idx in pending]
+            failed = []
+
+            for coro in asyncio.as_completed(tasks):
+                t0 = get_trace_time()
+                idx, result, retryable = await coro
+                t1 = get_trace_time()
+                total_transfer_ms += t1 - t0
+
+                if result is None:
+                    if retryable:
+                        failed.append(idx)
+                    # Non-retryable failures (e.g. stale slot): drop
+                    # immediately so the round-level retry doesn't
+                    # waste another ~RTT per round on a slot that
+                    # cannot be resurrected.
+                    continue
+
+                gpu_data = _to_gpu(result)
+                batch_results[idx] = gpu_data
+                t2 = get_trace_time()
+                total_copy_ms += t2 - t1
+
+            if failed:
+                logger.warning(
+                    "[UCXXTransportStrategy] Fetch round %d/%d: "
+                    "%d/%d episodes failed, %s",
+                    round_num + 1,
+                    _MAX_FETCH_ROUNDS,
+                    len(failed),
+                    len(pending),
+                    "retrying" if round_num + 1 < _MAX_FETCH_ROUNDS else "giving up",
+                )
+            pending = failed
+
+        if pending:
+            logger.error(
+                "[UCXXTransportStrategy] %d episodes failed after %d rounds: indices=%s",
+                len(pending),
+                _MAX_FETCH_ROUNDS,
+                pending,
+            )
+
+        return batch_results, total_transfer_ms, total_copy_ms
+
+    # ------------------------------------------------------------------
+    # Cache key helpers (kept as static methods for tests + the
+    # cross-task lookup helper used inside _fetch_batch).
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _ref_cache_key(metadata: dict) -> str:
+        return (
+            f"{metadata.get('_worker_ip')}:"
+            f"{metadata.get('_ucxx_port')}:"
+            f"{metadata.get('_slot')}"
+        )
+
+    @staticmethod
+    def _ref_cache_key_from_task(
+        ucxx_tasks: list,
+        idx: int,
+    ) -> str:
+        for task_idx, metadata in ucxx_tasks:
+            if task_idx == idx:
+                return (
+                    f"{metadata.get('_worker_ip')}:"
+                    f"{metadata.get('_ucxx_port')}:"
+                    f"{metadata.get('_slot')}"
+                )
+        return str(idx)
+
+
+def compose_ucxx_transport(
+    packer: Any,
+    *,
+    device: Any,
+    prefetch_timeout: float = 300.0,
+    max_attempts: int = 2,
+    read_timeout: float = 30.0,
+) -> None:
+    """Attach a fresh UCXX strategy to ``packer`` and start its prefetch worker.
+
+    The one place that wiring lives, so the mixin and the composed attach path
+    cannot drift.  ``packer`` need only be a ``PrefetchDataPackerMixin``; no
+    UCXX ancestry is required.
+    """
+    strategy = UCXXTransportStrategy()
+    strategy.setup(device=device, max_attempts=max_attempts, read_timeout=read_timeout)
+    packer.set_transport_strategy(strategy)
+    packer._setup_prefetch(
+        prefetch_timeout=prefetch_timeout,
+        thread_name="UCXXDataPackerPrefetch",
+    )

--- a/cosmos_rl/utils/payload_transport/ucxx/transport.py
+++ b/cosmos_rl/utils/payload_transport/ucxx/transport.py
@@ -94,6 +94,17 @@ class UCXXPayloadTransport(PayloadTransport):
         defensive default of the base class.
         """
         setup = getattr(packer, "_setup_ucxx_data_packer", None)
+        if setup is None and callable(getattr(packer, "set_transport_strategy", None)):
+            # Composed packer: schedules but has no UCXX ancestry.  Synthesise
+            # the mixin's setup signature so the tunable resolution below is
+            # shared rather than copied.
+            import functools
+
+            from cosmos_rl.utils.payload_transport.ucxx.strategy import (
+                compose_ucxx_transport,
+            )
+
+            setup = functools.partial(compose_ucxx_transport, packer)
         if setup is None:
             return
         custom = getattr(config, "custom", None) or {}

--- a/tests/run_test.sh
+++ b/tests/run_test.sh
@@ -130,6 +130,14 @@ run python tests/test_ucxx_rollout_mixin.py
 run python tests/test_ucxx_transport.py
 run python tests/test_launcher_shutdown.py
 run python tests/test_process_flow.py
+# Composed-transport seam and the UCXX end-to-end guard.  A test file
+# does nothing until it is named here -- run_test.sh is the only thing
+# build_and_test runs.
+run python tests/test_transport_strategy.py
+run python tests/test_prefetch_mixin.py
+run python tests/test_trajectory.py
+run python tests/test_rollout_prefetch_loop_integration.py
+run python tests/test_ucxx_e2e.py
 run python tests/test_custom_class.py
 run python tests/test_math_verify.py
 run python tests/test_policy_overfit.py

--- a/tests/test_nccl_addressing.py
+++ b/tests/test_nccl_addressing.py
@@ -26,7 +26,7 @@ the request channel, and the per-pair UID key.
 
 import unittest
 
-from cosmos_rl.utils.payload_transport.nccl.data_packer_mixin import (
+from cosmos_rl.utils.payload_transport.nccl.strategy import (
     _pair_key,
     _parse_ref,
 )

--- a/tests/test_nccl_data_packer_mixin.py
+++ b/tests/test_nccl_data_packer_mixin.py
@@ -29,6 +29,7 @@ from unittest import mock
 from cosmos_rl.utils.payload_transport.nccl.data_packer_mixin import (
     NCCLDataPackerMixin,
 )
+from cosmos_rl.utils.payload_transport.nccl.strategy import NCCLTransportStrategy
 
 
 class _StubDataPacker:
@@ -46,8 +47,76 @@ class _StubDataPacker:
         return rollout_output
 
 
+# The NCCL engine moved from the mixin to NCCLTransportStrategy, which the
+# mixin now composes.  These tests drive that engine directly (they set up
+# rendezvous/comm-cache state by hand and call _fetch_all), so the harness
+# forwards the legacy ``_nccl_dp_*`` names and engine methods to the attached
+# strategy.  That keeps them exercising the real transport code -- now through
+# the composition -- rather than restating it against a new class.
+_FORWARDED_STATE = [
+    "device",
+    "redis",
+    "config",
+    "rendezvous",
+    "comm_cache",
+    "streams",
+    "recv_lock",
+    "receiver_rank",
+    "receiver_replica",
+    "prefix",
+    "max_attempts",
+    "recv_timeout",
+    "first_transfer_timeout",
+    "warm_pairs",
+    "schema",
+    "total_nccl",
+    "total_fallback",
+    "total_bytes",
+    "total_latency_ms",
+    "last_bytes",
+    "last_count",
+]
+_FORWARDED_METHODS = [
+    "_fetch_all",
+    "_rendezvous_one",
+    "_quarantine_endpoint",
+    "_quarantine_recv_failures",
+]
+
+
 class _Packer(NCCLDataPackerMixin, _StubDataPacker):
-    """MRO: NCCLDataPackerMixin first, then _StubDataPacker."""
+    """MRO: NCCLDataPackerMixin first, then _StubDataPacker.
+
+    Auto-attaches a strategy so tests can poke transport state before (or
+    without) calling ``_setup_nccl_data_packer``, exactly as they did when the
+    engine lived on the mixin.
+    """
+
+    def __init__(self):
+        super().__init__()
+        self.set_transport_strategy(NCCLTransportStrategy())
+
+
+def _install_forwarding():
+    for name in _FORWARDED_STATE:
+
+        def _get(self, _n=name):
+            return getattr(self._transport_strategy, "_" + _n)
+
+        def _set(self, value, _n=name):
+            setattr(self._transport_strategy, "_" + _n, value)
+
+        setattr(_Packer, "_nccl_dp_" + name, property(_get, _set))
+
+    for name in _FORWARDED_METHODS:
+
+        def _call(self, *a, _n=name, **kw):
+            return getattr(self._transport_strategy, _n)(*a, **kw)
+
+        setattr(_Packer, name, _call)
+
+
+_install_forwarding()
 
 
 class TestShutdownAbortsBeforeJoin(unittest.TestCase):
@@ -64,16 +133,26 @@ class TestShutdownAbortsBeforeJoin(unittest.TestCase):
         )
         return p
 
-    def test_abort_hook_is_passed_and_runs_before_the_join(self):
+    def test_abort_runs_before_the_join(self):
+        """Ordering through the real path, not a stubbed shutdown_prefetch.
+
+        The mixin no longer passes an abort hook explicitly -- shutdown_prefetch
+        defaults before_join to the attached strategy, so composing a transport
+        is enough to get its teardown.  What still has to hold is the ordering,
+        so observe the actual join.
+        """
         order = []
         p = self._packer(order)
+        p._setup_prefetch(prefetch_timeout=5.0, thread_name="AbortOrderTest")
 
-        def _fake_shutdown_prefetch(*, join_timeout=5.0, before_join=None):
-            self.assertIsNotNone(before_join, "NCCL must supply an abort hook")
-            before_join()  # transport unblocks in-flight I/O ...
-            order.append("join")  # ... then the join happens
+        thread = p._prefetch_thread
+        real_join = thread.join
 
-        p.shutdown_prefetch = _fake_shutdown_prefetch
+        def _join(timeout=None):
+            order.append("join")
+            return real_join(timeout=timeout)
+
+        thread.join = _join
         p.shutdown_nccl_data_packer()
         self.assertEqual(order, ["abort_all", "join"])
 
@@ -171,7 +250,7 @@ class TestGetPolicyInputDispatch(unittest.TestCase):
 
     def test_nccl_string_cache_hit_delegates_to_super(self):
         resolved = {"observations": [1, 2, 3]}
-        key = NCCLDataPackerMixin._nccl_dp_cache_key("nccl:0:abc")
+        key = NCCLTransportStrategy._ref_cache_key("nccl:0:abc")
         self.p._nccl_dp_prefetch_cache = {key: resolved}
         out = self.p.get_policy_input(rollout_output="nccl:0:abc")
         self.assertIs(out, resolved)
@@ -181,7 +260,7 @@ class TestGetPolicyInputDispatch(unittest.TestCase):
     def test_nccl_dict_cache_hit_delegates_to_super(self):
         resolved = {"observations": [9]}
         ref = {"_nccl": True, "_transfer_id": "1:xyz"}
-        key = NCCLDataPackerMixin._nccl_dp_cache_key(ref)
+        key = NCCLTransportStrategy._ref_cache_key(ref)
         self.p._nccl_dp_prefetch_cache = {key: resolved}
         out = self.p.get_policy_input(rollout_output=ref)
         self.assertIs(out, resolved)
@@ -190,19 +269,19 @@ class TestGetPolicyInputDispatch(unittest.TestCase):
 class TestCacheKey(unittest.TestCase):
     def test_string_form(self):
         self.assertEqual(
-            NCCLDataPackerMixin._nccl_dp_cache_key("nccl:0:abcdef"), "0:abcdef"
+            NCCLTransportStrategy._ref_cache_key("nccl:0:abcdef"), "0:abcdef"
         )
 
     def test_dict_form(self):
         self.assertEqual(
-            NCCLDataPackerMixin._nccl_dp_cache_key(
+            NCCLTransportStrategy._ref_cache_key(
                 {"_nccl": True, "_transfer_id": "3:deadbeef"}
             ),
             "3:deadbeef",
         )
 
     def test_non_ref_falls_back_to_str(self):
-        self.assertEqual(NCCLDataPackerMixin._nccl_dp_cache_key(42), "42")
+        self.assertEqual(NCCLTransportStrategy._ref_cache_key(42), "42")
 
 
 class _FakeRv:
@@ -222,24 +301,28 @@ class _FakeRv:
 
 
 def _consumer(rv, cache):
+    """Build a transport strategy wired to the given rendezvous / comm cache.
+
+    The engine tests below drive NCCLTransportStrategy directly -- that is
+    where the recv path lives now -- rather than through a packer, which would
+    only add a scheduling layer none of them exercise.
+    """
     from cosmos_rl.utils.trajectory import (
         build_trajectory_schema,
     )
 
-    p = _Packer()
-    p._nccl_dp_rendezvous = rv
-    p._nccl_dp_comm_cache = cache
-    p._nccl_dp_receiver_rank = 0
-    p._nccl_dp_receiver_replica = "pol-A"
-    p._nccl_dp_prefix = "pfx"
-    p._nccl_dp_max_attempts = 2
-    p._nccl_dp_recv_timeout = 5.0
-    p._nccl_dp_first_transfer_timeout = 30.0
-    p._nccl_dp_warm_pairs = set()
-    p._nccl_dp_device = None
-    p._nccl_dp_schema = build_trajectory_schema(
-        {"max_steps": 4, "obs_dim": 2, "action_dim": 1}
-    )
+    p = NCCLTransportStrategy()
+    p._rendezvous = rv
+    p._comm_cache = cache
+    p._receiver_rank = 0
+    p._receiver_replica = "pol-A"
+    p._prefix = "pfx"
+    p._max_attempts = 2
+    p._recv_timeout = 5.0
+    p._first_transfer_timeout = 30.0
+    p._warm_pairs = set()
+    p._device = None
+    p._schema = build_trajectory_schema({"max_steps": 4, "obs_dim": 2, "action_dim": 1})
     return p
 
 
@@ -262,10 +345,10 @@ class TestQuarantineClearsWarmMarker(unittest.TestCase):
 
         p = _consumer(_FakeRv(None), _RecordingCache())
         pair = ("rA", 0, 0)
-        p._nccl_dp_warm_pairs.add(pair)
-        p._quarantine_endpoint(p._nccl_dp_comm_cache, ("rA", 0), pair)
+        p._warm_pairs.add(pair)
+        p._quarantine_endpoint(p._comm_cache, ("rA", 0), pair)
         self.assertEqual(quarantined, [("rA", 0)])  # endpoint quarantined
-        self.assertNotIn(pair, p._nccl_dp_warm_pairs)  # demoted to warming
+        self.assertNotIn(pair, p._warm_pairs)  # demoted to warming
 
     def test_quarantine_survives_cache_raising(self):
         class _BoomCache:
@@ -274,9 +357,9 @@ class TestQuarantineClearsWarmMarker(unittest.TestCase):
 
         p = _consumer(_FakeRv(None), _BoomCache())
         pair = ("rA", 0, 0)
-        p._nccl_dp_warm_pairs.add(pair)
-        p._quarantine_endpoint(p._nccl_dp_comm_cache, ("rA", 0), pair)  # no raise
-        self.assertNotIn(pair, p._nccl_dp_warm_pairs)  # still demoted
+        p._warm_pairs.add(pair)
+        p._quarantine_endpoint(p._comm_cache, ("rA", 0), pair)  # no raise
+        self.assertNotIn(pair, p._warm_pairs)  # still demoted
 
 
 class TestSyncFetchContainment(unittest.TestCase):
@@ -290,8 +373,8 @@ class TestSyncFetchContainment(unittest.TestCase):
             build_trajectory_schema,
         )
 
-        p = _Packer()
-        p._nccl_dp_schema = build_trajectory_schema(
+        p = NCCLTransportStrategy()
+        p._schema = build_trajectory_schema(
             {"max_steps": 4, "obs_dim": 2, "action_dim": 1}
         )
         return p
@@ -304,24 +387,24 @@ class TestSyncFetchContainment(unittest.TestCase):
 
         p._fetch_all = boom
         # "nccl:0:x" parses to a real ref, so _fetch_all IS reached and raises.
-        self.assertIsNone(p._sync_fetch("nccl:0:x"))
+        self.assertIsNone(p.sync_fetch("nccl:0:x"))
 
     def test_returns_none_on_unparseable_ref(self):
         p = self._packer()
         # Not an NCCL reference -> None without touching _fetch_all.
-        self.assertIsNone(p._sync_fetch(12345))
+        self.assertIsNone(p.sync_fetch(12345))
 
     def test_returns_none_on_malformed_schema(self):
         # A corrupt dict ref raises from _parse_ref/deserialize_schema, which is
         # now INSIDE the containment (base get_policy_input has none above it).
         p = self._packer()
         bad = {"_nccl": True, "_transfer_id": "0:x", "_schema": "not-a-schema"}
-        self.assertIsNone(p._sync_fetch(bad))
+        self.assertIsNone(p.sync_fetch(bad))
 
     def test_returns_result_on_success(self):
         p = self._packer()
         p._fetch_all = lambda refs: ({0: {"ok": 1}}, 4, 1.0)
-        self.assertEqual(p._sync_fetch("nccl:0:x"), {"ok": 1})
+        self.assertEqual(p.sync_fetch("nccl:0:x"), {"ok": 1})
 
 
 class TestColdStartTolerance(unittest.TestCase):
@@ -368,7 +451,7 @@ class TestColdStartTolerance(unittest.TestCase):
         p = _consumer(rv, cache)
         # Mark the pair WARM (has transferred before) -> tight timeout + a
         # timeout now is a genuine failure.
-        p._nccl_dp_warm_pairs.add(("rA", 0, 0))
+        p._warm_pairs.add(("rA", 0, 0))
 
         out = p._rendezvous_one(_ref(), None)
         self.assertIsNone(out)
@@ -415,15 +498,15 @@ class TestRecvFailureIsolation(unittest.TestCase):
         )
         cache.get_or_create(("rA", 0, 0), uid_chars=[1], local_rank=1)
 
-        p = _Packer()
-        p._nccl_dp_rendezvous = object()
-        p._nccl_dp_comm_cache = cache
-        p._nccl_dp_device = None
-        p._nccl_dp_streams = None
-        p._nccl_dp_receiver_rank = 0
-        p._nccl_dp_recv_timeout = 5.0
-        p._nccl_dp_first_transfer_timeout = 30.0
-        p._nccl_dp_warm_pairs = {("rA", 0, 0)} if warm else set()
+        p = NCCLTransportStrategy()
+        p._rendezvous = object()
+        p._comm_cache = cache
+        p._device = None
+        p._streams = None
+        p._receiver_rank = 0
+        p._recv_timeout = 5.0
+        p._first_transfer_timeout = 30.0
+        p._warm_pairs = {("rA", 0, 0)} if warm else set()
         # Skip the real rendezvous; hand _fetch_all one accepted recv.
         p._rendezvous_one = lambda ref, pynccl: (0, torch.zeros(4, dtype=torch.uint8))
 
@@ -466,22 +549,22 @@ class TestRecvLaunchSerialized(unittest.TestCase):
         cache = CommCache(build_fn=lambda u, r: 7, abort_fn=lambda i: None)
         cache.get_or_create(("rA", 0, 0), uid_chars=[1], local_rank=1)
 
-        p = _Packer()
-        p._nccl_dp_rendezvous = object()
-        p._nccl_dp_comm_cache = cache
-        p._nccl_dp_device = None
-        p._nccl_dp_streams = None
-        p._nccl_dp_receiver_rank = 0
-        p._nccl_dp_recv_timeout = 5.0
-        p._nccl_dp_first_transfer_timeout = 30.0
-        p._nccl_dp_warm_pairs = set()  # warming -> failing recv just retries
-        p._nccl_dp_recv_lock = threading.Lock()
+        p = NCCLTransportStrategy()
+        p._rendezvous = object()
+        p._comm_cache = cache
+        p._device = None
+        p._streams = None
+        p._receiver_rank = 0
+        p._recv_timeout = 5.0
+        p._first_transfer_timeout = 30.0
+        p._warm_pairs = set()  # warming -> failing recv just retries
+        p._recv_lock = threading.Lock()
         p._rendezvous_one = lambda ref, pynccl: (0, torch.zeros(4, dtype=torch.uint8))
 
         held = []
 
         def _recv(*a, **k):
-            held.append(p._nccl_dp_recv_lock.locked())
+            held.append(p._recv_lock.locked())
             # Raise so posted stays empty -> return before the unpack loop; the
             # lock must already be held at the point of the NCCL launch.
             raise RuntimeError("stop after lock check")
@@ -490,7 +573,7 @@ class TestRecvLaunchSerialized(unittest.TestCase):
             p._fetch_all([(0, _ref())])
 
         self.assertEqual(held, [True])  # launch happened WITH the lock held
-        self.assertFalse(p._nccl_dp_recv_lock.locked())  # released afterwards
+        self.assertFalse(p._recv_lock.locked())  # released afterwards
 
     def test_fetch_all_lazily_creates_lock_without_setup(self):
         # A bare harness that skips _setup_nccl_data_packer leaves the lock None;
@@ -503,23 +586,23 @@ class TestRecvLaunchSerialized(unittest.TestCase):
         cache = CommCache(build_fn=lambda u, r: 1, abort_fn=lambda i: None)
         cache.get_or_create(("rA", 0, 0), uid_chars=[1], local_rank=1)
 
-        p = _Packer()
-        p._nccl_dp_rendezvous = object()
-        p._nccl_dp_comm_cache = cache
-        p._nccl_dp_device = None
-        p._nccl_dp_streams = None
-        p._nccl_dp_receiver_rank = 0
-        p._nccl_dp_recv_timeout = 5.0
-        p._nccl_dp_first_transfer_timeout = 30.0
-        p._nccl_dp_warm_pairs = set()
-        self.assertIsNone(p._nccl_dp_recv_lock)  # setup skipped
+        p = NCCLTransportStrategy()
+        p._rendezvous = object()
+        p._comm_cache = cache
+        p._device = None
+        p._streams = None
+        p._receiver_rank = 0
+        p._recv_timeout = 5.0
+        p._first_transfer_timeout = 30.0
+        p._warm_pairs = set()
+        self.assertIsNone(p._recv_lock)  # setup skipped
         p._rendezvous_one = lambda ref, pynccl: (0, torch.zeros(4, dtype=torch.uint8))
 
         with mock.patch.object(
             pynccl_mod, "nccl_recv", mock.Mock(side_effect=RuntimeError("x"))
         ):
             p._fetch_all([(0, _ref())])  # must not raise TypeError
-        self.assertIsNotNone(p._nccl_dp_recv_lock)  # lazily created
+        self.assertIsNotNone(p._recv_lock)  # lazily created
 
 
 class TestRecvSyncFailureContained(unittest.TestCase):
@@ -536,23 +619,23 @@ class TestRecvSyncFailureContained(unittest.TestCase):
         import torch
 
         import cosmos_rl.utils.pynccl as pynccl_mod
-        from cosmos_rl.utils.payload_transport.nccl import data_packer_mixin as dpm
+        from cosmos_rl.utils.payload_transport.nccl import strategy as dpm
         from cosmos_rl.utils.payload_transport.nccl.comm_cache import CommCache
 
         aborted = []
         cache = CommCache(build_fn=lambda u, r: 9, abort_fn=lambda i: aborted.append(i))
         cache.get_or_create(("rA", 0, 0), uid_chars=[1], local_rank=1)
 
-        p = _Packer()
-        p._nccl_dp_rendezvous = object()
-        p._nccl_dp_comm_cache = cache
-        p._nccl_dp_device = None
-        p._nccl_dp_streams = None
-        p._nccl_dp_receiver_rank = 0
-        p._nccl_dp_recv_timeout = 5.0
-        p._nccl_dp_first_transfer_timeout = 30.0
-        p._nccl_dp_warm_pairs = {("rA", 0, 0)}  # warm -> eligible for quarantine
-        p._nccl_dp_recv_lock = threading.Lock()
+        p = NCCLTransportStrategy()
+        p._rendezvous = object()
+        p._comm_cache = cache
+        p._device = None
+        p._streams = None
+        p._receiver_rank = 0
+        p._recv_timeout = 5.0
+        p._first_transfer_timeout = 30.0
+        p._warm_pairs = {("rA", 0, 0)}  # warm -> eligible for quarantine
+        p._recv_lock = threading.Lock()
         p._rendezvous_one = lambda ref, pynccl: (0, torch.zeros(4, dtype=torch.uint8))
 
         bad_stream = mock.Mock()
@@ -606,7 +689,7 @@ class TestReceiverRenegotiation(unittest.TestCase):
             "sender_replica": "rA",
             "sender_rank": 0,
             "transfer_id": "0:x",
-            "schema": p._nccl_dp_schema,
+            "schema": p._schema,
         }
 
         out = p._rendezvous_one(ref, None)
@@ -791,12 +874,12 @@ class TestUidTtlCoversColdStart(unittest.TestCase):
         packer = NCCLDataPackerMixin()
         with (
             mock.patch(
-                "cosmos_rl.utils.payload_transport.nccl.data_packer_mixin.NcclRendezvous",
+                "cosmos_rl.utils.payload_transport.nccl.strategy.NcclRendezvous",
                 _RvSpy,
             ),
             mock.patch.object(packer, "_setup_prefetch", lambda **kw: None),
             mock.patch(
-                "cosmos_rl.utils.payload_transport.nccl.data_packer_mixin."
+                "cosmos_rl.utils.payload_transport.nccl.strategy."
                 "get_transfer_stream_pool",
                 lambda **kw: None,
             ),

--- a/tests/test_nccl_e2e.py
+++ b/tests/test_nccl_e2e.py
@@ -65,7 +65,7 @@ def _make_trajectory(device, ep_len=8, obs_dim=4, action_dim=2):
     }
 
 
-def _worker(rank: int, world_size: int, err_queue):
+def _worker(rank: int, world_size: int, err_queue, composed: bool = False):
     """Entry point for each spawned rank.  Reports failures via err_queue."""
     try:
         import redis
@@ -103,16 +103,34 @@ def _worker(rank: int, world_size: int, err_queue):
                 time.sleep(0.05)
             producer.cleanup_nccl()
         else:
-            # Consumer.
-            packer = _ConsumerPacker()
-            packer._setup_nccl_data_packer(
-                device=device,
-                redis_client=client,
-                config=config,
-                prefetch_timeout=30.0,
-                max_attempts=3,
-                recv_timeout=10.0,
-            )
+            # Consumer, built one of the two supported ways.  Both must move
+            # real bytes GPU->GPU; the composed path is otherwise only covered
+            # by CPU tests with a fake transport.
+            if composed:
+                from cosmos_rl.utils.payload_transport.nccl.strategy import (
+                    compose_nccl_transport,
+                )
+
+                packer = _ComposedPacker()
+                compose_nccl_transport(
+                    packer,
+                    device=device,
+                    redis_client=client,
+                    config=config,
+                    prefetch_timeout=30.0,
+                    max_attempts=3,
+                    recv_timeout=10.0,
+                )
+            else:
+                packer = _ConsumerPacker()
+                packer._setup_nccl_data_packer(
+                    device=device,
+                    redis_client=client,
+                    config=config,
+                    prefetch_timeout=30.0,
+                    max_attempts=3,
+                    recv_timeout=10.0,
+                )
             # Wait for the producer's metadata.
             raw = None
             deadline = time.monotonic() + 30
@@ -129,7 +147,14 @@ def _worker(rank: int, world_size: int, err_queue):
             expected = _make_trajectory(device)["observations"]
             assert torch.allclose(obs.float(), expected), "payload mismatch"
             client.set(_DONE_KEY, "1")
-            packer.shutdown_nccl_data_packer()
+            if composed:
+                # No transport-specific teardown to call: shutdown_prefetch
+                # defaults before_join to the attached strategy, which is the
+                # abort that lets a parked recv fail fast.
+                packer.shutdown_prefetch()
+                packer._transport_strategy.shutdown()
+            else:
+                packer.shutdown_nccl_data_packer()
     except Exception as e:  # pragma: no cover - surfaced to the parent
         import traceback
 
@@ -164,8 +189,16 @@ try:
     class _ConsumerPacker(_NCCLDataPackerMixin, _BaseTrajPacker):
         pass
 
+    from cosmos_rl.utils.payload_transport.prefetch_mixin import (
+        PrefetchDataPackerMixin as _PrefetchDataPackerMixin,
+    )
+
+    class _ComposedPacker(_PrefetchDataPackerMixin, _BaseTrajPacker):
+        """No NCCL ancestry -- the transport arrives as an attached strategy."""
+
 except Exception:  # pragma: no cover - import guarded for CPU-only collection
     _ConsumerPacker = None
+    _ComposedPacker = None
 
 
 def _ensure_redis() -> bool:
@@ -242,13 +275,14 @@ class TestNcclE2E(unittest.TestCase):
         for key in (_META_KEY, _DONE_KEY):
             self.client.delete(key)
 
-    def test_two_rank_roundtrip(self):
+    def _run_roundtrip(self, composed: bool):
         import torch.multiprocessing as mp
 
         ctx = mp.get_context("spawn")
         err_queue = ctx.Queue()
         procs = [
-            ctx.Process(target=_worker, args=(rank, 2, err_queue)) for rank in range(2)
+            ctx.Process(target=_worker, args=(rank, 2, err_queue, composed))
+            for rank in range(2)
         ]
         for p in procs:
             p.start()
@@ -263,6 +297,20 @@ class TestNcclE2E(unittest.TestCase):
                 p.terminate()
                 errors.append("a rank hung and was terminated")
         self.assertEqual(errors, [], "\n".join(errors))
+
+    def test_two_rank_roundtrip(self):
+        """Consumer built by subclassing the NCCL mixin (the original path)."""
+        self._run_roundtrip(composed=False)
+
+    def test_two_rank_roundtrip_composed(self):
+        """Consumer built by COMPOSING the transport -- no NCCL ancestry.
+
+        The composed path's other coverage is CPU-only with a stand-in
+        transport, so without this it never actually moves bytes between two
+        GPUs. Same assertions as above: if composition wires anything
+        differently, the payload comes back wrong or not at all.
+        """
+        self._run_roundtrip(composed=True)
 
 
 if __name__ == "__main__":

--- a/tests/test_nccl_rollout_mixin.py
+++ b/tests/test_nccl_rollout_mixin.py
@@ -576,7 +576,7 @@ class TestGpuPackUnpackRoundtrip(unittest.TestCase):
     """
 
     def test_pack_then_unpack_on_device(self):
-        from cosmos_rl.utils.payload_transport.nccl.data_packer_mixin import _unpack
+        from cosmos_rl.utils.payload_transport.nccl.strategy import _unpack
 
         device = torch.device("cuda:0")
         p = _make_producer()

--- a/tests/test_transport_strategy.py
+++ b/tests/test_transport_strategy.py
@@ -1,0 +1,407 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Composed-transport seam: does the scheduler actually route through a strategy?
+
+These drive the real scheduling layer -- background worker, cache, early-ack --
+rather than asserting that methods exist, because the failure this guards
+against is a hook that is *defined* but never *reached*: the packer would
+silently behave as if no transport were attached and every payload would take
+the fallback path.
+"""
+
+import threading
+import unittest
+import unittest.mock
+from typing import Any, Dict, List, Optional
+
+from cosmos_rl.utils.payload_transport.prefetch_mixin import PrefetchDataPackerMixin
+from cosmos_rl.utils.payload_transport.registry import make_transport_strategy
+from cosmos_rl.utils.payload_transport.strategy import PayloadTransportStrategy
+
+
+class _RecordingStrategy(PayloadTransportStrategy):
+    """Minimal strategy that records which hooks the scheduler invoked."""
+
+    def __init__(self, *, sync_result: Any = None):
+        self.calls: List[str] = []
+        self.payloads: Dict[str, Any] = {}
+        self.sync_result = sync_result
+        self.completed: List[tuple] = []
+        self.failed: List[str] = []
+        self.before_join_calls = 0
+        self.fetch_started = threading.Event()
+
+    # -- recognition ------------------------------------------------------
+    def should_intercept(self, rollout_output: Any) -> bool:
+        self.calls.append("should_intercept")
+        return isinstance(rollout_output, str) and rollout_output.startswith("ref:")
+
+    def cache_key(self, rollout_output: Any) -> str:
+        self.calls.append("cache_key")
+        return f"key::{rollout_output}"
+
+    # -- fetching ---------------------------------------------------------
+    def fetch_batch(self, tasks: List[Any]) -> Dict[str, Any]:
+        self.calls.append("fetch_batch")
+        self.fetch_started.set()
+        out = {}
+        for _idx, ro in tasks:
+            out[self.cache_key(ro)] = self.payloads.get(ro, {"payload": ro})
+        return out
+
+    def sync_fetch(self, rollout_output: Any) -> Optional[Any]:
+        self.calls.append("sync_fetch")
+        return self.sync_result
+
+    # -- telemetry --------------------------------------------------------
+    def on_prefetch_complete(self, batch_id, n_results, fetch_ms, step) -> None:
+        self.calls.append("on_prefetch_complete")
+        self.completed.append((batch_id, n_results, step))
+
+    def on_resolve_failed(self, rollout_output: Any, cache_key: str) -> None:
+        self.calls.append("on_resolve_failed")
+        self.failed.append(cache_key)
+
+    def before_join(self) -> None:
+        self.before_join_calls += 1
+
+
+class _BasePacker:
+    """Stands in for the real DataPacker below the mixin.
+
+    The mixin resolves a reference and hands the *resolved payload* down via
+    ``super().get_policy_input``, so tagging what arrives here is how we tell
+    "resolved through the strategy" from "passed through untouched".
+    """
+
+    def get_policy_input(
+        self, sample=None, rollout_output=None, n_ignore_prefix_tokens=0, **kw
+    ):
+        return {"received": rollout_output}
+
+
+class _Packer(PrefetchDataPackerMixin, _BasePacker):
+    pass
+
+
+class TestStrategyDelegation(unittest.TestCase):
+    def setUp(self):
+        self.packer = _Packer()
+        self.strategy = _RecordingStrategy()
+        self.packer.set_transport_strategy(self.strategy)
+
+    def tearDown(self):
+        self.packer.shutdown_prefetch(join_timeout=5.0)
+
+    def test_prefetched_payload_is_served_from_the_strategy(self):
+        """The whole point: a ref resolves via the strategy, not the fallback."""
+        self.packer._setup_prefetch(prefetch_timeout=10.0)
+        self.packer.start_prefetch(["ref:a", "ref:b"])
+        self.packer.wait_prefetch()
+
+        out = self.packer.get_policy_input(rollout_output="ref:a")
+        # Resolved by the strategy, then handed to the base packer.
+        self.assertEqual(out, {"received": {"payload": "ref:a"}})
+        self.assertIn("fetch_batch", self.strategy.calls)
+
+    def test_non_matching_payload_falls_through_untouched(self):
+        """should_intercept gates the whole path; a plain payload must pass by."""
+        self.packer._setup_prefetch(prefetch_timeout=10.0)
+        out = self.packer.get_policy_input(rollout_output="plain-text")
+        # Reached the base packer unresolved -- exactly as handed in.
+        self.assertEqual(out, {"received": "plain-text"})
+        self.assertNotIn("fetch_batch", self.strategy.calls)
+
+    def test_cache_miss_falls_back_to_strategy_sync_fetch(self):
+        self.strategy.sync_result = {"payload": "from-sync"}
+        self.packer._setup_prefetch(prefetch_timeout=10.0)
+
+        # Never prefetched, so the cache cannot serve it.
+        out = self.packer.get_policy_input(rollout_output="ref:never-prefetched")
+        self.assertEqual(out, {"received": {"payload": "from-sync"}})
+        self.assertIn("sync_fetch", self.strategy.calls)
+
+    def test_unresolvable_reference_reports_through_on_resolve_failed(self):
+        self.strategy.sync_result = None  # both cache and sync come up empty
+        self.packer._setup_prefetch(prefetch_timeout=10.0)
+
+        self.packer.get_policy_input(rollout_output="ref:gone")
+        self.assertEqual(self.strategy.failed, ["key::ref:gone"])
+
+    def test_on_prefetch_complete_receives_the_iteration_counter(self):
+        """step is passed in rather than read off the packer -- verify it advances."""
+        self.packer._setup_prefetch(prefetch_timeout=10.0)
+        for _ in range(2):
+            self.packer.start_prefetch(["ref:a"])
+            self.packer.wait_prefetch()
+
+        steps = [step for (_bid, _n, step) in self.strategy.completed]
+        self.assertEqual(len(steps), 2)
+        self.assertEqual(steps, sorted(steps))
+        self.assertGreater(steps[-1], 0)
+
+    def test_shutdown_calls_strategy_before_join_by_default(self):
+        """Teardown must unwedge transport I/O without the caller arranging it."""
+        self.packer._setup_prefetch(prefetch_timeout=10.0)
+        self.packer.shutdown_prefetch(join_timeout=5.0)
+        self.assertEqual(self.strategy.before_join_calls, 1)
+
+    def test_explicit_before_join_overrides_the_strategy(self):
+        self.packer._setup_prefetch(prefetch_timeout=10.0)
+        called = []
+        self.packer.shutdown_prefetch(
+            join_timeout=5.0, before_join=lambda: called.append(1)
+        )
+        self.assertEqual(called, [1])
+        self.assertEqual(self.strategy.before_join_calls, 0)
+
+
+class TestWithoutStrategy(unittest.TestCase):
+    """No strategy attached: the mixin must stay an inert pass-through."""
+
+    def setUp(self):
+        self.packer = _Packer()
+
+    def test_never_intercepts(self):
+        self.assertFalse(self.packer._should_intercept("ref:a"))
+        out = self.packer.get_policy_input(rollout_output="ref:a")
+        self.assertEqual(out, {"received": "ref:a"})
+
+    def test_cache_key_and_fetch_batch_still_raise(self):
+        with self.assertRaises(NotImplementedError):
+            self.packer._cache_key("ref:a")
+        with self.assertRaises(NotImplementedError):
+            self.packer._fetch_batch([(0, "ref:a")])
+
+    def test_detaching_restores_pass_through(self):
+        self.packer.set_transport_strategy(_RecordingStrategy())
+        self.assertTrue(self.packer._should_intercept("ref:a"))
+        self.packer.set_transport_strategy(None)
+        self.assertFalse(self.packer._should_intercept("ref:a"))
+
+
+class TestSubclassPathStillWins(unittest.TestCase):
+    """The mixin path predates strategies and must keep working unchanged."""
+
+    def test_subclass_override_beats_an_attached_strategy(self):
+        class _Overriding(_Packer):
+            def _should_intercept(self, rollout_output):
+                return rollout_output == "only-this"
+
+        packer = _Overriding()
+        packer.set_transport_strategy(_RecordingStrategy())
+
+        # The strategy would accept "ref:a"; the override must win.
+        self.assertFalse(packer._should_intercept("ref:a"))
+        self.assertTrue(packer._should_intercept("only-this"))
+
+    def test_subclass_hooks_work_with_no_strategy_at_all(self):
+        class _SubclassTransport(_Packer):
+            def _should_intercept(self, rollout_output):
+                return rollout_output == "mine"
+
+            def _cache_key(self, rollout_output):
+                return "k"
+
+            def _fetch_batch(self, tasks):
+                return {"k": {"payload": "via-subclass"}}
+
+        packer = _SubclassTransport()
+        packer._setup_prefetch(prefetch_timeout=10.0)
+        try:
+            packer.start_prefetch(["mine"])
+            packer.wait_prefetch()
+            self.assertEqual(
+                packer.get_policy_input(rollout_output="mine"),
+                {"received": {"payload": "via-subclass"}},
+            )
+        finally:
+            packer.shutdown_prefetch(join_timeout=5.0)
+
+
+class TestFactorySelectsFromConfig(unittest.TestCase):
+    """Selecting a transport from config is the whole point of the seam."""
+
+    @staticmethod
+    def _config(mode, tp=1, cp=1, pp=1):
+        class _Parallelism:
+            tp_size, cp_size, pp_size = tp, cp, pp
+
+        class _Policy:
+            parallelism = _Parallelism()
+
+        class _Config:
+            policy = _Policy()
+            custom = {} if mode is None else {"payload_transfer": mode}
+
+        return _Config()
+
+    def test_builds_the_transport_the_config_names(self):
+        from cosmos_rl.utils.payload_transport.nccl.strategy import (
+            NCCLTransportStrategy,
+        )
+        from cosmos_rl.utils.payload_transport.ucxx.strategy import (
+            UCXXTransportStrategy,
+        )
+
+        self.assertIsInstance(
+            make_transport_strategy(self._config("nccl")), NCCLTransportStrategy
+        )
+        self.assertIsInstance(
+            make_transport_strategy(self._config("ucxx")), UCXXTransportStrategy
+        )
+
+    def test_redis_needs_no_strategy(self):
+        """redis moves payloads through the control plane -- nothing to compose.
+
+        None is the right answer rather than a null object: an unattached packer
+        already passes everything through, which is exactly redis's behaviour.
+        """
+        self.assertIsNone(make_transport_strategy(self._config(None)))
+
+    def test_rejects_a_topology_neither_transport_can_serve(self):
+        """The guard must fire here too, not just on the mixin path.
+
+        Both transports deliver a payload to exactly one receiver, so a split
+        topology has to fail loudly at selection rather than hang mid-run.
+        """
+        for mode in ("nccl", "ucxx"):
+            for kw in ({"tp": 2}, {"cp": 2}, {"pp": 2}):
+                with self.subTest(mode=mode, **kw):
+                    with self.assertRaises(ValueError):
+                        make_transport_strategy(self._config(mode, **kw))
+
+    def test_a_factory_built_strategy_drives_the_packer(self):
+        """End-to-end: config -> strategy -> attached -> intercepts."""
+        packer = _Packer()
+        strategy = make_transport_strategy(self._config("nccl"))
+        packer.set_transport_strategy(strategy)
+        # NCCL's wire format, recognised without any subclassing.
+        self.assertTrue(packer._should_intercept({"_nccl": True}))
+        self.assertFalse(packer._should_intercept("plain-text"))
+
+
+class TestComposedPackerAttaches(unittest.TestCase):
+    """A packer with NO transport ancestry must still get wired by attach.
+
+    This is the payoff of the whole refactor: a consumer keeps one packer class
+    and lets config pick the transport.  It only works if attach_data_packer
+    recognises a packer that merely schedules -- otherwise the strategy is
+    never set up (device and the redis client exist only at attach time) and
+    every payload silently takes the fallback path.
+    """
+
+    def test_ucxx_attach_wires_a_plain_scheduling_packer(self):
+        from cosmos_rl.utils.payload_transport.ucxx import transport as ucxx_transport
+
+        packer = _Packer()  # PrefetchDataPackerMixin + a plain base, no UCXX ancestry
+        self.assertFalse(hasattr(packer, "_setup_ucxx_data_packer"))
+
+        captured = {}
+
+        def _fake_compose(pk, **kw):
+            captured["packer"] = pk
+            captured["kwargs"] = kw
+
+        with unittest.mock.patch(
+            "cosmos_rl.utils.payload_transport.ucxx.strategy.compose_ucxx_transport",
+            _fake_compose,
+        ):
+            ucxx_transport.UCXXPayloadTransport().attach_data_packer(
+                packer, config=_cfg(), device="cpu"
+            )
+
+        self.assertIs(captured.get("packer"), packer)
+        # Tunables still come from the shared resolution, not a second copy.
+        self.assertIn("prefetch_timeout", captured.get("kwargs", {}))
+        self.assertIn("read_timeout", captured.get("kwargs", {}))
+
+    def test_a_transport_mixin_packer_still_takes_the_mixin_path(self):
+        """Back-compat: subclassing must keep winning over composition."""
+        from cosmos_rl.utils.payload_transport.ucxx.data_packer_mixin import (
+            UCXXDataPackerMixin,
+        )
+
+        class _MixinPacker(UCXXDataPackerMixin, _BasePacker):
+            pass
+
+        packer = _MixinPacker()
+        self.assertTrue(callable(packer._setup_ucxx_data_packer))
+
+
+def _cfg():
+    class _Config:
+        custom = {"ucxx_prefetch_timeout": 12.0, "ucxx_read_timeout": 3.0}
+
+    return _Config()
+
+
+class TestStrategyTelemetryCountsTheBatch(unittest.TestCase):
+    """The real strategies must accumulate the BATCH's figures.
+
+    `on_prefetch_complete` receives `n_results`, which the base passes as
+    `len(self._prefetch_cache)` -- the whole double-buffered cache, not this
+    batch. Accumulating that over-counts every step, and reading a byte total
+    that was never set silently reports 0.0 MB forever. Both are invisible
+    unless something asserts on the counters, so this does.
+    """
+
+    def _nccl(self):
+        from cosmos_rl.utils.payload_transport.nccl.strategy import (
+            NCCLTransportStrategy,
+        )
+
+        return NCCLTransportStrategy()
+
+    def _ucxx(self):
+        from cosmos_rl.utils.payload_transport.ucxx.strategy import (
+            UCXXTransportStrategy,
+        )
+
+        return UCXXTransportStrategy()
+
+    def test_nccl_totals_track_the_batch_not_the_cache(self):
+        s = self._nccl()
+        s._last_count, s._last_bytes = 3, 4096
+        # n_results is deliberately larger: it is the cache size, not the batch.
+        s.on_prefetch_complete(batch_id=1, n_results=50, fetch_ms=12.0, step=1)
+        self.assertEqual(s._total_nccl, 3)
+        self.assertEqual(s._total_bytes, 4096)
+
+        s._last_count, s._last_bytes = 2, 1024
+        s.on_prefetch_complete(batch_id=2, n_results=50, fetch_ms=8.0, step=2)
+        self.assertEqual(s._total_nccl, 5)
+        self.assertEqual(s._total_bytes, 5120)
+
+    def test_ucxx_totals_track_the_batch_not_the_cache(self):
+        s = self._ucxx()
+        s._last_count, s._last_bytes = 3, 4096
+        s.on_prefetch_complete(batch_id=1, n_results=50, fetch_ms=12.0, step=1)
+        self.assertEqual(s._total_ucxx, 3)
+        self.assertEqual(s._total_bytes, 4096)
+
+    def test_bytes_are_not_silently_zero(self):
+        """The failure mode was a byte total that never left 0."""
+        for s in (self._nccl(), self._ucxx()):
+            s._last_count, s._last_bytes = 1, 8192
+            s.on_prefetch_complete(batch_id=1, n_results=1, fetch_ms=1.0, step=1)
+            self.assertGreater(
+                s._total_bytes, 0, f"{type(s).__name__} reported 0 bytes"
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_ucxx_data_packer_mixin.py
+++ b/tests/test_ucxx_data_packer_mixin.py
@@ -39,6 +39,7 @@ from typing import Any, List
 from cosmos_rl.utils.payload_transport.ucxx.data_packer_mixin import (
     UCXXDataPackerMixin,
 )
+from cosmos_rl.utils.payload_transport.ucxx.strategy import UCXXTransportStrategy
 
 
 class _StubDataPacker:
@@ -72,7 +73,16 @@ class _StubDataPacker:
 
 
 class _Packer(UCXXDataPackerMixin, _StubDataPacker):
-    """MRO: UCXXDataPackerMixin first, then _StubDataPacker."""
+    """MRO: UCXXDataPackerMixin first, then _StubDataPacker.
+
+    Auto-attaches a strategy.  The transport moved off the mixin, so without
+    one the hooks are pass-throughs by design and these tests would exercise
+    nothing -- setup is what normally attaches it, and most tests here skip it.
+    """
+
+    def __init__(self):
+        super().__init__()
+        self.set_transport_strategy(UCXXTransportStrategy())
 
 
 # ---------------------------------------------------------------------------
@@ -193,7 +203,7 @@ class TestGetPolicyInputDispatch(unittest.TestCase):
             "_ucxx_port": 7000,
             "_slot": 5,
         }
-        cache_key = UCXXDataPackerMixin._ucxx_dp_cache_key(ref)
+        cache_key = UCXXTransportStrategy._ref_cache_key(ref)
         # Inject directly into the cache (bypass UCXX entirely).
         self.p._ucxx_dp_prefetch_cache = {cache_key: resolved}
 
@@ -211,7 +221,7 @@ class TestGetPolicyInputDispatch(unittest.TestCase):
 
 class TestCacheKey(unittest.TestCase):
     def test_cache_key_format(self):
-        key = UCXXDataPackerMixin._ucxx_dp_cache_key(
+        key = UCXXTransportStrategy._ref_cache_key(
             {
                 "_worker_ip": "10.0.0.1",
                 "_ucxx_port": 7000,
@@ -223,7 +233,7 @@ class TestCacheKey(unittest.TestCase):
     def test_cache_key_handles_missing_fields(self):
         # Missing fields should yield a still-deterministic string so
         # collisions show up rather than crashes.
-        key = UCXXDataPackerMixin._ucxx_dp_cache_key({"_worker_ip": "x"})
+        key = UCXXTransportStrategy._ref_cache_key({"_worker_ip": "x"})
         self.assertIn("x:", key)
 
 

--- a/tests/test_ucxx_e2e.py
+++ b/tests/test_ucxx_e2e.py
@@ -1,0 +1,247 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Gated 2-process end-to-end test for the UCXX payload transport.
+
+The NCCL counterpart (``test_nccl_e2e.py``) has existed for a while; UCXX had
+no equivalent, so every claim about it rested on CPU unit tests driving a
+stand-in client.  This moves a real trajectory between two GPUs over a real
+UCXX endpoint: rank 0 writes into its shared ring buffer and serves it, rank 1
+resolves the reference through the consumer packer and compares the payload
+against the source tensor.
+
+Both consumer construction paths are covered -- subclassing ``UCXXDataPackerMixin``
+and composing ``UCXXTransportStrategy`` -- because a transport that wires
+differently under composition would surface exactly here and nowhere else.
+
+Unlike NCCL, UCXX needs no control plane: the rendezvous *is* the metadata the
+producer returns (worker ip, port, slot).  A ``multiprocessing.Queue`` carries
+it between the two ranks, so this test has no Redis dependency at all.
+
+Self-skips unless CUDA has >= 2 devices and the ``ucxx`` extra is installed.
+
+    pytest tests/test_ucxx_e2e.py -q
+"""
+
+import unittest
+
+import torch
+
+_EP_LEN = 8
+_OBS_DIM = 4
+_ACTION_DIM = 2
+
+try:
+    from cosmos_rl.utils.payload_transport.ucxx import UCXX_AVAILABLE
+except Exception:  # pragma: no cover - package absent entirely
+    UCXX_AVAILABLE = False
+
+
+def _free_base_port(span: int = 8) -> int:
+    """Find a base port with `span` consecutive free ports above it.
+
+    The UCXX server binds base+0..base+n_server_threads-1, so a single free
+    port is not enough.
+    """
+    import socket
+
+    for _ in range(50):
+        with socket.socket() as probe:
+            probe.bind(("127.0.0.1", 0))
+            base = probe.getsockname()[1]
+        socks = []
+        try:
+            for off in range(span):
+                sk = socket.socket()
+                sk.bind(("127.0.0.1", base + off))
+                socks.append(sk)
+        except OSError:
+            continue
+        finally:
+            for sk in socks:
+                sk.close()
+        return base
+    raise RuntimeError("no run of free ports found")
+
+
+def _make_trajectory(device, ep_len=_EP_LEN):
+    return {
+        "observations": torch.arange(
+            ep_len * _OBS_DIM, dtype=torch.float32, device=device
+        ).reshape(ep_len, _OBS_DIM),
+        "actions": torch.ones(ep_len, _ACTION_DIM, dtype=torch.float32, device=device),
+        "rewards": torch.arange(ep_len, dtype=torch.float32, device=device),
+        "episode_length": ep_len,
+    }
+
+
+def _producer(meta_q, done_q, err_q):
+    """Rank 0: serve one trajectory out of a real UCXX endpoint."""
+    try:
+        from cosmos_rl.utils.payload_transport.ucxx import UCXXRolloutMixin
+
+        torch.cuda.set_device(0)
+        device = torch.device("cuda:0")
+
+        rollout = UCXXRolloutMixin()
+        rollout.setup_ucxx(
+            replica_id="rollout-0",
+            max_steps=_EP_LEN,
+            obs_dim=_OBS_DIM,
+            action_dim=_ACTION_DIM,
+            # A BASE port, not a request to auto-assign: the server runs
+            # n_server_threads listeners at base+0..base+n-1, so passing 0
+            # binds the reserved low ports and the consumer has nothing to
+            # reach. Reserve a run of free ports and hand over the first.
+            port=_free_base_port(),
+        )
+        meta = rollout.write_to_buffer(_make_trajectory(device))
+        assert meta is not None, "producer failed to write the trajectory"
+        assert meta.get("_ucxx"), f"metadata is not a UCXX reference: {meta!r}"
+        # Fail here, not later as an opaque "could not resolve": the server
+        # binds base+0..base+n-1, so a bad base port advertises something the
+        # consumer can never reach.
+        port = meta.get("_ucxx_port")
+        assert isinstance(port, int) and port > 1024, (
+            f"producer advertised an unusable port {port!r}; setup_ucxx takes a "
+            "BASE port, not a request to auto-assign"
+        )
+        meta_q.put(meta)
+
+        # Serve until the consumer confirms, bounded so a dead peer cannot hang
+        # the suite.
+        try:
+            done_q.get(timeout=120)
+        except Exception:
+            pass
+        rollout.cleanup_ucxx()
+    except Exception as e:  # pragma: no cover - surfaced to the parent
+        import traceback
+
+        err_q.put(f"producer: {e}\n{traceback.format_exc()}")
+
+
+def _consumer(meta_q, done_q, err_q, composed: bool):
+    """Rank 1: resolve the reference and check the bytes actually arrived."""
+    try:
+        torch.cuda.set_device(1)
+        device = torch.device("cuda:1")
+
+        class _BaseTrajPacker:
+            # Mirrors the real DataPacker signature: the prefetch mixin
+            # delegates positionally via super().
+            def get_policy_input(
+                self, sample=None, rollout_output=None, n_ignore_prefix_tokens=0, **kw
+            ):
+                return rollout_output
+
+        if composed:
+            from cosmos_rl.utils.payload_transport.prefetch_mixin import (
+                PrefetchDataPackerMixin,
+            )
+            from cosmos_rl.utils.payload_transport.ucxx.strategy import (
+                compose_ucxx_transport,
+            )
+
+            class _Packer(PrefetchDataPackerMixin, _BaseTrajPacker):
+                """No UCXX ancestry -- the transport is an attached strategy."""
+
+            packer = _Packer()
+            compose_ucxx_transport(
+                packer, device=device, prefetch_timeout=60.0, read_timeout=30.0
+            )
+        else:
+            from cosmos_rl.utils.payload_transport.ucxx import UCXXDataPackerMixin
+
+            class _Packer(UCXXDataPackerMixin, _BaseTrajPacker):
+                pass
+
+            packer = _Packer()
+            packer._setup_ucxx_data_packer(
+                device=device, prefetch_timeout=60.0, read_timeout=30.0
+            )
+
+        meta = meta_q.get(timeout=120)
+        assert packer._should_intercept(meta), (
+            f"consumer did not recognise the producer's reference: {meta!r}"
+        )
+
+        resolved = packer.get_policy_input(rollout_output=meta)
+        assert resolved is not None, "consumer failed to resolve the UCXX ref"
+        obs = resolved["observations"]
+        expected = _make_trajectory(device)["observations"]
+        assert obs.shape == expected.shape, f"shape {obs.shape} != {expected.shape}"
+        assert torch.allclose(obs.float(), expected), "payload mismatch"
+
+        done_q.put(1)
+        if composed:
+            # No transport-specific teardown exists for a composed packer:
+            # shutdown_prefetch defaults before_join to the attached strategy,
+            # and UCXX deliberately closes its client afterwards rather than
+            # aborting mid-flight.
+            packer.shutdown_prefetch()
+            packer._transport_strategy.shutdown()
+        else:
+            packer.shutdown_ucxx_data_packer()
+    except Exception as e:  # pragma: no cover - surfaced to the parent
+        import traceback
+
+        err_q.put(f"consumer: {e}\n{traceback.format_exc()}")
+        try:
+            done_q.put(1)  # never leave the producer parked on our account
+        except Exception:
+            pass
+
+
+@unittest.skipUnless(
+    torch.cuda.is_available() and torch.cuda.device_count() >= 2,
+    "requires >= 2 CUDA devices for a real UCXX transfer",
+)
+@unittest.skipUnless(UCXX_AVAILABLE, "requires the 'ucxx' extra")
+class TestUcxxE2E(unittest.TestCase):
+    def _run_roundtrip(self, composed: bool):
+        import torch.multiprocessing as mp
+
+        ctx = mp.get_context("spawn")
+        meta_q, done_q, err_q = ctx.Queue(), ctx.Queue(), ctx.Queue()
+        procs = [
+            ctx.Process(target=_producer, args=(meta_q, done_q, err_q)),
+            ctx.Process(target=_consumer, args=(meta_q, done_q, err_q, composed)),
+        ]
+        for p in procs:
+            p.start()
+        for p in procs:
+            p.join(timeout=180)
+
+        errors = []
+        while not err_q.empty():
+            errors.append(err_q.get())
+        for p in procs:
+            if p.is_alive():
+                p.terminate()
+                errors.append("a rank hung and was terminated")
+        self.assertEqual(errors, [], "\n".join(errors))
+
+    def test_two_process_roundtrip(self):
+        """Consumer built by subclassing UCXXDataPackerMixin."""
+        self._run_roundtrip(composed=False)
+
+    def test_two_process_roundtrip_composed(self):
+        """Consumer built by COMPOSING the transport -- no UCXX ancestry."""
+        self._run_roundtrip(composed=True)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_ucxx_fetch_engine.py
+++ b/tests/test_ucxx_fetch_engine.py
@@ -43,8 +43,14 @@ import numpy as np
 import torch
 
 from cosmos_rl.utils.payload_transport.ucxx.data_packer_mixin import (
-    _MAX_FETCH_ROUNDS,
     UCXXDataPackerMixin,
+)
+
+# The fetch engine and its round cap moved to the strategy that the mixin
+# now composes; these tests drive that engine directly.
+from cosmos_rl.utils.payload_transport.ucxx.strategy import (
+    _MAX_FETCH_ROUNDS,
+    UCXXTransportStrategy,
 )
 
 # Imported from the data-packer layer, which owns the trajectory field names
@@ -127,17 +133,17 @@ def _meta(slot=1, ip="10.0.0.1", port=7000):
 
 
 def _make_consumer(client, *, max_attempts=2, device="cpu"):
-    p = _Packer()
-    p._ucxx_dp_client = client
-    p._ucxx_dp_device = device
-    p._ucxx_dp_max_attempts = max_attempts
-    p._ucxx_dp_read_timeout = 0.01
+    p = UCXXTransportStrategy()
+    p._client = client
+    p._device = device
+    p._max_attempts = max_attempts
+    p._read_timeout = 0.01
     return p
 
 
 def _fetch(p, metas):
     """Drive the real entry point: [(idx, metadata), ...] -> {cache_key: data}."""
-    return p._fetch_batch([(i, m) for i, m in enumerate(metas)])
+    return p.fetch_batch([(i, m) for i, m in enumerate(metas)])
 
 
 class TestTransientRetryWithinARound(unittest.TestCase):
@@ -285,16 +291,16 @@ class TestSyncFetchContainment(unittest.TestCase):
     def test_returns_none_on_failure(self):
         client = _FakeClient({1: [StaleSlotError("gone")]})
         p = _make_consumer(client)
-        self.assertIsNone(p._sync_fetch(_meta(slot=1)))
+        self.assertIsNone(p.sync_fetch(_meta(slot=1)))
 
     def test_returns_none_when_the_client_is_absent(self):
         p = _make_consumer(None)
-        self.assertIsNone(p._sync_fetch(_meta(slot=1)))
+        self.assertIsNone(p.sync_fetch(_meta(slot=1)))
 
     def test_returns_data_on_success(self):
         client = _FakeClient({1: [_payload()]})
         p = _make_consumer(client)
-        got = p._sync_fetch(_meta(slot=1))
+        got = p.sync_fetch(_meta(slot=1))
         self.assertIsNotNone(got)
         self.assertIn(OBSERVATIONS, got)
 
@@ -303,9 +309,7 @@ class TestFetchAllReportsTiming(unittest.TestCase):
     def test_returns_results_and_both_timings(self):
         client = _FakeClient({1: [_payload()]})
         p = _make_consumer(client)
-        results, transfer_ms, copy_ms = asyncio.run(
-            p._ucxx_dp_fetch_all([(0, _meta(slot=1))])
-        )
+        results, transfer_ms, copy_ms = asyncio.run(p._fetch_all([(0, _meta(slot=1))]))
         self.assertIn(0, results)
         self.assertGreaterEqual(transfer_ms, 0.0)
         self.assertGreaterEqual(copy_ms, 0.0)


### PR DESCRIPTION
`PrefetchDataPackerMixin` owns scheduling — the background worker, the double-buffered cache, the early-ack handshake — and delegates every transport-specific decision to six hooks. Those hooks arrived by **mixing
a transport class into the packer**, which forces the choice to compile time: a consumer picks `NCCLSimpleRLDataPacker` or `UCXXSimpleRLDataPacker` before it has read any config.

cosmos-rl already selects the transport from config in `_attach_payload_transport`. Only the packer *class* could not follow.

This expresses the same six-hook contract as an object the packer holds:

```python
strategy = make_transport_strategy(config)   # nccl | ucxx | None for redis
packer.set_transport_strategy(strategy)
```

## What moved

The transports moved **verbatim**. The only changes are dropping the `_nccl_dp_` / `_ucxx_dp_` prefixes (state no longer shares a namespace with a packer) and taking the iteration counter as an argument.

| | before | after |
|---|---|---|
| `NCCLDataPackerMixin` | 861 | **127** |
| `UCXXDataPackerMixin` | 665 | **162** |

The difference is now `NCCLTransportStrategy` (826) and `UCXXTransportStrategy` (581). Keeping the move mechanical is deliberate: this is the code an 8-GPU run and the e2e probe validated, and a refactor is not the
 place to also rewrite it.

Both mixins remain, thin, because `attach_data_packer` dispatches on them and out-of-tree consumers subclass them.

## Details the contract had to settle

- **`on_prefetch_complete` takes the step counter as an argument.** The mixin form read `self._prefetch_step_count` off the packer — the one place a transport reached into scheduling state. A scan of both transport
s for `_prefetch*`, `super().`, and `self.config/device/redis_client` confirmed it was the only one.

- **`shutdown_prefetch` defaults `before_join` to the attached strategy**, so composing a transport does not also require remembering to wire its teardown.

- **UCXX deliberately does *not* implement `before_join`.** `ncclCommAbort` is designed to be called while a peer thread sits in a collective; closing a UCXX client from another thread while its worker is inside it
s own event loop has no such guarantee. UCXX keeps closing *after* a widened join.

- **`attach_data_packer` gained a composed path.** It dispatched only on `_setup_nccl_data_packer` / `redis_client`, so a composed packer would never be set up — `device` and the redis client exist only at attach t
ime. The new path reuses `_attach_via_mixin` **verbatim** via `functools.partial`, so the subtle tunable resolution (cold-start floors, batch hint) has exactly one copy. `compose_{nccl,ucxx}_transport` is now the s
ingle place that wiring lives; the mixins call it too, so the paths cannot drift.

- **`make_transport_strategy` returns `None` for redis**, which needs no strategy — an unattached packer already passes everything through. It runs the single-receiver guard first, matching `CommMixin`, so a topolo
gy neither transport can serve fails at selection rather than hanging mid-run.

## Validation

Hardware, on an 8-GPU node:

```
tests/test_nccl_e2e.py  ->  Ran 2 tests ... OK
```

**Both** roundtrips passed — the mixin path *and* the composed path — moving real bytes GPU→GPU. 36 suites completed with **0 failures**, including all 20 transport suites.

The companion rl-gym run trained **80/80 steps** through the composed packer, ~100 NCCL payload transfers:

```
policy data packer: TransportSimpleRLDataPacker (payload_transfer='nccl')
[NCCLTransportStrategy] Initialised: device=cuda:0, rank=0, max_attempts=2, recv_timeout=5.0s
[NCCLTransportStrategy] Iteration 50: 100 NCCL, avg 28 ms/iter
```

Locally, the CI file list was run on this branch and on `main` and the failure lists set-diffed: **identical, zero regressions**.

## New GPU coverage

The composed path had none — every composed-path test was CPU-only against a stand-in transport, which is the wrong kind of evidence for a transport refactor. Both e2e tests now run their roundtrip twice, once subc
lassed and once composed.

`tests/test_ucxx_e2e.py` is new outright: **UCXX had no end-to-end test at all**. It needs no control plane (UCXX's rendezvous *is* the producer's metadata), so a `multiprocessing.Queue` carries it and there is no
Redis dependency.

| | before | after |
|---|---|---|
| NCCL mixin path | ✅ | ✅ |
| NCCL composed | — | ✅ |
| UCXX mixin path | **none** | ✅ |
| UCXX composed | — | ✅ |