### PR TITLE
fix(pynccl): bound the raw NCCL host call and the group wrappers

### DIFF
--- a/cosmos_rl/utils/pynccl.py
+++ b/cosmos_rl/utils/pynccl.py
@@ -233,14 +233,61 @@ _worker_init_lock = threading.Lock()
 # ---------------------------------------------------------------------------
 
 
+def _run_functor_bounded(task: _Task) -> ncclComm_t:
+    """Run the raw NCCL host call with ``task.timeout_ms`` already counting.
+
+    The raw call is the first of two phases and it can block indefinitely: a
+    receive posted against a peer that never sends does not return, so the
+    async-error deadline below is never reached and the operation is unbounded.
+    Arm an abort *before* entering the functor; aborting the communicator makes
+    the blocked call return an error instead of wedging the worker thread.
+
+    Communicator creation passes ``comm_idx=None`` because the communicator it
+    would abort does not exist yet, so that call stays unbounded here.
+    """
+    if task.comm_idx is None:
+        return task.functor()
+
+    lock = threading.Lock()
+    returned = False
+
+    def _abort_blocked_call() -> None:
+        with lock:
+            if returned:
+                return
+            logger.error(
+                f"NCCL: raw host call exceeded {task.timeout_ms} ms for task {task}; "
+                f"aborting communicator idx={task.comm_idx}"
+            )
+            task.timed_out.set()
+            _notify_p2p_phase(task.phase_observer, "abort_enter")
+            _safe_abort(task.comm_idx)
+            _notify_p2p_phase(task.phase_observer, "abort_return")
+
+    timer = threading.Timer(task.timeout_ms / 1000.0, _abort_blocked_call)
+    timer.daemon = True
+    timer.start()
+    try:
+        return task.functor()
+    finally:
+        with lock:
+            returned = True
+        timer.cancel()
+
+
 def run_task(task: _Task):
     logger.debug(f"[Worker] Got task {task} | queue_size={_task_q.qsize()}")
 
     comm: ncclComm_t | None = None
     try:
         logger.debug(f"[Worker] Executing functor for task {task}")
-        comm = task.functor()
+        comm = _run_functor_bounded(task)
         logger.debug(f"[Worker] Functor for task {task} returned comm={comm}")
+
+        if task.timed_out.is_set():
+            # The raw call blocked past the deadline and its communicator is
+            # already aborted, so there is no async error left to poll for.
+            return
 
         deadline = time.monotonic() + task.timeout_ms / 1000.0
         # Poll async error status until success or timeout.
