### PR TITLE
fix: skip discard reports in colocated mode

### DIFF
--- a/cosmos_rl/rollout/worker/colocated/rollout_control.py
+++ b/cosmos_rl/rollout/worker/colocated/rollout_control.py
@@ -42,6 +42,9 @@ class ColocatedRolloutControlWorker(DisaggregatedRolloutControlWorker):
         DisaggregatedRolloutControlWorker.rollout_command_handler_registry
     )
 
+    def _report_discarded_samples(self, count: int) -> None:
+        """Skip remote capacity accounting because colocated scheduling observes its local queue."""
+
     def set_command_dispatcher(self, dispatcher: CommandDispatcher):
         """
         Set the command dispatcher for the policy worker.

--- a/tests/test_discarded_rollout_accounting.py
+++ b/tests/test_discarded_rollout_accounting.py
@@ -9,13 +9,21 @@ from unittest.mock import AsyncMock, MagicMock, patch
 from cosmos_rl.dispatcher.protocol import RolloutRequest
 from cosmos_rl.dispatcher.status import PolicyStatusManager
 from cosmos_rl.rollout.schema import RolloutResult
+from cosmos_rl.rollout.worker.colocated.rollout_control import (
+    ColocatedRolloutControlWorker,
+)
 from cosmos_rl.rollout.worker.rollout_control import (
     DisaggregatedRolloutControlWorker,
 )
 
 
-def _rollout_worker(*, n_generation: int = 2, should_report: bool = True):
-    worker = object.__new__(DisaggregatedRolloutControlWorker)
+def _rollout_worker(
+    *,
+    n_generation: int = 2,
+    should_report: bool = True,
+    worker_type=DisaggregatedRolloutControlWorker,
+):
+    worker = object.__new__(worker_type)
     worker.config = SimpleNamespace(
         train=SimpleNamespace(
             non_text=True,
@@ -84,6 +92,19 @@ def test_non_reporting_rank_does_not_report_discard():
         [SimpleNamespace(prompt_idx=0)],
     )
 
+    worker.api_client.post_rollout_completion.assert_not_called()
+
+
+def test_colocated_worker_does_not_report_discarded_samples():
+    worker = _rollout_worker(worker_type=ColocatedRolloutControlWorker)
+
+    valid_payloads, valid_results = worker._filter_valid_rollout_results_and_report(
+        [RolloutResult(completions=[])],
+        [SimpleNamespace(prompt_idx=0)],
+    )
+
+    assert valid_payloads == []
+    assert valid_results == []
     worker.api_client.post_rollout_completion.assert_not_called()
 
 


### PR DESCRIPTION
## Summary

- suppress disaggregated discard-capacity reports in colocated rollout workers
- keep colocated scheduling driven by its local policy queue
- add a regression test for empty colocated rollout results

## Why

Discard reports include a string report ID for idempotent capacity settlement. Colocated mode does not use the disaggregated in-flight capacity ledger, but inherited the reporting path and attempted to aggregate the string ID as a numeric metric, raising TypeError.

## Validation

- python -m pytest tests/test_discarded_rollout_accounting.py -q (7 passed)
- pre-commit run --files cosmos_rl/rollout/worker/colocated/rollout_control.py tests/test_discarded_rollout_accounting.py