### PR TITLE
test: bound every subprocess wait in the GPU suites

### DIFF
--- a/tests/run_test.sh
+++ b/tests/run_test.sh
@@ -129,6 +129,8 @@ run python tests/test_ucxx_fetch_engine.py
 run python tests/test_ucxx_rollout_mixin.py
 run python tests/test_ucxx_transport.py
 run python tests/test_launcher_shutdown.py
+# Guards the wait/teardown helper the GPU suites below rely on to stay bounded.
+run python tests/test_subprocess_helpers.py
 run python tests/test_process_flow.py
 # Composed-transport seam and the UCXX end-to-end guard.  A test file
 # does nothing until it is named here -- run_test.sh is the only thing

--- a/tests/subprocess_helpers.py
+++ b/tests/subprocess_helpers.py
@@ -55,7 +55,16 @@ def kill_process_group(process):
         try:
             _kill_descendants(process.pid)
             pgid = os.getpgid(process.pid)
-            os.killpg(pgid, signal.SIGKILL)
+            # Only killpg a group the child actually leads.  A Popen without
+            # ``start_new_session=True`` leaves the child in *our* process
+            # group, and killpg on that would SIGKILL the test runner itself --
+            # turning a bounded timeout into a suite that dies with no report.
+            # ``_kill_descendants`` above already walked the tree, so skipping
+            # the group signal costs nothing.
+            if pgid != os.getpgrp():
+                os.killpg(pgid, signal.SIGKILL)
+            else:
+                process.kill()
         except (ProcessLookupError, PermissionError):
             pass
         except Exception:
@@ -95,8 +104,31 @@ def wait_for_controller_ready(
     )
 
 
+def resolve_timeout(timeout_s):
+    """Scale a test's wait budget by ``COSMOS_TEST_TIMEOUT_SCALE``.
+
+    The per-call budgets below are sized for a healthy GPU node.  A slow or
+    contended cluster needs all of them raised at once, so the knob is a single
+    multiplier on the helper rather than one env var per test.
+    """
+    try:
+        scale = float(os.environ.get("COSMOS_TEST_TIMEOUT_SCALE", "1"))
+    except ValueError:
+        scale = 1.0
+    if scale <= 0:
+        scale = 1.0
+    return timeout_s * scale
+
+
 def wait_all_or_fail(testcase, processes, timeout_s, context):
-    """Bounded wait for subprocess trees; always reaps process groups."""
+    """Bounded wait for subprocess trees; always reaps process groups.
+
+    Waits against a single shared deadline, not a per-process one: these tests
+    launch a controller plus its peers, and the controller is an HTTP server
+    that exits only on normal completion.  Waiting on it first would otherwise
+    turn any peer-side failure into an unbounded hang.
+    """
+    timeout_s = resolve_timeout(timeout_s)
     deadline = time.monotonic() + timeout_s
     try:
         try:

--- a/tests/test_colocated_separated.py
+++ b/tests/test_colocated_separated.py
@@ -25,6 +25,7 @@ import tempfile
 
 from cosmos_rl.utils import network_util
 from launch_test_worker import load_simple_grpo_config
+from subprocess_helpers import wait_all_or_fail
 
 
 class TestColocatedSeparated(unittest.TestCase):
@@ -125,13 +126,12 @@ class TestColocatedSeparated(unittest.TestCase):
 
         processes = [controller_process, policy_process, rollout_process]
 
-        # Wait for process to complete
-        for process in processes:
-            stdout, stderr = process.communicate()
-            # Check if process completed successfully
-            assert process.returncode == 0, (
-                f"Process failed with code: {process.returncode}"
-            )
+        wait_all_or_fail(
+            self,
+            processes,
+            timeout_s=600,
+            context="test_colocated_separated",
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_custom_class.py
+++ b/tests/test_custom_class.py
@@ -60,13 +60,12 @@ class TestCustomSampler(unittest.TestCase):
         )
         processes = [process]
 
