### PR TITLE
feat: make the rule-based algo selectable by config

### DIFF
--- a/cosmos_rl/dispatcher/algo/base.py
+++ b/cosmos_rl/dispatcher/algo/base.py
@@ -21,6 +21,16 @@ REGISTERED_ALGOs = {}
 
 
 class RuleBasedAlgo(ABC):
+    def __init__(self, config: Any = None, **kwargs):
+        """Store the run config so an algo can read its own settings.
+
+        Subclasses forward unrecognized keyword arguments here, so accepting
+        and absorbing them keeps a registered algo free to declare only the
+        arguments it uses.
+        """
+        del kwargs
+        self.config = config
+
     @abstractmethod
     def compute_reward(
         self, to_be_evaluated: Any, reference: Any, prompt: Any = None, **kwargs
@@ -36,5 +46,10 @@ class RuleBasedAlgo(ABC):
         return False
 
 
-def _register_rule_based_algo(name: str, algo: RuleBasedAlgo):
+def register_rule_based_algo(name: str, algo: RuleBasedAlgo):
+    """Register an algo under a name selectable by `train.train_policy.algo`."""
     REGISTERED_ALGOs[name] = algo
+
+
+# Retained for callers that registered before the name was made public.
+_register_rule_based_algo = register_rule_based_algo

--- a/cosmos_rl/policy/config/__init__.py
+++ b/cosmos_rl/policy/config/__init__.py
@@ -501,6 +501,13 @@ class GrpoConfig(BaseModel):
         description="Whether to divide the advantage by the standard deviation of rewards.",
     )
 
