### PR TITLE
fix(pynccl): move bytes in the movement collectives so every dtype transfers

### DIFF
--- a/cosmos_rl/utils/pynccl.py
+++ b/cosmos_rl/utils/pynccl.py
@@ -410,8 +410,27 @@ def _submit_nccl(
 
 
 def _dtype_enum(dtype: torch.dtype) -> int:
-    """Map torch.dtype to NCCL enum (raises on unsupported)."""
+    """Map torch.dtype to NCCL enum (raises on unsupported).
+
+    Only reductions need this; movement collectives use :func:`_byte_count`.
+    """
     return ncclDataTypeEnum.from_torch(dtype)
+
+
+def _byte_count(tensor: torch.Tensor) -> int:
+    """Byte extent of a contiguous tensor.
+
+    Movement collectives (broadcast / send / recv / allgather) never interpret
+    the payload -- NCCL uses the datatype solely to derive ``count * itemsize``
+    -- so they are issued as ``ncclUint8`` over this count instead.  That keeps
+    them dtype-agnostic: ``torch.bool``, ``int16``, the unsigned types and any
+    dtype torch adds later all transfer without an entry in
+    :class:`ncclDataTypeEnum`, several of which NCCL has no enum for at all.
+
+    Contiguity is guaranteed by :func:`_check_tensor`, and ``storage_offset`` is
+    already folded into ``data_ptr()``, so this is the exact wire extent.
+    """
+    return tensor.numel() * tensor.element_size()
 
 
 def _redop_enum(op: ReduceOp) -> int:
@@ -713,8 +732,8 @@ def nccl_broadcast(
         _nccl.ncclBroadcast(
             sendbuf,
             recvbuf,
-            tensor.numel(),
-            _dtype_enum(tensor.dtype),
+            _byte_count(tensor),
+            ncclDataTypeEnum.ncclUint8,
             rank,
             meta.comm,
             stream_ptr,
@@ -774,8 +793,8 @@ def nccl_send(
         if phase_observer is None:
             _nccl.ncclSend(
                 _buf(tensor),
-                tensor.numel(),
-                _dtype_enum(tensor.dtype),
+                _byte_count(tensor),
+                ncclDataTypeEnum.ncclUint8,
                 peer,
                 meta.comm,
                 stream_ptr,
@@ -784,8 +803,8 @@ def nccl_send(
             _notify_p2p_phase(phase_observer, "raw_call_enter")
             api_result = _nccl._ncclSendResult(
                 _buf(tensor),
-                tensor.numel(),
-                _dtype_enum(tensor.dtype),
+                _byte_count(tensor),
+                ncclDataTypeEnum.ncclUint8,
                 peer,
                 meta.comm,
                 stream_ptr,
@@ -829,8 +848,8 @@ def nccl_recv(
         if phase_observer is None:
             _nccl.ncclRecv(
                 _buf(tensor),
-                tensor.numel(),
-                _dtype_enum(tensor.dtype),
+                _byte_count(tensor),
+                ncclDataTypeEnum.ncclUint8,
                 peer,
                 meta.comm,
                 stream_ptr,
@@ -839,8 +858,8 @@ def nccl_recv(
             _notify_p2p_phase(phase_observer, "raw_call_enter")
             api_result = _nccl._ncclRecvResult(
                 _buf(tensor),
-                tensor.numel(),
-                _dtype_enum(tensor.dtype),
+                _byte_count(tensor),
+                ncclDataTypeEnum.ncclUint8,
                 peer,
                 meta.comm,
                 stream_ptr,
@@ -908,8 +927,8 @@ def nccl_alltoall(
         _nccl.ncclAllGather(
             _buf(sendbuff),
             _buf(recvbuff),
-            sendbuff.numel(),
-            _dtype_enum(sendbuff.dtype),
+            _byte_count(sendbuff),
+            ncclDataTypeEnum.ncclUint8,
             meta.comm,
             stream_ptr,
         )

--- a/cosmos_rl/utils/pynccl_wrapper.py
+++ b/cosmos_rl/utils/pynccl_wrapper.py
@@ -83,6 +83,15 @@ class ncclDataTypeEnum:
 
     @classmethod
     def from_torch(cls, dtype: torch.dtype) -> int:
+        """Map a torch dtype to its NCCL enum, for **reductions only**.
+
+        Movement collectives (broadcast / send / recv / allgather) do not come
+        through here: they are issued as ``ncclUint8`` over a byte count, which
+        makes them dtype-agnostic.  Reductions genuinely need the dtype because
+        the arithmetic depends on it, so this mapping stays deliberately narrow
+        -- notably ``torch.bool`` keeps raising, since ``ncclSum`` over
+        bools-as-bytes yields counts rather than a logical OR.
+        """
         if dtype == torch.int8:
             return cls.ncclInt8
         if dtype == torch.uint8:
@@ -103,7 +112,10 @@ class ncclDataTypeEnum:
             return cls.ncclFloat8e4m3
         if dtype == torch.float8_e5m2:
             return cls.ncclFloat8e5m2
-        raise ValueError(f"Unsupported dtype: {dtype}")
+        raise ValueError(
+            f"Unsupported dtype for NCCL reduction: {dtype}. "
+            "Movement collectives are dtype-agnostic; cast before reducing."
+        )
 
 
 ncclRedOp_t = ctypes.c_int

--- a/tests/run_test.sh
+++ b/tests/run_test.sh
@@ -95,6 +95,7 @@ run python tests/test_high_availability_nccl.py
 run python tests/test_nccl_collectives.py
 run python tests/test_nccl_timeout.py
 run python tests/test_pynccl_phase_observer.py
+run python tests/test_pynccl_dtype_agnostic.py
 run python tests/test_parallel_map.py
 run python tests/test_policy_to_policy.py
 run python tests/test_policy_to_rollout.py

--- a/tests/test_nccl_collectives.py
+++ b/tests/test_nccl_collectives.py
@@ -37,6 +37,41 @@ def setup_nccl_comm(rank, world_size, nccl_uid):
     return comm_idx
 
 
+# Dtypes exercised by the movement collectives.  bool and int16 have no entry in
+# ncclDataTypeEnum -- NCCL has no int16 type at all -- so they pass only because
+# broadcast/send/recv are issued as byte counts.
+MOVEMENT_DTYPES = [
+    torch.float32,
+    torch.float16,
+    torch.int32,
+    torch.int64,
+    torch.uint8,
+    torch.int8,
+    torch.bfloat16,
+    torch.float64,
+    torch.bool,
+    torch.int16,
+]
+
+# Reductions stay typed, so bool/int16 are excluded here by design.
+REDUCTION_DTYPES = MOVEMENT_DTYPES[:8]
+
+
+def make_payload(dtype, size, device, seed):
+    """Deterministic payload of `dtype` that varies with `seed`."""
+    if dtype == torch.bool:
+        # Must be a *mixed* pattern: an all-False payload is indistinguishable
+        # from a buffer that was never written, which would make the assertion
+        # vacuous.  The +seed shifts the pattern so different senders differ.
+        return (torch.arange(size, device=device) + seed) % 3 == 0
+    return torch.arange(size, dtype=dtype, device=device) * seed
+
+
+def assert_payload_eq(actual, expected, message):
+    """Exact comparison -- movement collectives copy bytes, so nothing drifts."""
+    assert torch.equal(actual, expected), message
+
+
 class TestNCCLBidirectionalSendRecv(unittest.TestCase):
     @staticmethod
     def run_bidirectional_sender(rank, world_size, nccl_uid, dtypes):
@@ -46,10 +81,9 @@ class TestNCCLBidirectionalSendRecv(unittest.TestCase):
         for dtype in dtypes:
             # Create test tensor
             tensor_size = 1000
-            send_tensor = torch.ones(
-                tensor_size, dtype=dtype, device=f"cuda:{rank}"
-            ) * (rank + 1)
-            recv_tensor = torch.zeros(tensor_size, dtype=dtype, device=f"cuda:{rank}")
+            device = f"cuda:{rank}"
+            send_tensor = make_payload(dtype, tensor_size, device, rank + 1)
+            recv_tensor = torch.zeros(tensor_size, dtype=dtype, device=device)
 
             send_rank = 0
             # Send to other rank and receive from other rank
@@ -61,11 +95,11 @@ class TestNCCLBidirectionalSendRecv(unittest.TestCase):
                 nccl_recv(recv_tensor, other_rank, comm_idx)
                 nccl_send(recv_tensor, other_rank, comm_idx)
 
-            # Verify received data
-            expected = torch.ones(tensor_size, dtype=dtype, device=f"cuda:{rank}") * (
-                send_rank + 1
+            # Verify received data: rank 0's payload is echoed back by rank 1.
+            expected = make_payload(dtype, tensor_size, device, send_rank + 1)
+            assert_payload_eq(
+                recv_tensor, expected, f"send/recv failed for dtype {dtype}"
             )
-            assert torch.allclose(recv_tensor, expected)
 
     def test_nccl_bidirectional_send_recv(self):
         """Test bidirectional NCCL send/recv operations between two processes with different CUDA devices."""
@@ -77,16 +111,7 @@ class TestNCCLBidirectionalSendRecv(unittest.TestCase):
         # Define functions for each process (same function but different rank)
         functions = self.run_bidirectional_sender
         # Spawn processes with different functions
-        dtypes = [
-            torch.float32,
-            torch.float16,
-            torch.int32,
-            torch.int64,
-            torch.uint8,
-            torch.int8,
-            torch.bfloat16,
-            torch.float64,
-        ]
+        dtypes = MOVEMENT_DTYPES
         mp.spawn(
             functions,
             args=(world_size, nccl_uid, dtypes),
@@ -106,26 +131,23 @@ class TestNCCLBroadcast(unittest.TestCase):
             for root_rank in range(world_size):
                 # Create test tensor
                 tensor_size = 1000
+                device = f"cuda:{rank}"
                 if rank == root_rank:  # Root rank
                     # Create tensor with unique values based on root rank
-                    tensor = torch.arange(
-                        tensor_size, dtype=dtype, device=f"cuda:{rank}"
-                    ) * (root_rank + 1)
+                    tensor = make_payload(dtype, tensor_size, device, root_rank + 1)
                 else:
                     # Create empty tensor for receiving
-                    tensor = torch.zeros(
-                        tensor_size, dtype=dtype, device=f"cuda:{rank}"
-                    )
+                    tensor = torch.zeros(tensor_size, dtype=dtype, device=device)
 
                 # Perform broadcast from current root rank
                 nccl_broadcast(tensor, root_rank, comm_idx)
 
                 # Verify received data
-                expected = torch.arange(
-                    tensor_size, dtype=dtype, device=f"cuda:{rank}"
-                ) * (root_rank + 1)
-                assert torch.allclose(tensor, expected), (
-                    f"Broadcast from rank {root_rank} failed for dtype {dtype}"
+                expected = make_payload(dtype, tensor_size, device, root_rank + 1)
+                assert_payload_eq(
+                    tensor,
+                    expected,
+                    f"Broadcast from rank {root_rank} failed for dtype {dtype}",
                 )
 
     def test_nccl_broadcast(self):
@@ -136,16 +158,7 @@ class TestNCCLBroadcast(unittest.TestCase):
         nccl_uid = create_nccl_uid()
 
         # Define data types to test
-        dtypes = [
-            torch.float32,
-            torch.float16,
-            torch.int32,
-            torch.int64,
-            torch.uint8,
-            torch.int8,
-            torch.bfloat16,
-            torch.float64,
-        ]
+        dtypes = MOVEMENT_DTYPES
 
         # Spawn processes
         mp.spawn(
@@ -188,16 +201,7 @@ class TestNCCLAllreduce(unittest.TestCase):
         nccl_uid = create_nccl_uid()
 
         # Define data types to test
-        dtypes = [
-            torch.float32,
-            torch.float16,
-            torch.int32,
-            torch.int64,
-            torch.uint8,
-            torch.int8,
-            torch.bfloat16,
-            torch.float64,
-        ]
+        dtypes = REDUCTION_DTYPES
 
         # Spawn processes
         mp.spawn(

--- a/tests/test_nccl_transport.py
+++ b/tests/test_nccl_transport.py
@@ -105,3 +105,7 @@ class TestAttachDataPacker(unittest.TestCase):
                     device="cuda:0",
                     redis_endpoint=RedisEndpoint("h", 1),
                 )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_pynccl_dtype_agnostic.py
+++ b/tests/test_pynccl_dtype_agnostic.py
@@ -1,0 +1,193 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""CPU tests pinning the dtype/count arguments handed to the raw NCCL API.
+
+Movement collectives (broadcast / send / recv / allgather) must be issued as
+``ncclUint8`` over a byte count so that every torch dtype transfers -- including
+``torch.bool`` and ``torch.int16``, which have no entry in ``ncclDataTypeEnum``
+(NCCL has no int16 type at all).  Reductions must stay typed, since their
+arithmetic depends on the dtype.
+
+These run without CUDA or a communicator: the raw library calls are mocked and
+the recorded arguments are asserted directly.
+"""
+
+import unittest
+from contextlib import ExitStack
+from unittest.mock import Mock, patch
+
+import torch
+from torch.distributed import ReduceOp
+
+from cosmos_rl.utils import pynccl
+from cosmos_rl.utils.pynccl_wrapper import ncclDataTypeEnum
+
+# (dtype, itemsize).  bool and int16 are the regression cases -- both are absent
+# from ncclDataTypeEnum.from_torch, so they only work via the byte path.
+DTYPES = [
+    (torch.bool, 1),
+    (torch.int8, 1),
+    (torch.uint8, 1),
+    (torch.int16, 2),
+    (torch.float16, 2),
+    (torch.bfloat16, 2),
+    (torch.int32, 4),
+    (torch.float32, 4),
+    (torch.int64, 8),
+    (torch.float64, 8),
+]
+
+# Deliberately not a power of two: a rounding or off-by-one error in the byte
+# arithmetic stays visible instead of being masked by a round number.
+NUMEL = 7
+
+
+def _tensor(dtype: torch.dtype, numel: int = NUMEL) -> torch.Tensor:
+    return torch.zeros(numel, dtype=dtype)
+
+
+class _RawCalls(ExitStack):
+    """Patch pynccl's plumbing so a wrapper runs inline against mocked C calls."""
+
+    def __init__(self, *names: str):
+        super().__init__()
+        self._names = names
+        self.mocks: dict[str, Mock] = {}
+
+    def __enter__(self) -> "_RawCalls":
+        super().__enter__()
+        meta = pynccl._CommMeta(comm=Mock(), rank=1, world_size=2)
+        self.enter_context(patch.object(pynccl, "_worker_started", True))
+        self.enter_context(patch.object(pynccl, "_check_tensor"))
+        self.enter_context(patch.object(pynccl, "_stream_ptr", return_value=Mock()))
+        self.enter_context(patch.object(pynccl, "_buf", return_value=Mock()))
+        self.enter_context(
+            patch.object(pynccl._CommunicatorRegistry, "get", return_value=meta)
+        )
+        self.enter_context(
+            patch.object(
+                pynccl._nccl,
+                "ncclCommGetAsyncError",
+                Mock(return_value=0),
+            )
+        )
+        for name in self._names:
+            mock = Mock()
+            self.enter_context(patch.object(pynccl._nccl, name, mock, create=True))
+            self.mocks[name] = mock
+        return self
+
+
+class TestMovementIsDtypeAgnostic(unittest.TestCase):
+    """Every movement wrapper sends bytes, whatever the tensor dtype."""
+
+    def _assert_bytes(self, mock: Mock, count_index: int, expected_bytes: int):
+        mock.assert_called_once()
+        args = mock.call_args.args
+        self.assertEqual(args[count_index], expected_bytes)
+        self.assertEqual(args[count_index + 1], ncclDataTypeEnum.ncclUint8)
+
+    def test_broadcast_passes_a_byte_count_for_every_dtype(self):
+        for dtype, itemsize in DTYPES:
+            with self.subTest(dtype=dtype):
+                with _RawCalls("ncclBroadcast") as raw:
+                    pynccl.nccl_broadcast(_tensor(dtype), 1, 4)
+                # ncclBroadcast(sendbuf, recvbuf, count, datatype, root, ...)
+                self._assert_bytes(raw.mocks["ncclBroadcast"], 2, NUMEL * itemsize)
+
+    def test_send_and_recv_pass_a_byte_count_for_every_dtype(self):
+        for direction, name in (("send", "ncclSend"), ("recv", "ncclRecv")):
+            call = pynccl.nccl_send if direction == "send" else pynccl.nccl_recv
+            for dtype, itemsize in DTYPES:
+                with self.subTest(direction=direction, dtype=dtype):
+                    with _RawCalls(name) as raw:
+                        call(_tensor(dtype), 0, 4)
+                    # nccl{Send,Recv}(buf, count, datatype, peer, ...)
+                    self._assert_bytes(raw.mocks[name], 1, NUMEL * itemsize)
+
+    def test_observer_path_passes_the_same_byte_count(self):
+        """The phase-observer branch is a separate call site; it must match."""
+        for direction, name in (
+            ("send", "_ncclSendResult"),
+            ("recv", "_ncclRecvResult"),
+        ):
+            call = pynccl.nccl_send if direction == "send" else pynccl.nccl_recv
+            with self.subTest(direction=direction):
+                with _RawCalls(name) as raw:
+                    raw.mocks[name].return_value = 0
+                    raw.enter_context(
+                        patch.object(
+                            pynccl._nccl,
+                            "_ncclCommGetAsyncErrorResult",
+                            Mock(return_value=(0, 0)),
+                            create=True,
+                        )
+                    )
+                    call(_tensor(torch.bool), 0, 4, phase_observer=lambda *_: None)
+                self._assert_bytes(raw.mocks[name], 1, NUMEL)
+
+    def test_alltoall_passes_a_byte_count(self):
+        for dtype, itemsize in DTYPES:
+            with self.subTest(dtype=dtype):
+                with _RawCalls("ncclAllGather") as raw:
+                    pynccl.nccl_alltoall(_tensor(dtype), _tensor(dtype, NUMEL * 2), 4)
+                # ncclAllGather(sendbuf, recvbuf, sendcount, datatype, ...)
+                self._assert_bytes(raw.mocks["ncclAllGather"], 2, NUMEL * itemsize)
+
+
+class TestReductionsStayTyped(unittest.TestCase):
+    """Reductions must keep the real dtype -- their arithmetic depends on it."""
+
+    def test_allreduce_passes_the_typed_enum(self):
+        with _RawCalls("ncclAllReduce") as raw:
+            buf = _tensor(torch.float32)
+            pynccl.nccl_allreduce(buf, buf, ReduceOp.SUM, 4)
+
+        args = raw.mocks["ncclAllReduce"].call_args.args
+        # ncclAllReduce(sendbuf, recvbuf, count, datatype, op, ...)
+        self.assertEqual(args[2], NUMEL)  # elements, not bytes
+        self.assertEqual(args[3], ncclDataTypeEnum.ncclFloat32)
+
+    def test_allreduce_still_rejects_bool(self):
+        """A bool allreduce must fail rather than silently summing bytes.
+
+        The dtype lookup happens inside the functor that runs on the NCCL worker
+        thread, and _submit_nccl reports a functor failure as a TimeoutError on
+        the enqueue path -- so assert on the observable contract (the collective
+        never reaches the wire) rather than on the exception type.
+        """
+        with _RawCalls("ncclAllReduce") as raw:
+            buf = _tensor(torch.bool)
+            with self.assertRaises(Exception):
+                pynccl.nccl_allreduce(buf, buf, ReduceOp.SUM, 4)
+            raw.mocks["ncclAllReduce"].assert_not_called()
+
+        # The mapping itself raises precisely, which is what callers see when
+        # they resolve the dtype up front.
+        with self.assertRaisesRegex(ValueError, "reduction"):
+            pynccl._dtype_enum(torch.bool)
+
+    def test_from_torch_still_rejects_bool(self):
+        """Intentional, not an oversight.
+
+        ncclSum over bools-as-bytes yields counts rather than a logical OR, so
+        bool has no correct reduction mapping.  Movement does not come through
+        here, so nothing needs it.
+        """
+        for dtype in (torch.bool, torch.int16):
+            with self.subTest(dtype=dtype):
+                with self.assertRaisesRegex(ValueError, "reduction"):
+                    ncclDataTypeEnum.from_torch(dtype)
+
+    def test_from_torch_still_maps_the_reducible_dtypes(self):
+        self.assertEqual(
+            ncclDataTypeEnum.from_torch(torch.float32), ncclDataTypeEnum.ncclFloat32
+        )
+        self.assertEqual(
+            ncclDataTypeEnum.from_torch(torch.int64), ncclDataTypeEnum.ncclInt64
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_pynccl_phase_observer.py
+++ b/tests/test_pynccl_phase_observer.py
@@ -23,6 +23,7 @@ class TestP2PPhaseObserver(unittest.TestCase):
     ) -> dict[str, Mock]:
         tensor = Mock()
         tensor.numel.return_value = 8
+        tensor.element_size.return_value = 2
         meta = pynccl._CommMeta(comm=Mock(), rank=1, world_size=2)
         legacy_raw = Mock()
         result_raw = Mock(return_value=raw_result)


### PR DESCRIPTION
## Problem

A full-model weight sync fails as soon as the model carries a `torch.bool` buffer:

```
ValueError: Unsupported dtype: torch.bool
```

`ncclDataTypeEnum.from_torch` (`cosmos_rl/utils/pynccl_wrapper.py`) maps 10 dtypes and raises on everything else. Two of the three weight-sync paths walk `state_dict()` verbatim with no dtype cast, so both die on the first bool entry:

| Path | Casts before send? | Affected |
|---|---|---|
| P2R policy→rollout (`rl_worker.py`) | yes, `train.transfer_dtype` | no |
| R2R broadcast (`weight_sync.py`, `do_nccl_broadcast_grouped`) | no, verbatim `state_dict()` | **yes** |
| P2P `sync_all_states` (`llm_trainer.py`, merges `named_buffers()`) | no | **yes** |

Concrete motivation: a model with bool buffers (attention/causal masks, `is_initialized` flags) in `state_dict()` cannot weight-sync at all. In our case 15 bool buffers out of 840 entries, so it fires on the first full-model broadcast.

## Why not just add a `torch.bool` branch

The gap is wider than bool. `from_torch` also rejects `int16`, `uint16/32/64`, the `fnuz` fp8 variants, and complex. It covers `int8`/`int32`/`int64` but not `int16`, and `uint8` but no wider unsigned — an ad-hoc list rather than a principled subset. Several of those **cannot** be expressed as an enum entry at all, because NCCL has no corresponding type.

Adding a bool branch would also introduce a caveat that needs documenting: bool mapped to `ncclUint8` is byte-safe for movement but wrong for reductions, since `ncclSum` over bools-as-bytes yields counts rather than a logical OR.

## Fix

`ncclBroadcast`/`Send`/`Recv`/`AllGather` use the datatype for exactly one thing — deriving `count * itemsize`. They perform no conversion. So `(numel, dtype)` and `(numel * element_size, ncclUint8)` put identical bytes on the wire, and the movement wrappers can simply pass a byte count:

```python
def _byte_count(tensor: torch.Tensor) -> int:
    return tensor.numel() * tensor.element_size()

_nccl.ncclBroadcast(
    sendbuf, recvbuf,
    _byte_count(tensor), ncclDataTypeEnum.ncclUint8,
    rank, meta.comm, stream_ptr,
)
```

Applied to all six movement call sites: `nccl_broadcast`, `nccl_send` and `nccl_recv` (both the legacy and phase-observer branches), and `nccl_alltoall`.

Contiguity is already guaranteed by `_check_tensor`, `storage_offset` is folded into `data_ptr()`, and the count arguments are `ctypes.c_size_t` — so the byte extent is exact and cannot overflow.

**`nccl_allreduce` deliberately stays typed.** Reduction arithmetic genuinely depends on the dtype, so it keeps `_dtype_enum`, and `from_torch(torch.bool)` still raises — which is correct. `from_torch` becomes the reduction-only mapping and its error message now says so. This removes the reduction caveat rather than documenting it.

This also matches what the rollout payload transport already does — pack into a flat `uint8` buffer and carry dtype out of band in a `TensorSpec` schema (`pack.py`, `trajectory.py`) — which is why that path never had this problem.

## Tests

- **New `tests/test_pynccl_dtype_agnostic.py`** (CPU-only, no CUDA or communicator): pins the exact byte count and `ncclUint8` across all six movement call sites for 10 dtypes, using a non-power-of-two element count so off-by-one arithmetic surfaces. Asserts `nccl_allreduce` still passes the typed enum and still rejects bool.
- **`tests/test_nccl_collectives.py`**: `torch.bool` and `torch.int16` added to the broadcast and send/recv sweeps, excluded from the allreduce sweep. `int16` earns its place — NCCL has no int16 type, so it passes only if the byte path is genuinely live. Bool payloads use a mixed pattern, since an all-False buffer is indistinguishable from one that was never written.
- **`tests/test_nccl_transport.py`**: added the missing `unittest.main()`. It was registered in `run_test.sh` but ran zero tests when invoked as a script.
- Registered the new suite in `tests/run_test.sh`.

Verified locally: the CPU suites pass, and on a single-GPU box a 1-rank communicator broadcasts `bool`/`int16`/`float32`/`uint8`/`int64` with exact round-trip. Reverting only `pynccl.py`/`pynccl_wrapper.py` makes the bool case fail again, confirming the fix is responsible.

The multi-GPU sweeps in `test_nccl_collectives.py` and `test_comm.py` need 2–8 GPUs and have not been run yet; they are the natural thing for CI to cover.