-        # Wait for process to complete
-        for process in processes:
-            stdout, stderr = process.communicate()
-            # Check if process completed successfully
-            assert process.returncode == 0, (
-                f"Process failed with code: {process.returncode}"
-            )
+        wait_all_or_fail(
+            self,
+            processes,
+            timeout_s=600,
+            context="test_data_packer_factory",
+        )
 
     def test_custom_sampler(self):
         cur_dir = os.path.dirname(os.path.abspath(__file__))
@@ -94,13 +93,12 @@ class TestCustomSampler(unittest.TestCase):
         )
         processes = [process]
 
-        # Wait for process to complete
-        for process in processes:
-            stdout, stderr = process.communicate()
-            # Check if process completed successfully
-            assert process.returncode == 0, (
-                f"Process failed with code: {process.returncode}"
-            )
+        wait_all_or_fail(
+            self,
+            processes,
+            timeout_s=600,
+            context="test_custom_sampler",
+        )
 
 
 class TestCustomRolloutOutput(unittest.TestCase):

--- a/tests/test_parallel_map.py
+++ b/tests/test_parallel_map.py
@@ -19,6 +19,8 @@ import sys
 import subprocess
 import unittest
 
+from subprocess_helpers import wait_all_or_fail
+
 
 class TestParallelMap(unittest.TestCase):
     def test_parallel_topo_mapper(self):
@@ -49,28 +51,15 @@ class TestParallelMap(unittest.TestCase):
             stderr=sys.stderr,
             env=env,
         )
-        try:
-            # Wait for process to complete
-            for process in [policy_process]:
-                stdout, stderr = process.communicate()
-
-                # stdout/stderr are both piped directly to sys.stderr above, so
-                # communicate() returns (None, None). Only decode when we
-                # actually captured bytes.
-                stderr_msg = (
-                    stderr.decode(errors="replace")
-                    if isinstance(stderr, (bytes, bytearray))
-                    else ""
-                )
-                assert process.returncode == 0, (
-                    f"Process failed with return code {process.returncode}. "
-                    f"See subprocess output above. {stderr_msg}"
-                )
-
-        finally:
-            # Ensure process is terminated
-            for process in [policy_process]:
-                process.wait()
+        # stdout/stderr are piped straight to sys.stderr above, so the
+        # subprocess output is already on the console; the helper only needs to
+        # bound the wait and check the exit code.
+        wait_all_or_fail(
+            self,
+            [policy_process],
+            timeout_s=600,
+            context="test_parallel_map_check",
+        )
 
     def test_policy_parallelism_extract(self):
         """Test policy parallelism extraction using torchrun."""
@@ -116,26 +105,12 @@ class TestParallelMap(unittest.TestCase):
                 stderr=sys.stderr,
                 env=env,
             )
-            try:
-                # Wait for process to complete
-                for process in [policy_process]:
-                    stdout, stderr = process.communicate()
-
-                    stderr_msg = (
-                        stderr.decode(errors="replace")
-                        if isinstance(stderr, (bytes, bytearray))
-                        else ""
-                    )
-                    assert process.returncode == 0, (
-                        f"Process failed with return code {process.returncode} "
-                        f"(fsdp={fsdp}, tp={tp}, pp={pp}). "
-                        f"See subprocess output above. {stderr_msg}"
-                    )
-
-            finally:
-                # Ensure process is terminated
-                for process in [policy_process]:
-                    process.wait()
+            wait_all_or_fail(
+                self,
+                [policy_process],
+                timeout_s=600,
+                context=f"test_policy_parallelism_extract fsdp={fsdp} tp={tp} pp={pp}",
+            )
 
     def test_rollout_parallelism_extract(self):
         """Test rollout parallelism extraction using torchrun."""
@@ -176,26 +151,12 @@ class TestParallelMap(unittest.TestCase):
                 stderr=sys.stderr,
                 env=env,
             )
