### PR TITLE
bound and configure rollout prompt prefetch

### DIFF
--- a/cosmos_rl/policy/config/__init__.py
+++ b/cosmos_rl/policy/config/__init__.py
@@ -1572,9 +1572,11 @@ class RolloutConfig(BaseModel):
         description=(
             "Maximum number of rollout prompt batches to keep in the bounded "
             "_prompt_queue when prefetch_rollout is enabled.  The default of 2 "
-            "preserves the original one-batch look-ahead behavior; increase it "
-            "only when deeper prompt/setup overlap is useful and the extra "
-            "queued payloads fit comfortably in memory."
+            "preserves the original one-batch look-ahead behavior.  Values above "
+            "2 are useful only for absorbing bursty fetch/setup latency; each "
+            "queued batch consumes the controller's samples_on_the_fly budget "
+            "and can engage the soft throttle earlier, so keep this small relative "
+            "to train.train_policy.allowed_outdated_steps."
         ),
     )
 

--- a/cosmos_rl/policy/config/__init__.py
+++ b/cosmos_rl/policy/config/__init__.py
@@ -1566,6 +1566,18 @@ class RolloutConfig(BaseModel):
         ),
     )
 
+    prefetch_queue_maxsize: int = Field(
+        default=2,
+        ge=1,
+        description=(
+            "Maximum number of rollout prompt batches to keep in the bounded "
+            "_prompt_queue when prefetch_rollout is enabled.  The default of 2 "
+            "preserves the original one-batch look-ahead behavior; increase it "
+            "only when deeper prompt/setup overlap is useful and the extra "
+            "queued payloads fit comfortably in memory."
+        ),
+    )
+
     broadcast_all_params: bool = Field(
         default=False,
         description=(

--- a/cosmos_rl/rollout/worker/rollout_control.py
+++ b/cosmos_rl/rollout/worker/rollout_control.py
@@ -162,19 +162,6 @@ class DisaggregatedRolloutControlWorker(RolloutWorkerBase):
         # ``work()`` / ``_main_loop_impl`` / ``_prefetch_loop`` ensures
         # we observe the post-override value at the points where the
         # decision actually matters.
-        #
-        # Bounded queue: in single-producer mode, ``_prefetch_loop``
-        # would otherwise race ahead of the consumer and queue
-        # arbitrarily many batches.  The default cap keeps the
-        # prefetcher exactly one batch ahead; users with heavier setup
-        # stages can increase it via ``prefetch_queue_maxsize``.  In
-        # legacy mode, queue depth never exceeds 1 anyway (``main_loop``
-        # only calls ``request_new_prompts`` when the queue is empty),
-        # so the cap is harmless there.
-        self._prompt_queue: Queue[List[RLPayload]] = Queue(
-            maxsize=self._prefetch_queue_maxsize
-        )
-
         # Vestigial lock from the dual-producer era: prior to the
         # single-producer-mode refactor, both ``main_loop`` (via
         # ``request_new_prompts``) and ``_prefetch_loop`` could put
@@ -197,6 +184,9 @@ class DisaggregatedRolloutControlWorker(RolloutWorkerBase):
         self.rollout: RolloutBase = RolloutRegistry.get_rollout_cls(
             self.config.rollout.backend
         )(self.config, self.parallel_dims, self.device)
+        # RolloutBase.__init__ has now run post_init_hook, so backend
+        # overrides of rollout queue settings are visible.
+        self._configure_prompt_queue()
 
         # communicator index for the cached communicators in C++ binding.
         self.global_commnicator_idex = -1
@@ -301,8 +291,8 @@ class DisaggregatedRolloutControlWorker(RolloutWorkerBase):
         ``__init__``: backends may flip ``prefetch_rollout`` from
         ``post_init_hook``, which runs *after* this constructor.
 
-        See the comment in ``__init__`` next to ``self._prompt_queue``
-        for the motivation.
+        See the comment in ``__init__`` next to
+        ``_configure_prompt_queue`` for the motivation.
 
         When True, ``_prefetch_loop`` is the *sole* producer for
         ``_prompt_queue`` and ``_main_loop_impl`` consumes only.
@@ -324,6 +314,12 @@ class DisaggregatedRolloutControlWorker(RolloutWorkerBase):
     def _prompt_fetch_target_depth(self, *, prep_overlap: bool) -> int:
         """Queue depth used by prompt-fetch loops."""
         return self._prefetch_queue_maxsize if prep_overlap else 1
+
+    def _configure_prompt_queue(self) -> None:
+        """Create the bounded prompt queue from post-backend config."""
+        self._prompt_queue: Queue[List[RLPayload]] = Queue(
+            maxsize=self._prefetch_queue_maxsize
+        )
 
     def setup(
         self,
@@ -2742,10 +2738,11 @@ class DisaggregatedRolloutControlWorker(RolloutWorkerBase):
         notify the rollout backend via ``submit_setup`` so
         :class:`RolloutGenerationMixin` can start ``_prepare_sample``
         on its own bg thread, then ``put`` onto ``_prompt_queue``.
-        Back-pressure is provided by the bounded queue: ``put``
-        blocks when ``main_loop`` is behind, so this thread runs
-        exactly as fast as the consumer drains -- no polling, no
-        ``time.sleep``, no lock.
+        Before leasing a prompt from the controller, the producer
+        waits for bounded-queue capacity.  Since this is the sole
+        producer, observing capacity reserves that slot until
+        ``put``; no extra prompt is leased or submitted for setup
+        while ``main_loop`` is behind.
 
         ``submit_setup`` is called *before* ``put`` so the bg setup
         worker has a head start.  By the time ``main_loop`` pops
@@ -2797,9 +2794,14 @@ class DisaggregatedRolloutControlWorker(RolloutWorkerBase):
                 if self.state.prompt_fetch_end():
                     return
 
-                # Sole producer: no lock, no empty-check (we always
-                # try to fetch the next batch and let the bounded
-                # queue's ``put`` back-pressure us off).
+                # Wait before leasing from the controller.  Checking
+                # capacity reserves the slot because this is the sole
+                # producer; only the consumer can change the queue
+                # before the matching put.
+                while self._prompt_queue.full():
+                    if self.shutdown_signal.wait(timeout=0.05):
+                        return
+
                 try:
                     payloads, is_end = self.api_client.get_next_prompt(
                         self.batch_size,

--- a/cosmos_rl/rollout/worker/rollout_control.py
+++ b/cosmos_rl/rollout/worker/rollout_control.py
@@ -163,14 +163,17 @@ class DisaggregatedRolloutControlWorker(RolloutWorkerBase):
         # we observe the post-override value at the points where the
         # decision actually matters.
         #
-        # Bounded queue (``maxsize=2``): in single-producer mode,
-        # ``_prefetch_loop`` would otherwise race ahead of the
-        # consumer and queue arbitrarily many batches.  Maxsize=2
-        # keeps the prefetcher exactly one batch ahead.  In legacy
-        # mode, queue depth never exceeds 1 anyway (``main_loop``
-        # only calls ``request_new_prompts`` when the queue is
-        # empty), so the cap is harmless there.
-        self._prompt_queue: Queue[List[RLPayload]] = Queue(maxsize=2)
+        # Bounded queue: in single-producer mode, ``_prefetch_loop``
+        # would otherwise race ahead of the consumer and queue
+        # arbitrarily many batches.  The default cap keeps the
+        # prefetcher exactly one batch ahead; users with heavier setup
+        # stages can increase it via ``prefetch_queue_maxsize``.  In
+        # legacy mode, queue depth never exceeds 1 anyway (``main_loop``
+        # only calls ``request_new_prompts`` when the queue is empty),
+        # so the cap is harmless there.
+        self._prompt_queue: Queue[List[RLPayload]] = Queue(
+            maxsize=self._prefetch_queue_maxsize
+        )
 
         # Vestigial lock from the dual-producer era: prior to the
         # single-producer-mode refactor, both ``main_loop`` (via
@@ -312,6 +315,15 @@ class DisaggregatedRolloutControlWorker(RolloutWorkerBase):
         return bool(
             self.config.rollout.prefetch_rollout and self.parallel_dims.world_size == 1
         )
+
+    @property
+    def _prefetch_queue_maxsize(self) -> int:
+        """Configured bounded prompt-queue size for prefetch look-ahead."""
+        return self.config.rollout.prefetch_queue_maxsize
+
+    def _prompt_fetch_target_depth(self, *, prep_overlap: bool) -> int:
+        """Queue depth used by prompt-fetch loops."""
+        return self._prefetch_queue_maxsize if prep_overlap else 1
 
     def setup(
         self,
@@ -2178,15 +2190,18 @@ class DisaggregatedRolloutControlWorker(RolloutWorkerBase):
             # drives ``request_new_prompts`` itself.
             if not self._single_producer_mode and not self.state.prompt_fetch_end():
                 # Legacy cadence fetches one batch when the queue is
-                # empty (depth 1).  Prep-overlap stages one batch ahead
-                # (depth 2): with a batch already queued, its per-prompt
+                # empty (depth 1).  Prep-overlap stages queued batches
+                # according to the same cap that bounds the prefetch
+                # queue: with a batch already queued, its per-prompt
                 # prep runs on the mixin's bg setup thread while the
                 # batch in front of it generates.  The fetch is a
                 # cross-rank collective, so every rank runs this loop in
                 # lockstep -- the loop bound (queue depth, prompt_fetch_end,
                 # whether the last fetch added a batch) is identical on
                 # all ranks.
-                target_depth = 2 if prep_overlap else 1
+                target_depth = self._prompt_fetch_target_depth(
+                    prep_overlap=prep_overlap
+                )
                 while (
                     not self.state.prompt_fetch_end()
                     and self._prompt_queue.qsize() < target_depth

--- a/tests/test_rollout_prefetch_loop_integration.py
+++ b/tests/test_rollout_prefetch_loop_integration.py
@@ -114,7 +114,9 @@ def _make_worker_for_prefetch(
         except StopIteration:
             return ([], True)
 
-    worker.api_client = SimpleNamespace(get_next_prompt=_get_next_prompt)
+    worker.api_client = SimpleNamespace(
+        get_next_prompt=MagicMock(side_effect=_get_next_prompt)
+    )
 
     # Fake rollout backend: records bind_prefetch_context/submit_setup
     # calls.  Mimics the surface a RolloutGenerationMixin-composing
@@ -362,10 +364,7 @@ class TestPrefetchLoopSubmitSetupWiring(unittest.TestCase):
         self.assertEqual(len(recorder), 2)
 
     def test_bounded_queue_back_pressure(self) -> None:
-        """``put`` blocks when the bounded queue is full; the producer
-        runs at the consumer's pace.  This is the back-pressure
-        mechanism that replaces the old 500 ms polling sleep.
-        """
+        """A full queue prevents the producer from leasing another batch."""
         recorder: List[List[dict]] = []
         # Many batches, small queue.  Producer should not race ahead.
         n_batches = 6
@@ -385,18 +384,23 @@ class TestPrefetchLoopSubmitSetupWiring(unittest.TestCase):
         thread = threading.Thread(target=worker._prefetch_loop, daemon=True)
         thread.start()
 
-        # Sleep without draining: queue should fill to maxsize=1 and
-        # producer should block on put.  After this sleep,
-        # exactly 1 batch should be queued and 1 submit_setup
-        # should have been recorded (the one currently blocked on
-        # put), or possibly 2 (the one in-queue plus the one stuck
-        # at put).  The strict invariant is that submit_setup has
-        # NOT been called n_batches times yet.
-        time.sleep(0.3)
-        self.assertLess(
+        deadline = time.monotonic() + 3.0
+        while worker._prompt_queue.qsize() < 1 and time.monotonic() < deadline:
+            time.sleep(0.005)
+        self.assertEqual(worker._prompt_queue.qsize(), 1)
+
+        # Leave the queue full long enough for an ungated producer to
+        # lease and submit the next batch before blocking on put.
+        time.sleep(0.1)
+        self.assertEqual(
+            worker.api_client.get_next_prompt.call_count,
+            1,
+            "a full queue must prevent another controller lease",
+        )
+        self.assertEqual(
             len(recorder),
-            n_batches,
-            "producer must not race ahead of bounded queue",
+            1,
+            "a full queue must prevent setup for an unqueued batch",
         )
 
         # Drain: pop one at a time and verify the producer keeps up.
@@ -425,14 +429,16 @@ class TestPrefetchQueueMaxsize(unittest.TestCase):
         )
         return worker
 
-    def test_prefetch_queue_maxsize_reads_rollout_config(self) -> None:
-        worker = self._make_minimal_worker(prefetch_queue_maxsize=5)
+    def test_prompt_queue_and_target_depth_use_post_override_config(self) -> None:
+        worker = self._make_minimal_worker(prefetch_queue_maxsize=2)
 
+        # Simulate a rollout backend overriding config from post_init_hook
+        # before the worker configures its queue.
+        worker.config.rollout.prefetch_queue_maxsize = 5
+        worker._configure_prompt_queue()
+
+        self.assertEqual(worker._prompt_queue.maxsize, 5)
         self.assertEqual(worker._prefetch_queue_maxsize, 5)
-
-    def test_prompt_fetch_target_depth_uses_queue_maxsize_for_overlap(self) -> None:
-        worker = self._make_minimal_worker(prefetch_queue_maxsize=5)
-
         self.assertEqual(worker._prompt_fetch_target_depth(prep_overlap=True), 5)
         self.assertEqual(worker._prompt_fetch_target_depth(prep_overlap=False), 1)
 

--- a/tests/test_rollout_prefetch_loop_integration.py
+++ b/tests/test_rollout_prefetch_loop_integration.py
@@ -419,15 +419,20 @@ class TestPrefetchLoopSubmitSetupWiring(unittest.TestCase):
         self.assertEqual(len(recorder), n_batches, "submit_setup once per batch")
 
 
-class TestPrefetchQueueMaxsize(unittest.TestCase):
-    def _make_minimal_worker(self, *, prefetch_queue_maxsize: int = 2) -> Any:
-        worker = DisaggregatedRolloutControlWorker.__new__(
-            DisaggregatedRolloutControlWorker
-        )
-        worker.config = SimpleNamespace(
+class _MinimalPrefetchQueueWorker(DisaggregatedRolloutControlWorker):
+    def __init__(self, *, prefetch_queue_maxsize: int = 2) -> None:
+        self.config = SimpleNamespace(
             rollout=SimpleNamespace(prefetch_queue_maxsize=prefetch_queue_maxsize)
         )
-        return worker
+
+
+class TestPrefetchQueueMaxsize(unittest.TestCase):
+    def _make_minimal_worker(
+        self, *, prefetch_queue_maxsize: int = 2
+    ) -> _MinimalPrefetchQueueWorker:
+        return _MinimalPrefetchQueueWorker(
+            prefetch_queue_maxsize=prefetch_queue_maxsize
+        )
 
     def test_prompt_queue_uses_configured_maxsize(self) -> None:
         worker = self._make_minimal_worker(prefetch_queue_maxsize=5)

--- a/tests/test_rollout_prefetch_loop_integration.py
+++ b/tests/test_rollout_prefetch_loop_integration.py
@@ -415,6 +415,40 @@ class TestPrefetchLoopSubmitSetupWiring(unittest.TestCase):
         self.assertEqual(len(recorder), n_batches, "submit_setup once per batch")
 
 
+class TestPrefetchQueueMaxsize(unittest.TestCase):
+    def _make_minimal_worker(self, *, prefetch_queue_maxsize: int = 2) -> Any:
+        worker = DisaggregatedRolloutControlWorker.__new__(
+            DisaggregatedRolloutControlWorker
+        )
+        worker.config = SimpleNamespace(
+            rollout=SimpleNamespace(prefetch_queue_maxsize=prefetch_queue_maxsize)
+        )
+        return worker
+
+    def test_prefetch_queue_maxsize_reads_rollout_config(self) -> None:
+        worker = self._make_minimal_worker(prefetch_queue_maxsize=5)
+
+        self.assertEqual(worker._prefetch_queue_maxsize, 5)
+
+    def test_prompt_fetch_target_depth_uses_queue_maxsize_for_overlap(self) -> None:
+        worker = self._make_minimal_worker(prefetch_queue_maxsize=5)
+
+        self.assertEqual(worker._prompt_fetch_target_depth(prep_overlap=True), 5)
+        self.assertEqual(worker._prompt_fetch_target_depth(prep_overlap=False), 1)
+
+    def test_rollout_config_validates_prefetch_queue_maxsize(self) -> None:
+        from cosmos_rl.policy.config import RolloutConfig
+        from pydantic import ValidationError
+
+        self.assertEqual(RolloutConfig().prefetch_queue_maxsize, 2)
+        self.assertEqual(
+            RolloutConfig(prefetch_queue_maxsize=5).prefetch_queue_maxsize,
+            5,
+        )
+        with self.assertRaises(ValidationError):
+            RolloutConfig(prefetch_queue_maxsize=0)
+
+
 class TestSingleProducerModeIsLive(unittest.TestCase):
     """``_single_producer_mode`` must reflect live config, not a snapshot.
 

--- a/tests/test_rollout_prefetch_loop_integration.py
+++ b/tests/test_rollout_prefetch_loop_integration.py
@@ -429,6 +429,13 @@ class TestPrefetchQueueMaxsize(unittest.TestCase):
         )
         return worker
 
+    def test_prompt_queue_uses_configured_maxsize(self) -> None:
+        worker = self._make_minimal_worker(prefetch_queue_maxsize=5)
+
+        worker._configure_prompt_queue()
+
+        self.assertEqual(worker._prompt_queue.maxsize, 5)
+
     def test_prompt_queue_and_target_depth_use_post_override_config(self) -> None:
         worker = self._make_minimal_worker(prefetch_queue_maxsize=2)
 


### PR DESCRIPTION
## Summary

- Add `rollout.prefetch_queue_maxsize` with default `2` and `ge=1` validation.
- Construct the bounded prompt queue after rollout backend `post_init_hook` overrides are visible.
- Reuse the configured capacity for multi-rank prep-overlap target depth while preserving legacy depth `1` when overlap is disabled.
- In the single-process prefetch loop, wait for queue capacity before leasing another controller prompt or starting its setup.

## Why

Queue `put()` backpressure happens too late: the prefetch producer has already leased a controller prompt and submitted its setup before it blocks on a full queue. This can leave one additional dispatched batch hidden outside the configured queue capacity.

Because queued prompts consume the controller's `samples_on_the_fly` budget, deeper queues can also engage the soft throttle earlier. Values above `2` are therefore intended only for absorbing bursty fetch/setup latency.

## Validation

- `uv run python tests/test_rollout_prefetch_loop_integration.py` — 13 tests passed
- `uvx ruff@0.12.7 check --fix cosmos_rl/policy/config/__init__.py cosmos_rl/rollout/worker/rollout_control.py tests/test_rollout_prefetch_loop_integration.py`
- `uvx ruff@0.12.7 format cosmos_rl/policy/config/__init__.py cosmos_rl/rollout/worker/rollout_control.py tests/test_rollout_prefetch_loop_integration.py`
- `python -m py_compile cosmos_rl/policy/config/__init__.py cosmos_rl/rollout/worker/rollout_control.py tests/test_rollout_prefetch_loop_integration.py`
- `git diff --check`