@@ -677,24 +724,31 @@ def nccl_broadcast(
     _submit_nccl(_broadcast_call, timeout_ms, comm_idx)
 
 
-def nccl_group_start(comm_idx: int):
+def nccl_group_start(comm_idx: int, timeout_ms: Optional[int] = None):
+    """Open a NCCL group; ``timeout_ms`` bounds it like the other wrappers."""
     meta = _COMM_REGISTRY.get(comm_idx)
 
     def _group_start_call():
         _nccl.ncclGroupStart()
         return meta.comm
 
-    _submit_nccl(_group_start_call, None, comm_idx)
+    _submit_nccl(_group_start_call, timeout_ms, comm_idx)
 
 
-def nccl_group_end(comm_idx: int):
+def nccl_group_end(comm_idx: int, timeout_ms: Optional[int] = None):
+    """Close a NCCL group; ``timeout_ms`` bounds it like the other wrappers.
+
+    Callers that batch many point-to-point operations spend most of a grouped
+    setup here, so this must honour the caller's budget rather than silently
+    falling back to ``COSMOS_NCCL_TIMEOUT_MS``.
+    """
     meta = _COMM_REGISTRY.get(comm_idx)
 
     def _group_end_call():
         _nccl.ncclGroupEnd()
         return meta.comm
 
-    _submit_nccl(_group_end_call, None, comm_idx)
+    _submit_nccl(_group_end_call, timeout_ms, comm_idx)
 
 
 def nccl_send(
@@ -872,7 +926,7 @@ def get_nccl_timeout_ms() -> int:
     return _get_timeout_ms()
 
 
-def _safe_abort(comm_idx: Optional[int], comm: ncclComm_t):
+def _safe_abort(comm_idx: Optional[int], comm: Optional[ncclComm_t] = None):
     """Abort NCCL communicator gracefully, regardless of its registry state.
 
     If *comm_idx* is given, we first try to abort via :func:`nccl_abort` so the
@@ -901,6 +955,8 @@ __all__ = [
     "get_nccl_comm_nranks",
     # collectives
     "nccl_broadcast",
+    "nccl_group_start",
+    "nccl_group_end",
     "nccl_send",
     "nccl_recv",
     "nccl_allreduce",

--- a/tests/test_pynccl_raw_call_timeout.py
+++ b/tests/test_pynccl_raw_call_timeout.py
@@ -1,0 +1,131 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""CPU tests for bounding the raw NCCL host call and the group wrappers."""
+
+import threading
+import time
+import unittest
+from contextlib import ExitStack
+from unittest.mock import Mock, patch
+
+from cosmos_rl.utils import pynccl
+from cosmos_rl.utils.pynccl_wrapper import ncclResultEnum
+
+
+class TestRawCallTimeout(unittest.TestCase):
+    """A raw host call that never returns must still hit the task timeout."""
+
+    def _blocking_task(self, timeout_ms: int, comm_idx):
+        """Build a task whose functor blocks until the abort releases it."""
+        released = threading.Event()
+
+        def _functor():
+            # Stands in for ``ncclRecv`` against a peer that never sends: the
+            # call only returns once the communicator is aborted.
+            released.wait(timeout=30.0)
+            return Mock()
+
+        task = pynccl._Task(_functor, timeout_ms, comm_idx)
+        return task, released
+
+    def test_blocked_raw_call_aborts_communicator_and_times_out(self):
+        task, released = self._blocking_task(timeout_ms=200, comm_idx=7)
+        abort = Mock(side_effect=lambda _idx: released.set())
+
+        started = time.monotonic()
+        with patch.object(pynccl, "nccl_abort", abort):
+            pynccl.run_task(task)
+        elapsed = time.monotonic() - started
+
+        abort.assert_called_once_with(7)
+        self.assertTrue(task.timed_out.is_set())
+        self.assertTrue(task.done.is_set())
+        # Bounded by the task timeout, not by the functor's own 30s ceiling.
+        self.assertLess(elapsed, 10.0)
+
+    def test_submit_raises_timeout_error_for_blocked_raw_call(self):
+        released = threading.Event()
+
+        def _functor():
+            released.wait(timeout=30.0)
+            return Mock()
+
+        with ExitStack() as stack:
+            stack.enter_context(patch.object(pynccl, "_worker_started", True))
+            stack.enter_context(
+                patch.object(
+                    pynccl,
+                    "nccl_abort",
+                    Mock(side_effect=lambda _idx: released.set()),
+                )
+            )
+            with self.assertRaises(TimeoutError):
+                pynccl._submit_nccl(_functor, 200, 3)
+
+    def test_returning_raw_call_is_not_aborted(self):
+        task, _ = self._blocking_task(timeout_ms=60_000, comm_idx=7)
+        task.functor = lambda: Mock()
+        abort = Mock()
+        query = Mock(return_value=ncclResultEnum.ncclSuccess)
+
+        with ExitStack() as stack:
+            stack.enter_context(patch.object(pynccl, "nccl_abort", abort))
+            stack.enter_context(
+                patch.object(pynccl._nccl, "ncclCommGetAsyncError", query)
+            )
+            pynccl.run_task(task)
+
+        abort.assert_not_called()
+        self.assertFalse(task.timed_out.is_set())
+
+    def test_communicator_creation_has_nothing_to_abort(self):
+        """``comm_idx=None`` means the communicator does not exist yet."""
+        task = pynccl._Task(lambda: Mock(), 200, None)
+        abort = Mock()
+        query = Mock(return_value=ncclResultEnum.ncclSuccess)
+
+        with ExitStack() as stack:
+            stack.enter_context(patch.object(pynccl, "nccl_abort", abort))
+            stack.enter_context(
+                patch.object(pynccl._nccl, "ncclCommGetAsyncError", query)
+            )
+            pynccl.run_task(task)
+
+        abort.assert_not_called()
+        self.assertFalse(task.timed_out.is_set())
+
+
+class TestGroupTimeoutForwarding(unittest.TestCase):
+    """The group wrappers must honour the caller's budget, not the default."""
+
+    def _record_submit(self, call, timeout_ms):
+        submit = Mock()
+        meta = pynccl._CommMeta(comm=Mock(), rank=0, world_size=2)
+        with ExitStack() as stack:
+            stack.enter_context(
+                patch.object(pynccl._CommunicatorRegistry, "get", return_value=meta)
+            )
+            stack.enter_context(patch.object(pynccl, "_submit_nccl", submit))
+            if timeout_ms is None:
+                call(4)
+            else:
+                call(4, timeout_ms=timeout_ms)
+        return submit.call_args
+
+    def test_group_start_forwards_explicit_timeout(self):
+        args, _ = self._record_submit(pynccl.nccl_group_start, 1_800_000)
+        self.assertEqual(args[1:], (1_800_000, 4))
+
+    def test_group_end_forwards_explicit_timeout(self):
+        args, _ = self._record_submit(pynccl.nccl_group_end, 1_800_000)
+        self.assertEqual(args[1:], (1_800_000, 4))
+
+    def test_group_helpers_still_default_to_environment_timeout(self):
+        for call in (pynccl.nccl_group_start, pynccl.nccl_group_end):
+            args, _ = self._record_submit(call, None)
+            self.assertEqual(args[1:], (None, 4))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem

`run_task` starts its deadline **after** `task.functor()` returns:

```python
comm = task.functor()
deadline = time.monotonic() + task.timeout_ms / 1000.0
while time.monotonic() < deadline:
    err = _nccl.ncclCommGetAsyncError(comm)
```

A non-blocking NCCL operation has two phases: the host API call that enqueues the work, and the asynchronous completion of that work. The loop above bounds phase 2. Phase 1 is unbounded — a receive posted against a peer that never sends blocks inside `ncclRecv` and never reaches the deadline, so a caller that passes an explicit `timeout_ms` still wedges the pynccl worker thread indefinitely. Downstream callers cannot fix this themselves: the abort has to happen from another thread, and the abort target is pynccl's own registry.

Separately, `nccl_group_start`/`nccl_group_end` passed `None` for the timeout, so their async-error poll fell back to `COSMOS_NCCL_TIMEOUT_MS` (600 s) regardless of what the caller configured. Callers that batch many point-to-point operations spend most of a grouped setup inside `ncclGroupEnd`, which is exactly the phase that silently got the default.

## Change

1. Arm a timer **before** entering the functor. On expiry it aborts the task's registered communicator, which makes the blocked raw call return an error; the task then reports the same `TimeoutError` as an expired async-error poll. A lock around the "functor returned" flag prevents aborting a call that completes on the deadline boundary.
2. Communicator creation passes `comm_idx=None` and stays unbounded here, because the communicator the timer would abort does not exist yet. That is called out in the docstring rather than silently skipped.
3. `nccl_group_start`/`nccl_group_end` take an optional `timeout_ms` and forward it, defaulting to the previous environment-driven behaviour.

## Validation

- `pytest tests/test_pynccl_raw_call_timeout.py` — a functor that blocks for 30 s under a 200 ms budget is aborted and returns within the budget; `_submit_nccl` surfaces `TimeoutError`; a fast call is not aborted; `comm_idx=None` is left alone; both group wrappers forward an explicit timeout and still default to `None`.
- `ruff check` / `ruff format --check` on both touched files.

CPU-only coverage: the abort path is exercised through the registry seam, not against a live communicator. A GPU regression (post a receive with no matching send, assert bounded return and communicator abort) is worth adding to the multi-GPU suite if you want it in-tree here.