-            try:
-                # Wait for process to complete
-                for process in [policy_process]:
-                    stdout, stderr = process.communicate()
-
-                    stderr_msg = (
-                        stderr.decode(errors="replace")
-                        if isinstance(stderr, (bytes, bytearray))
-                        else ""
-                    )
-                    assert process.returncode == 0, (
-                        f"Process failed with return code {process.returncode} "
-                        f"(fsdp={fsdp}, tp={tp}, pp={pp}). "
-                        f"See subprocess output above. {stderr_msg}"
-                    )
-
-            finally:
-                # Ensure process is terminated
-                for process in [policy_process]:
-                    process.wait()
+            wait_all_or_fail(
+                self,
+                [policy_process],
+                timeout_s=600,
+                context=f"test_rollout_parallelism_extract fsdp={fsdp} tp={tp} pp={pp}",
+            )
 
 
 if __name__ == "__main__":

--- a/tests/test_policy_to_policy.py
+++ b/tests/test_policy_to_policy.py
@@ -18,6 +18,8 @@ import unittest
 import torch
 import subprocess
 import sys
+
+from subprocess_helpers import wait_all_or_fail
 from multiprocessing import shared_memory
 import numpy as np
 from cosmos_rl.utils.pynccl import (
@@ -97,18 +99,12 @@ class TestPolicyToPolicy(unittest.TestCase):
                 env=policy_dst_env,
             )
 
-            try:
-                # Wait for process to complete
-                for process in [policy_process, policy_dst_process]:
-                    stdout, stderr = process.communicate()
-
-                    # Check if process completed successfully
-                    assert process.returncode == 0, f"Process failed: {stderr.decode()}"
-
-            finally:
-                # Ensure process is terminated
-                for process in [policy_process, policy_dst_process]:
-                    process.wait()
+            wait_all_or_fail(
+                self,
+                [policy_process, policy_dst_process],
+                timeout_s=600,
+                context="test_policy_to_policy",
+            )
         finally:
             # Clean up shared memory
             try:
@@ -197,18 +193,12 @@ class TestPolicyToPolicy(unittest.TestCase):
                         env=policy_dst_env,
                     )
                 )
-            try:
-                # Wait for process to complete
-                for process in [policy_process] + policy_dst_process:
-                    stdout, stderr = process.communicate()
-
-                    # Check if process completed successfully
-                    assert process.returncode == 0, f"Process failed: {stderr.decode()}"
-
-            finally:
-                # Ensure process is terminated
-                for process in [policy_process] + policy_dst_process:
-                    process.wait()
+            wait_all_or_fail(
+                self,
+                [policy_process] + policy_dst_process,
+                timeout_s=600,
+                context="test_policy_to_multi_policy",
+            )
         finally:
             # Clean up shared memory
             try:

--- a/tests/test_policy_to_rollout.py
+++ b/tests/test_policy_to_rollout.py
@@ -18,6 +18,8 @@ import unittest
 import torch
 import subprocess
 import sys
+
+from subprocess_helpers import wait_all_or_fail
 from multiprocessing import shared_memory
 import numpy as np
 from launch_test_worker import POLICY_WORLD_SIZE, ROLLOUT_WORLD_SIZE
@@ -98,20 +100,12 @@ class TestPolicyToRollout(unittest.TestCase):
                 env=rollout_env,
             )
 
-            try:
-                # Wait for process to complete
-                for process in [policy_process, rollout_process]:
-                    stdout, stderr = process.communicate()
-
-                    # Check if process completed successfully
-                    assert process.returncode == 0, (
-                        f"Process failed: {stderr.decode() if stderr else ''}"
-                    )
-
-            finally:
-                # Ensure process is terminated
-                for process in [policy_process, rollout_process]:
-                    process.wait()
+            wait_all_or_fail(
+                self,
+                [policy_process, rollout_process],
+                timeout_s=600,
+                context="policy_to_rollout_wieght_sync",
+            )
         finally:
             # Clean up shared memory
             try:

--- a/tests/test_policy_variant.py
+++ b/tests/test_policy_variant.py
@@ -21,6 +21,7 @@ import tempfile
 import toml
 
 from cosmos_rl.utils import network_util
+from subprocess_helpers import wait_all_or_fail
 
 
 class TestGspo(unittest.TestCase):
@@ -50,13 +51,12 @@ class TestGspo(unittest.TestCase):
         )
         processes = [process]
 