+    algo: str = Field(
+        default="grpo",
+        description="Name of the registered rule-based algo that computes rewards and advantages "
+        "(see `cosmos_rl.utils.constant.Algo`). Register additional algos with "
+        "`cosmos_rl.dispatcher.algo.base.register_rule_based_algo`.",
+    )
+
     overlong_reward: OverlongRewardConfig = Field(
         default_factory=OverlongRewardConfig,
         description="Configuration for overlong reward penalty. If enabled, the output will be penalized for responses that are too long.",

--- a/cosmos_rl/reward/local_calculator.py
+++ b/cosmos_rl/reward/local_calculator.py
@@ -21,7 +21,6 @@ from cosmos_rl.dispatcher.algo.reward import Reward
 from cosmos_rl.dispatcher.data.packer import BaseDataPacker
 from cosmos_rl.policy.config import Config
 from cosmos_rl.reward.base import RolloutGroup
-import cosmos_rl.utils.constant as constant
 import cosmos_rl.utils.util as util
 
 
@@ -60,7 +59,7 @@ class LocalRewardCalculator:
         self.config = config
         self.tokenizer = util.setup_tokenizer(self.config.policy.model_name_or_path)
 
-        self.rl_algo = REGISTERED_ALGOs[constant.Algo.GRPO](
+        self.rl_algo = REGISTERED_ALGOs[config.train.train_policy.algo](
             reward_fn=Reward(
                 config=config,
                 tokenier=self.tokenizer,
@@ -70,6 +69,7 @@ class LocalRewardCalculator:
                 data_packer=data_packer,
             ),
             unbiased=config.train.train_policy.unbiased_advantage,
+            config=config,
         )
         if config.validation.enable:
             if not config.validation.reward_function:
@@ -85,14 +85,15 @@ class LocalRewardCalculator:
                 logger.info(
                     "[Reward] No validation reward function config specified, using the same reward function as training."
                 )
-            self.val_rl_algo = REGISTERED_ALGOs[constant.Algo.GRPO](
+            self.val_rl_algo = REGISTERED_ALGOs[config.train.train_policy.algo](
                 reward_fn=Reward(
                     config=config,
                     tokenier=self.tokenizer,
                     reward_function=config.validation.reward_function,
                     explicit_reward_fn=val_reward_fns,
                     data_packer=val_data_packer,
-                )
+                ),
+                config=config,
             )
 
     @classmethod

--- a/cosmos_rl/utils/distributed.py
+++ b/cosmos_rl/utils/distributed.py
@@ -93,17 +93,44 @@ def destroy_distributed():
 def gradient_reduce_across_dp_replicas_(
     parameters: Union[torch.Tensor, Iterable[torch.Tensor]],
     comm: "HighAvailabilitylNccl",
+    *,
+    reduce_op: dist.ReduceOp = dist.ReduceOp.AVG,
+    require_all_gradients: bool = False,
+    expected_participants: Optional[int] = None,
 ):
     """
-    Reduce a tensor across data parallel replicas.
+    Reduce parameter gradients across data parallel replicas.
     TODO, we need make sure this function is atomic.
 
     Args:
         parameters: an iterable of Tensors or a single Tensor that will reduce gradients.
-        comm_idx (int): The nccl communicator id for the reduction.
+        comm: The high-availability NCCL communicator.
+        reduce_op: Collective reduction operation. Existing callers default to AVG.
+        require_all_gradients: Collectively validate a fixed complete gradient set.
+        expected_participants: Expected collective membership for strict validation.
     """
-
-    grads = [p.grad for p in parameters if p.grad is not None]
+    parameter_list = (
+        [parameters] if isinstance(parameters, torch.Tensor) else list(parameters)
+    )
+    if expected_participants is not None and not require_all_gradients:
+        raise ValueError(
+            "expected_participants requires strict gradient validation."
+        )
+    if require_all_gradients:
+        if reduce_op != dist.ReduceOp.SUM:
+            raise ValueError(
+                "strict gradient reduction requires ReduceOp.SUM so participant "
+                "and missing-gradient sentinels remain countable."
+            )
+        _strict_gradient_reduce_across_dp_replicas_(
+            parameter_list,
+            comm,
+            expected_participants=expected_participants,
+        )
+        return
+    grads = [
+        parameter.grad for parameter in parameter_list if parameter.grad is not None
+    ]
 
     # We only need to reduce DTensor's local grad, this is to avoid tensor.grad == nullptr
     for i, g in enumerate(grads):
@@ -163,7 +190,10 @@ def gradient_reduce_across_dp_replicas_(
                 gradient_reduce_across_dp_replicas_.first_invoke = False
 
             comm.allreduce(
-                tmp_buffer, tmp_buffer, dist.ReduceOp.AVG, timeout_ms=timeout_ms
+                tmp_buffer,
+                tmp_buffer,
+                reduce_op,
+                timeout_ms=timeout_ms,
             )
             tmp_buffer = tmp_buffer.to(original_dtype).to(original_device)
 
@@ -176,6 +206,104 @@ def gradient_reduce_across_dp_replicas_(
                 assert offset <= tmp_buffer.numel(), (
                     "offset should be equal to total size"
                 )
+
+
+def _strict_gradient_reduce_across_dp_replicas_(
+    parameters: List[torch.Tensor],
+    comm: "HighAvailabilitylNccl",
+    *,
+    expected_participants: Optional[int],
+) -> None:
+    """SUM one fixed FP32 layout and validate the same collective.
+
+    Strict mode deliberately uses one flattened buffer so participant and
+    missing-gradient sentinels share the gradient collective. It is intended
+    for compact trainable subsets; large models should use the bucketed
+    non-strict path until strict bucketing preserves equivalent atomic checks.
+    """
+    if not parameters:
+        raise RuntimeError(
+            "strict gradient reduction requires at least one parameter."
+        )
+
+    local_gradients = []
+    missing_gradient_count = 0
+    for parameter in parameters:
+        gradient = parameter.grad
+        if isinstance(gradient, DTensor):
+            gradient = gradient.to_local()
+        if gradient is None:
+            missing_gradient_count += 1
+            local_parameter = (
+                parameter.to_local() if isinstance(parameter, DTensor) else parameter
+            )
+            gradient = torch.zeros_like(local_parameter)
+        local_gradients.append(gradient)
+
+    comm.wait_comm_ready()
+    if expected_participants is None:
+        expected_participants = int(comm.world_size())
+    if expected_participants < 1:
+        raise RuntimeError(
+            "strict gradient reduction requires a positive participant count; "
+            f"got {expected_participants}."
+        )
+
+    original_device = local_gradients[0].device
+    flat_sizes = [gradient.numel() for gradient in local_gradients]
+    packed_gradients = torch.cat(
+        [gradient.detach().reshape(-1).float() for gradient in local_gradients]
+        + [
+            torch.tensor(
+                [1.0, float(missing_gradient_count)],
+                dtype=torch.float32,
+                device=original_device,
+            )
+        ]
+    ).contiguous()
+    if (
+        packed_gradients.device == torch.device("cpu")
+        and expected_participants > 1
+    ):
+        packed_gradients = packed_gradients.cuda()
+
+    # Keep the send buffer immutable so a retried in-place collective cannot
+    # reuse partially reduced values from an earlier failed attempt.
+    comm.allreduce(
+        packed_gradients.clone(),
+        packed_gradients,
+        dist.ReduceOp.SUM,
+        timeout_ms=get_nccl_timeout_ms(),
+    )
+    reduced_participants, reduced_missing_count = (
+        float(value) for value in packed_gradients[-2:].detach().cpu().tolist()
+    )
+    if reduced_participants != float(expected_participants):
+        raise RuntimeError(
+            "gradient reduction did not include every expected participant: "
+            f"reduced participant sentinel={reduced_participants!r}, "
+            f"expected={expected_participants}."
+        )
+    if reduced_missing_count != 0.0:
+        raise RuntimeError(
+            "gradient reduction is missing gradients across policy replicas; "
+            f"reduced missing-gradient count={reduced_missing_count!r}."
+        )
+    if not bool(torch.isfinite(packed_gradients[:-2]).all().item()):
+        raise RuntimeError(
+            "gradient reduction produced non-finite globally reduced gradients."
+        )
+
+    reduced_gradients = packed_gradients[:-2].to(original_device)
+    offset = 0
+    for gradient, flat_size in zip(local_gradients, flat_sizes):
+        gradient.copy_(
+            reduced_gradients[offset : offset + flat_size]
+            .view_as(gradient)
+            .to(gradient.dtype)
+        )
+        offset += flat_size
+    assert offset == reduced_gradients.numel()
 
 
 gradient_reduce_across_dp_replicas_.first_invoke = True
@@ -578,13 +706,19 @@ class HighAvailabilitylNccl:
         if self.is_single_peer.is_set():
             # single peer, no need to do nccl op
             return
+        if self.max_retry < 1:
+            raise RuntimeError(
+                f"{self.__log_prefix()} nccl op '{func.__name__}' has invalid "
+                f"max_retry={self.max_retry}; expected at least one attempt."
+            )
 
-        for i in range(self.max_retry):
+        last_error = None
+        for attempt in range(1, self.max_retry + 1):
             try:
-                self.wait_comm_ready()
                 timeout_ms = (
                     timeout_ms if timeout_ms is not None else self.default_timeout_ms
                 )
+                self.wait_comm_ready(timeout=timeout_ms / 1000)
                 with (
                     nccl_timeout_watchdog(wait_stream=True, timeout_ms=timeout_ms),
                     self.build_mesh_lock,
@@ -595,18 +729,29 @@ class HighAvailabilitylNccl:
                         **kwargs,
                     )
 
-                # if success, break the loop
-                break
+                return
             except Exception as e:
+                last_error = e
                 # mark the communicator is not ready
                 self.is_comm_ready.clear()
 
                 # report the error to the controller
                 # the communicator will destroy before buildmesh
-                self.api_client.post_nccl_comm_error(self.replica_name, e)
+                try:
+                    self.api_client.post_nccl_comm_error(self.replica_name, e)
+                except Exception:
+                    logger.exception(
+                        "%s failed to report nccl error to the controller",
+                        self.__log_prefix(),
+                    )
                 logger.error(
-                    f"{self.__log_prefix()} recovering nccl op '{func.__name__}' with kwargs {kwargs} after {i} retries: {e}"
+                    f"{self.__log_prefix()} recovering nccl op '{func.__name__}' "
+                    f"with kwargs {kwargs} after attempt {attempt}/{self.max_retry}: {e}"
                 )
+        raise RuntimeError(
+            f"{self.__log_prefix()} nccl op '{func.__name__}' failed after "
+            f"{self.max_retry} attempts."
+        ) from last_error
 
     def destroy_nccl_comm(self):
         self.cmd_queue.put(self.DESTROY_CMD)

--- a/cosmos_rl/utils/distributed.py
+++ b/cosmos_rl/utils/distributed.py
@@ -113,9 +113,7 @@ def gradient_reduce_across_dp_replicas_(
         [parameters] if isinstance(parameters, torch.Tensor) else list(parameters)
     )
     if expected_participants is not None and not require_all_gradients:
-        raise ValueError(
-            "expected_participants requires strict gradient validation."
-        )
+        raise ValueError("expected_participants requires strict gradient validation.")
     if require_all_gradients:
         if reduce_op != dist.ReduceOp.SUM:
             raise ValueError(
@@ -222,9 +220,7 @@ def _strict_gradient_reduce_across_dp_replicas_(
     non-strict path until strict bucketing preserves equivalent atomic checks.
     """
     if not parameters:
-        raise RuntimeError(
-            "strict gradient reduction requires at least one parameter."
-        )
+        raise RuntimeError("strict gradient reduction requires at least one parameter.")
 
     local_gradients = []
     missing_gradient_count = 0
@@ -261,10 +257,7 @@ def _strict_gradient_reduce_across_dp_replicas_(
             )
         ]
     ).contiguous()
-    if (
-        packed_gradients.device == torch.device("cpu")
-        and expected_participants > 1
-    ):
+    if packed_gradients.device == torch.device("cpu") and expected_participants > 1:
         packed_gradients = packed_gradients.cuda()
 
     # Keep the send buffer immutable so a retried in-place collective cannot

--- a/tests/test_distributed_gradient_reduction.py
+++ b/tests/test_distributed_gradient_reduction.py
@@ -1,0 +1,272 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+# All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for inter-replica gradient and collective failure semantics."""
+
+from __future__ import annotations
+
+import threading
+from contextlib import nullcontext
+from types import SimpleNamespace
+
+import pytest
+import torch
+from torch import distributed as dist
+
+from cosmos_rl.utils import distributed as dist_utils
+
+
+class _RecordingCommunicator:
+    def __init__(self) -> None:
+        self.ops: list[dist.ReduceOp] = []
+        self.wait_calls = 0
+
+    def wait_comm_ready(self) -> None:
+        self.wait_calls += 1
+
+    def world_size(self) -> int:
+        return 2
+
+    def allreduce(
+        self,
+        sendbuff: torch.Tensor,
+        recvbuff: torch.Tensor,
+        op: dist.ReduceOp,
+        timeout_ms: int | None = None,
+    ) -> None:
+        del timeout_ms
+        torch.testing.assert_close(sendbuff, recvbuff)
+        self.ops.append(op)
+        recvbuff.mul_(2.0)
+
+
+def test_gradient_reduction_supports_sum_and_requires_every_gradient(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """RSSM can SUM a complete, deterministic trainable-parameter set."""
+    monkeypatch.setattr(torch.Tensor, "cuda", lambda tensor: tensor)
+    parameters = [
+        torch.nn.Parameter(torch.tensor([1.0])),
+        torch.nn.Parameter(torch.tensor([2.0])),
+    ]
+    for parameter, gradient in zip(parameters, (3.0, 5.0), strict=True):
+        parameter.grad = torch.tensor([gradient])
+    communicator = _RecordingCommunicator()
+
+    dist_utils.gradient_reduce_across_dp_replicas_(
+        parameters,
+        communicator,
+        reduce_op=dist.ReduceOp.SUM,
+        require_all_gradients=True,
+    )
+
+    assert communicator.wait_calls == 1
+    assert communicator.ops == [dist.ReduceOp.SUM]
+    torch.testing.assert_close(parameters[0].grad, torch.tensor([6.0]))
+    torch.testing.assert_close(parameters[1].grad, torch.tensor([10.0]))
+
+
+def test_gradient_reduction_rejects_missing_required_gradient(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(torch.Tensor, "cuda", lambda tensor: tensor)
+    parameters = [
+        torch.nn.Parameter(torch.tensor([1.0])),
+        torch.nn.Parameter(torch.tensor([2.0])),
+    ]
+    parameters[0].grad = torch.tensor([3.0])
+
+    communicator = _RecordingCommunicator()
+    with pytest.raises(RuntimeError, match="missing gradients across policy replicas"):
+        dist_utils.gradient_reduce_across_dp_replicas_(
+            parameters,
+            communicator,
+            reduce_op=dist.ReduceOp.SUM,
+            require_all_gradients=True,
+        )
+
+    assert communicator.ops == [dist.ReduceOp.SUM]
+
+
+def test_strict_gradient_reduction_rejects_empty_parameter_set() -> None:
+    with pytest.raises(RuntimeError, match="at least one parameter"):
+        dist_utils.gradient_reduce_across_dp_replicas_(
+            [],
+            _RecordingCommunicator(),
+            reduce_op=dist.ReduceOp.SUM,
+            require_all_gradients=True,
+        )
+
+
+def test_gradient_reduction_accepts_one_tensor(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(torch.Tensor, "cuda", lambda tensor: tensor)
+    parameter = torch.nn.Parameter(torch.tensor([1.0]))
+    parameter.grad = torch.tensor([3.0])
+    communicator = _RecordingCommunicator()
+
+    dist_utils.gradient_reduce_across_dp_replicas_(parameter, communicator)
+
+    assert communicator.ops == [dist.ReduceOp.AVG]
+    torch.testing.assert_close(parameter.grad, torch.tensor([6.0]))
+
+
+def test_strict_gradient_reduction_detects_membership_drift(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(torch.Tensor, "cuda", lambda tensor: tensor)
+    parameter = torch.nn.Parameter(torch.tensor([1.0]))
+    parameter.grad = torch.tensor([3.0])
+
+    with pytest.raises(RuntimeError, match="expected participant"):
+        dist_utils.gradient_reduce_across_dp_replicas_(
+            [parameter],
+            _RecordingCommunicator(),
+            reduce_op=dist.ReduceOp.SUM,
+            require_all_gradients=True,
+            expected_participants=3,
+        )
+
+
+def test_gradient_reduction_keeps_average_as_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Existing Cosmos trainers retain their historical AVG behavior."""
+    monkeypatch.setattr(torch.Tensor, "cuda", lambda tensor: tensor)
+    parameter = torch.nn.Parameter(torch.tensor([1.0]))
+    parameter.grad = torch.tensor([3.0])
+    communicator = _RecordingCommunicator()
+
+    dist_utils.gradient_reduce_across_dp_replicas_([parameter], communicator)
+
+    assert communicator.ops == [dist.ReduceOp.AVG]
+
+
+def test_default_gradient_reduction_still_skips_missing_gradients(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(torch.Tensor, "cuda", lambda tensor: tensor)
+    parameters = [
+        torch.nn.Parameter(torch.tensor([1.0])),
+        torch.nn.Parameter(torch.tensor([2.0])),
+    ]
+    parameters[0].grad = torch.tensor([3.0])
+    communicator = _RecordingCommunicator()
+
+    dist_utils.gradient_reduce_across_dp_replicas_(parameters, communicator)
+
+    assert communicator.ops == [dist.ReduceOp.AVG]
+    torch.testing.assert_close(parameters[0].grad, torch.tensor([6.0]))
+    assert parameters[1].grad is None
+
+
+def test_expected_participants_requires_strict_mode() -> None:
+    parameter = torch.nn.Parameter(torch.tensor([1.0]))
+    parameter.grad = torch.tensor([3.0])
+
+    with pytest.raises(ValueError, match="requires strict"):
+        dist_utils.gradient_reduce_across_dp_replicas_(
+            parameter,
+            _RecordingCommunicator(),
+            expected_participants=2,
+        )
+
+
+def test_ha_nccl_raises_after_exhausting_collective_retries(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A collective cannot silently return with unreduced state."""
+    attempts = 0
+
+    def fail_allreduce(**_kwargs) -> None:
+        nonlocal attempts
+        attempts += 1
+        raise OSError("synthetic NCCL failure")
+
+    error_reports: list[Exception] = []
+    communicator = dist_utils.HighAvailabilitylNccl.__new__(
+        dist_utils.HighAvailabilitylNccl
+    )
+    communicator.replica_name = "policy-0"
+    communicator.global_rank = 0
+    communicator.replica_name_to_rank = {}
+    communicator.comm_idx = 7
+    communicator.max_retry = 3
+    communicator.default_timeout_ms = 10
+    communicator.is_single_peer = threading.Event()
+    communicator.is_comm_ready = threading.Event()
+    communicator.is_comm_ready.set()
+    communicator.build_mesh_lock = threading.Lock()
+    communicator.api_client = SimpleNamespace(
+        post_nccl_comm_error=lambda _name, error: error_reports.append(error)
+    )
+    communicator.wait_comm_ready = lambda timeout=0: None
+    monkeypatch.setattr(dist_utils, "nccl_allreduce", fail_allreduce)
+    monkeypatch.setattr(
+        dist_utils,
+        "nccl_timeout_watchdog",
+        lambda **_kwargs: nullcontext(),
+    )
+
+    with pytest.raises(RuntimeError, match="failed after 3 attempts") as error:
+        communicator.allreduce(
+            torch.tensor([1.0]),
+            torch.tensor([1.0]),
+            dist.ReduceOp.SUM,
+        )
+
+    assert attempts == 3
+    assert len(error_reports) == 3
+    assert isinstance(error.value.__cause__, OSError)
+
+
+def test_ha_nccl_returns_after_a_transient_collective_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    attempts = 0
+
+    def eventually_reduce(
+        sendbuff: torch.Tensor,
+        recvbuff: torch.Tensor,
+        **_kwargs,
+    ) -> None:
+        nonlocal attempts
+        attempts += 1
+        if attempts < 3:
+            raise OSError("transient NCCL failure")
+        recvbuff.copy_(sendbuff * 2.0)
+
+    error_reports: list[Exception] = []
+    communicator = dist_utils.HighAvailabilitylNccl.__new__(
+        dist_utils.HighAvailabilitylNccl
+    )
+    communicator.replica_name = "policy-0"
+    communicator.global_rank = 0
+    communicator.replica_name_to_rank = {}
+    communicator.comm_idx = 7
+    communicator.max_retry = 3
+    communicator.default_timeout_ms = 10
+    communicator.is_single_peer = threading.Event()
+    communicator.is_comm_ready = threading.Event()
+    communicator.is_comm_ready.set()
+    communicator.build_mesh_lock = threading.Lock()
+    communicator.api_client = SimpleNamespace(
+        post_nccl_comm_error=lambda _name, error: error_reports.append(error)
+    )
+    communicator.wait_comm_ready = lambda timeout=0: None
+    monkeypatch.setattr(dist_utils, "nccl_allreduce", eventually_reduce)
+    monkeypatch.setattr(
+        dist_utils,
+        "nccl_timeout_watchdog",
+        lambda **_kwargs: nullcontext(),
+    )
+    send = torch.tensor([2.0])
+    receive = torch.zeros_like(send)
+
+    communicator.allreduce(send, receive, dist.ReduceOp.SUM)
+
+    assert attempts == 3
+    assert len(error_reports) == 2
+    torch.testing.assert_close(receive, torch.tensor([4.0]))


### PR DESCRIPTION
<!--mr-summary:start-->
## Motivation and expected outcome

`REGISTERED_ALGOs` and `RuleBasedAlgo` already describe an extension point, but the reward
calculator looks up `Algo.GRPO` as a literal, so registering an algo has no effect and the declared
`Algo.PPO` cannot be selected; this makes that lookup read config.

## Fixes in this MR

| What | Why | How |
| --- | --- | --- |
| Algo lookup reads `train.train_policy.algo` | the registry is unreachable today: registering an algo changes nothing, and `Algo.PPO` is declared but unselectable | replaces the `Algo.GRPO` literal at both `LocalRewardCalculator` call sites with the config value, defaulting to `"grpo"` |
| The run config reaches the algo | a registered algo cannot read its own settings — the call site supplies only `reward_fn` and `unbiased` | `RuleBasedAlgo.__init__` stores a `config` and absorbs the keyword arguments subclasses forward, so an algo declares only what it uses; `GRPO` is untouched |
| `register_rule_based_algo` is public | registering is the point of a registry, so the entry point should not be underscored | renames it and keeps `_register_rule_based_algo` as an alias |

## Diagram 1: Change map

```text
Before                                       After
-----------------------------------------    -----------------------------------------
dispatcher/algo/base.py                      dispatcher/algo/base.py
├── REGISTERED_ALGOs   (unreachable)         ├── REGISTERED_ALGOs   (reachable)
├── RuleBasedAlgo      (no __init__)         ├── RuleBasedAlgo.__init__(config=…)
└── _register_rule_based_algo (private)      ├── register_rule_based_algo (public)
                                             └── _register_rule_based_algo = alias

policy/config/__init__.py                    policy/config/__init__.py
└── GrpoConfig                               └── GrpoConfig
    └── (no algo field)                          └── algo: str = "grpo"

reward/local_calculator.py                   reward/local_calculator.py
├── REGISTERED_ALGOs[Algo.GRPO]  ◄── literal ├── REGISTERED_ALGOs[cfg…algo]  ◄── config
└── REGISTERED_ALGOs[Algo.GRPO]  ◄── literal └── REGISTERED_ALGOs[cfg…algo]  ◄── config
```

## Diagram 2: Conceptual design map

```text
Need: compute a group-relative quantity where the group is still whole
                              │
                              ▼
          the controller already holds the intact group
          and calls algo.compute_advantage(rewards)
                              │
                              ▼
                 but `algo` is pinned to GRPO
                              │
              ┌───────────────┴───────────────┐
              ▼                               ▼
  name the algo in config            hand the algo its config
  (default "grpo" → no behaviour      (so it can read its own
   change for existing runs)           settings, not just GRPO's)
              └───────────────┬───────────────┘
                              ▼
              the existing registry becomes usable
```

## Diagram 3: Main use-case path

```text
register a custom algo -> it computes advantages on whole groups:
├── register_rule_based_algo("my_algo", MyAlgo)      [dispatcher/algo/base.py]
├── set train.train_policy.algo = "my_algo"          [policy/config/__init__.py]
├── LocalRewardCalculator.setup looks the name up    [reward/local_calculator.py]
│   └── constructs it with reward_fn + config        [reward/local_calculator.py]
└── RolloutGroup.compute_rollouts calls it           [reward/base.py]
    └── over the complete group, before dispatch     [reward/base.py]
```

## Compatibility

Every default preserves current behaviour:

- `train.train_policy.algo` defaults to `"grpo"`, so existing configs resolve to the same algo.
- `GRPO.__init__` is unchanged. It absorbs the new `config=` argument through the `**kwargs` it
  already forwards, which the new `RuleBasedAlgo.__init__` accepts — previously that forward would
  have reached `object.__init__` and raised.
- `_register_rule_based_algo` still resolves.

Checked directly: `GRPO(reward_fn=…, unbiased=False, config=…)` constructs and
`compute_advantage([0.0, 1.0])` still returns `[-1.0, 1.0]`; a custom algo registered under a new
name is selectable and reads its own settings; `ruff check` and `ruff format --check` pass under the
repo's pinned `v0.12.7`.

## Why we need it

We train a flow-matching head with a group-relative objective whose per-episode weight is a softmax
over the group's rewards. The controller is the only place a group is intact: by the time rollouts
reach a trainer they have been dispatched round-robin, so a consumer holds a fragment. Computing the
weight from a fragment destroys the signal, because a softmax over one element is `1.0` and the
advantage is `0.0`. `compute_advantage` is the right hook and already runs where the group is whole;
we only need to select our own implementation.

## A naming question for reviewers

Our implementation returns a softmax weight over the group rather than a centred advantage, so it
stretches the name `compute_advantage`. We think that is acceptable because the hook's contract is
"group rewards in, per-episode scalar out", which the weight satisfies. If you would rather keep
`compute_advantage` strictly an advantage, we are glad to add a separate optional hook instead.

## Diff stats

```text
  Total: +28 / −5 across 3 files
  Registry and interface ···· +16 / −1  (49%)
  Config schema ············· +7 / −0   (21%)
  Call sites ················ +5 / −4   (30%)
```
<!--mr-summary:end-->