-        # Wait for process to complete
-        for process in processes:
-            stdout, stderr = process.communicate()
-            # Check if process completed successfully
-            assert process.returncode == 0, (
-                f"Process failed with code: {process.returncode}"
-            )
+        wait_all_or_fail(
+            self,
+            processes,
+            timeout_s=600,
+            context="test_gspo",
+        )
 
 
 class TestReferenceReset(unittest.TestCase):
@@ -86,13 +86,12 @@ class TestReferenceReset(unittest.TestCase):
         )
         processes = [process]
 
-        # Wait for process to complete
-        for process in processes:
-            stdout, stderr = process.communicate()
-            # Check if process completed successfully
-            assert process.returncode == 0, (
-                f"Process failed with code: {process.returncode}"
-            )
+        wait_all_or_fail(
+            self,
+            processes,
+            timeout_s=600,
+            context="test_reference_reset",
+        )
 
 
 class TestPolicyBatchSize(unittest.TestCase):
@@ -122,13 +121,12 @@ class TestPolicyBatchSize(unittest.TestCase):
         )
         processes = [process]
 
-        # Wait for process to complete
-        for process in processes:
-            stdout, stderr = process.communicate()
-            # Check if process completed successfully
-            assert process.returncode == 0, (
-                f"Process failed with code: {process.returncode}"
-            )
+        wait_all_or_fail(
+            self,
+            processes,
+            timeout_s=600,
+            context="test_dynamic_batchsize",
+        )
 
 
 class TestDecoupledLoss(unittest.TestCase):
@@ -214,13 +212,12 @@ class TestDecoupledLoss(unittest.TestCase):
 
         processes = [controller_process, policy_process, rollout_process]
 
-        # Wait for process to complete
-        for process in processes:
-            stdout, stderr = process.communicate()
-            # Check if process completed successfully
-            assert process.returncode == 0, (
-                f"Process failed with code: {process.returncode}"
-            )
+        wait_all_or_fail(
+            self,
+            processes,
+            timeout_s=600,
+            context="test_decoupled_loss",
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_sequence_packing.py
+++ b/tests/test_sequence_packing.py
@@ -18,6 +18,8 @@ import os
 import sys
 import subprocess
 import torch
+
+from subprocess_helpers import wait_all_or_fail
 from transformers import AutoProcessor, AutoModelForCausalLM
 from transformers.utils.import_utils import (
     is_causal_conv1d_available,
@@ -158,13 +160,12 @@ class SeqPackingTest(unittest.TestCase):
         )
         processes = [process]
 
-        # Wait for process to complete
-        for process in processes:
-            stdout, stderr = process.communicate()
-            # Check if process completed successfully
-            assert process.returncode == 0, (
-                f"Process failed with code: {process.returncode}"
-            )
+        wait_all_or_fail(
+            self,
+            processes,
+            timeout_s=600,
+            context=f"run_train_for_sequence_packing fsdp={fsdp} tp={tp} cp={cp}",
+        )
 
     def test_train_for_sequence_packing(self):
         self.run_train_for_sequence_packing(4, 1, 1)

--- a/tests/test_subprocess_helpers.py
+++ b/tests/test_subprocess_helpers.py
@@ -1,0 +1,168 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""CPU-only tests for the subprocess wait/teardown helpers.
+
+``wait_all_or_fail`` is what bounds the GPU integration suites, so it is worth
+exercising against real processes rather than mocks: the failure it exists to
+prevent (an unbounded wait consuming the whole suite budget) only shows up when
+a process genuinely refuses to exit.
+"""
+
+import os
+import subprocess
+import sys
+import time
+import unittest
+
+from subprocess_helpers import kill_process_group, resolve_timeout, wait_all_or_fail
+
+
+def _spawn(code, new_session=False):
+    """Run ``code`` in a child python, output merged into ours."""
+    return subprocess.Popen(
+        [sys.executable, "-c", code],
+        stdout=sys.stderr,
+        stderr=sys.stderr,
+        start_new_session=new_session,
+    )
+
+
+_SLEEP_FOREVER = "import time; time.sleep(600)"
+
+
+class _Recorder:
+    """Stand-in for a TestCase that records failures instead of raising."""
+
+    def __init__(self):
+        self.failures = []
+        self.mismatches = []
+
+    def fail(self, msg):
+        self.failures.append(msg)
+        raise AssertionError(msg)
+
+    def assertEqual(self, actual, expected, msg=None):
+        if actual != expected:
+            self.mismatches.append(msg or f"{actual!r} != {expected!r}")
+            raise AssertionError(msg or f"{actual!r} != {expected!r}")
+
+
+class TestResolveTimeout(unittest.TestCase):
+    def setUp(self):
+        self._saved = os.environ.pop("COSMOS_TEST_TIMEOUT_SCALE", None)
+
+    def tearDown(self):
+        os.environ.pop("COSMOS_TEST_TIMEOUT_SCALE", None)
+        if self._saved is not None:
+            os.environ["COSMOS_TEST_TIMEOUT_SCALE"] = self._saved
+
+    def test_unset_is_identity(self):
+        self.assertEqual(resolve_timeout(600), 600)
+
+    def test_scale_multiplies(self):
+        os.environ["COSMOS_TEST_TIMEOUT_SCALE"] = "2.5"
+        self.assertEqual(resolve_timeout(600), 1500)
+
+    def test_garbage_falls_back_to_identity(self):
+        # A typo in the env must not silently zero out every budget.
+        for bad in ("", "abc", "0", "-3"):
+            os.environ["COSMOS_TEST_TIMEOUT_SCALE"] = bad
+            self.assertEqual(resolve_timeout(600), 600, f"scale={bad!r}")
+
+
+class TestWaitAllOrFail(unittest.TestCase):
+    def test_clean_exit_passes(self):
+        procs = [_spawn("pass"), _spawn("pass")]
+        wait_all_or_fail(self, procs, timeout_s=60, context="clean")
+        for p in procs:
+            self.assertEqual(p.returncode, 0)
+
+    def test_nonzero_exit_fails(self):
+        rec = _Recorder()
+        with self.assertRaises(AssertionError):
+            wait_all_or_fail(rec, [_spawn("raise SystemExit(3)")], 60, "nonzero")
+        self.assertTrue(rec.mismatches, "should have reported a bad exit code")
+
+    def test_hang_is_bounded_and_process_killed(self):
+        proc = _spawn(_SLEEP_FOREVER)
+        rec = _Recorder()
+        started = time.monotonic()
+        with self.assertRaises(AssertionError):
+            wait_all_or_fail(rec, [proc], timeout_s=2, context="hang")
+        elapsed = time.monotonic() - started
+
+        self.assertLess(elapsed, 30, "wait was not bounded by timeout_s")
+        self.assertTrue(any("Timed out" in m for m in rec.failures), rec.failures)
+        # The helper must also reap: a surviving child would keep holding GPUs
+        # (and, under torchrun, a rendezvous port) for the rest of the suite.
+        self.assertIsNotNone(proc.poll(), "hung process was left running")
+
+    def test_deadline_is_shared_not_per_process(self):
+        """Three hung processes must not each get the full budget."""
+        procs = [_spawn(_SLEEP_FOREVER) for _ in range(3)]
+        rec = _Recorder()
+        started = time.monotonic()
+        with self.assertRaises(AssertionError):
+            wait_all_or_fail(rec, procs, timeout_s=2, context="shared-deadline")
+        elapsed = time.monotonic() - started
+
+        # Per-process timeouts would take ~3x the budget before failing.
+        self.assertLess(elapsed, 30, f"deadline was not shared (took {elapsed:.1f}s)")
+        for p in procs:
+            self.assertIsNotNone(p.poll(), "process left running")
+
+    def test_later_process_still_reaped_when_earlier_one_hangs(self):
+        """The finally-block must reap peers the wait never got to."""
+        hung, peer = _spawn(_SLEEP_FOREVER), _spawn(_SLEEP_FOREVER)
+        rec = _Recorder()
+        with self.assertRaises(AssertionError):
+            wait_all_or_fail(rec, [hung, peer], timeout_s=2, context="peer-reap")
+        self.assertIsNotNone(hung.poll(), "hung process left running")
+        self.assertIsNotNone(peer.poll(), "peer process left running")
+
+
+class TestKillProcessGroup(unittest.TestCase):
+    def test_does_not_kill_our_own_process_group(self):
+        """A child sharing our process group must not take the runner down.
+
+        ``Popen`` without ``start_new_session=True`` leaves the child in the
+        runner's group; an unguarded ``killpg`` there would SIGKILL pytest.
+        Reaching the assertion below at all is the real assertion.
+        """
+        child = _spawn(_SLEEP_FOREVER, new_session=False)
+        self.assertEqual(os.getpgid(child.pid), os.getpgrp(), "precondition")
+
+        kill_process_group(child)
+
+        self.assertIsNotNone(child.poll(), "child should have been killed")
+
+    def test_kills_a_child_that_leads_its_own_group(self):
+        child = _spawn(_SLEEP_FOREVER, new_session=True)
+        self.assertNotEqual(os.getpgid(child.pid), os.getpgrp(), "precondition")
+
+        kill_process_group(child)
+
+        self.assertIsNotNone(child.poll(), "child should have been killed")
+
+    def test_already_exited_process_is_a_noop(self):
+        child = _spawn("pass")
+        child.wait()
+        kill_process_group(child)
+        self.assertEqual(child.returncode, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_teacher_model.py
+++ b/tests/test_teacher_model.py
@@ -160,13 +160,12 @@ class TestTeacherModel(unittest.TestCase):
 
         data["is_end"] = True
         redis_controller.publish_teacher_request(data, "test_client")
-        # Wait for process to complete
-        for process in processes:
-            stdout, stderr = process.communicate()
-            # Check if process completed successfully
-            assert process.returncode == 0, (
-                f"Process failed with code: {process.returncode}"
-            )
+        wait_all_or_fail(
+            self,
+            processes,
+            timeout_s=600,
+            context="test_teacher_model",
+        )
 
 
 class TestDistillationFlow(unittest.TestCase):


### PR DESCRIPTION
Eight test files waited on subprocesses with a bare communicate(), so any subprocess that failed to exit consumed the suite's entire remaining budget. test_policy_overfit did exactly that twice on an 8-GPU node, taking 29 later suites down with it.

Route all 16 call sites through the existing wait_all_or_fail helper: one shared deadline for the whole process group rather than a per-process one, and reaping in a finally so a peer the wait never reached is still cleaned up.  test_parallel_map also had an unbounded process.wait() in its own finally; the helper's reaping replaces it.

Fix a process-group hazard this would otherwise have armed. kill_process_group did os.killpg(os.getpgid(child), SIGKILL), but six of these eight files Popen without start_new_session=True, leaving the child in the *runner's* process group -- that call SIGKILLs pytest itself, turning a bounded timeout into a suite that dies with no report.  The three files already using the helper all happened to pass start_new_session=True, which is why it never fired.  Only signal a group the child actually leads; _kill_descendants already walks the tree, so nothing is lost.

Add tests/test_subprocess_helpers.py.  The helper is what bounds the GPU suites and had no coverage at all, so the tests drive real hanging processes rather than mocks: that a hang is bounded and the process reaped, that the deadline is shared (three hung processes do not each get the full budget), that a peer is reaped when an earlier process hangs, and both process-group cases.  CPU-only, ~6s.

Add COSMOS_TEST_TIMEOUT_SCALE, one multiplier over every budget so a slow or contended cluster can raise them all at once instead of via one env var per test.  A garbage or non-positive value falls back to 1.0 rather than zeroing every timeout.

While here: test_policy_to_policy asserted on stderr.decode(), but it pipes to sys.stderr so stderr is always None -- a real failure raised AttributeError instead of reporting the exit code.

Verified: the 11 new tests pass; ruff clean; the pre/post process-group behaviour was checked against a live same-group child (old logic exits 137, guarded logic exits 0 with the child reaped).  The eight converted files need GPUs and were not executed here.