### PR TITLE
perf(rollout): group the synchronous trainable-subset R2R broadcast

### DIFF
--- a/cosmos_rl/rollout/worker/rollout_control.py
+++ b/cosmos_rl/rollout/worker/rollout_control.py
@@ -1508,6 +1508,11 @@ class DisaggregatedRolloutControlWorker(RolloutWorkerBase):
 
                     src_rank = self.replica_name_to_rank[src_replica_name]
                     with torch.inference_mode():
+                        # One collective for the whole subset: a handshake per
+                        # parameter across every replica costs far more than the
+                        # traffic for a model of many small tensors.
+                        non_contig: list[tuple[torch.Tensor, torch.Tensor]] = []
+                        nccl_group_start(self.global_commnicator_idex)
                         for name, parameter in self.rollout.model_param_map(
                             self.weight_mapper
                         ).items():
@@ -1522,13 +1527,18 @@ class DisaggregatedRolloutControlWorker(RolloutWorkerBase):
                             recv_tensor = parameter
                             if not parameter.is_contiguous():
                                 recv_tensor = parameter.contiguous()
+                                non_contig.append((parameter, recv_tensor))
 
                             nccl_broadcast(
                                 recv_tensor, src_rank, self.global_commnicator_idex
                             )
 
-                            if not parameter.is_contiguous():
-                                parameter.copy_(recv_tensor)
+                        nccl_group_end(self.global_commnicator_idex)
+                        # Only now do the receives hold their data, so a copy
+                        # back into a non-contiguous parameter has to wait for
+                        # the group to close.
+                        for parameter, recv_tensor in non_contig:
+                            parameter.copy_(recv_tensor)
 
                     if not self.state.weight_synced():
                         assert not trainable_only, (

--- a/tests/run_test.sh
+++ b/tests/run_test.sh
@@ -151,7 +151,7 @@ run python tests/test_put_rollouts.py
 run python tests/test_trajectory_iteration.py
 run python tests/test_gym_example.py
 # Pytest-style CPU suites; install pytest in case the image lacks it.
-run /bin/bash -c "python -m pip install --quiet pytest && python -m pytest -q tests/test_weight_sync.py tests/test_checkpoint.py tests/test_ranked_rollout_end_and_wst_fence.py tests/test_terminal_checkpoint_trainer_hooks.py tests/test_terminal_drain_protocol.py tests/test_training_complete_checkpoint.py"
+run /bin/bash -c "python -m pip install --quiet pytest && python -m pytest -q tests/test_weight_sync.py tests/test_r2r_broadcast_grouping.py tests/test_checkpoint.py tests/test_ranked_rollout_end_and_wst_fence.py tests/test_terminal_checkpoint_trainer_hooks.py tests/test_terminal_drain_protocol.py tests/test_training_complete_checkpoint.py"
 run python -m unittest -v tests.contracts.test_trainer_metrics_contract
 run python -m unittest -v tests.contracts.test_config_routing_contract
 run python -m unittest -v tests.contracts.test_model_registry_contract

--- a/tests/test_r2r_broadcast_grouping.py
+++ b/tests/test_r2r_broadcast_grouping.py
@@ -1,0 +1,127 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the synchronous R2R broadcast shape (CPU-only).
+
+No NCCL traffic: the transport calls are stubbed with fakes that record the
+call order and, like a real group, only deliver a receive buffer's data once
+the group closes.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import torch
+
+from cosmos_rl.dispatcher.command import RolloutToRolloutBroadcastCommand
+from cosmos_rl.rollout.worker.rollout_control import DisaggregatedRolloutControlWorker
+from cosmos_rl.rollout.worker.weight_sync import AsyncR2RSyncMode
+
+
+class _FakeTransport:
+    """Records the call order and defers every receive fill to group end."""
+
+    def __init__(self):
+        self.calls: list[str] = []
+        self._pending: list[torch.Tensor] = []
+
+    def group_start(self, comm_idx):
+        self.calls.append("group_start")
+
+    def broadcast(self, tensor, rank, comm_idx):
+        self.calls.append("broadcast")
+        self._pending.append(tensor)
+
+    def group_end(self, comm_idx):
+        self.calls.append("group_end")
+        for tensor in self._pending:
+            tensor.fill_(1.0)
+        self._pending.clear()
+
+
+def _make_worker(param_map, trainable_params):
+    worker = object.__new__(DisaggregatedRolloutControlWorker)
+    worker.replica_name = "rollout-0"
+    worker.rank_in_rollout_repicas = 0
+    worker.replica_name_to_rank = {"rollout-0": 0, "rollout-1": 1}
+    worker.global_commnicator_idex = 7
+    worker.inference_stream = None
+    worker.weight_mapper = None
+    worker.trainable_params = trainable_params
+    worker.non_trainable_params_received = True
+    worker.current_weight_version = 3
+    worker.prepare_trainable_params = lambda: None
+    worker.rollout = SimpleNamespace(model_param_map=lambda _mapper: param_map)
+    worker.state = SimpleNamespace(
+        weight_synced=lambda: True, set_weight_synced=lambda: None
+    )
+    worker.config = SimpleNamespace(
+        validation=SimpleNamespace(enable=False, val_before_train=False, freq=1)
+    )
+    return worker
+
+
+def _broadcast(worker, trainable_only):
+    command = RolloutToRolloutBroadcastCommand(
+        src_replica_name="rollout-0",
+        dst_replica_names=["rollout-0", "rollout-1"],
+        weight_step=4,
+        total_steps=10,
+        trainable_only=trainable_only,
+    )
+    transport = _FakeTransport()
+    with (
+        patch(
+            "cosmos_rl.rollout.worker.rollout_control.nccl_group_start",
+            transport.group_start,
+        ),
+        patch(
+            "cosmos_rl.rollout.worker.rollout_control.nccl_broadcast",
+            transport.broadcast,
+        ),
+        patch(
+            "cosmos_rl.rollout.worker.rollout_control.nccl_group_end",
+            transport.group_end,
+        ),
+        patch(
+            "cosmos_rl.rollout.worker.rollout_control.get_async_r2r_sync_mode",
+            lambda _worker: AsyncR2RSyncMode.DISABLED,
+        ),
+        patch(
+            "cosmos_rl.rollout.worker.rollout_control.get_broadcast_all_params",
+            lambda _worker: False,
+        ),
+    ):
+        worker.broadcast_to_all_rollout_replica(command)
+    return transport
+
+
+def test_trainable_subset_travels_as_one_group():
+    param_map = {name: torch.zeros(2) for name in ("a.weight", "b.weight", "c.weight")}
+    worker = _make_worker(param_map, trainable_params={"a.weight", "b.weight"})
+
+    transport = _broadcast(worker, trainable_only=True)
+
+    # One group around the whole subset, and the frozen parameter stays home.
+    assert transport.calls == ["group_start", "broadcast", "broadcast", "group_end"]
+
+
+def test_whole_state_dict_travels_when_not_trainable_only():
+    param_map = {name: torch.zeros(2) for name in ("a.weight", "b.weight", "c.weight")}
+    worker = _make_worker(param_map, trainable_params={"a.weight"})
+
+    transport = _broadcast(worker, trainable_only=False)
+
+    assert transport.calls.count("broadcast") == len(param_map)
+
+
+def test_non_contiguous_parameter_is_written_after_the_group_closes():
+    # A transposed view: the broadcast lands in a contiguous copy, and the copy
+    # back into the parameter is only valid once the group has delivered it.
+    parameter = torch.zeros(2, 3).t()
+    assert not parameter.is_contiguous()
+    worker = _make_worker({"a.weight": parameter}, trainable_params={"a.weight"})
+
+    _broadcast(worker, trainable_only=True)
+
+    assert torch.equal(parameter, torch.ones(3, 2))


### PR DESCRIPTION
## Summary

The synchronous R2R path offers two shapes and the cheap one is neither of them:

- the per-parameter branch sends only the trainable subset, but pays one collective per
  tensor — each a handshake across every rollout replica;
- the grouped branch (`broadcast_all_params=true`) pays one collective, but walks the whole
  state dict and so ships the frozen parameters on every sync.

This groups the per-parameter loop, so both savings apply at once and `broadcast_all_params`
means only what its name says: whether frozen parameters travel too.

## Measurements

From an RL run with twelve single-rank rollout replicas on two nodes, 3.30 GiB of trainable
parameters across 321 tensors:

| Broadcast shape | Bytes per sync | Collectives | Transfer, median | Effective rate |
| --- | --- | --- | --- | --- |
| per-parameter, trainable subset | 3.30 GiB | 321 | 0.34 s | 9.7 GiB/s |
| grouped, whole state dict | 7.88 GiB | 1 | 0.16 s | 49 GiB/s |
| grouped, trainable subset — this PR | 3.30 GiB | 1 | 0.05 s | 66 GiB/s |

At equal bytes grouping is worth about 7x here, and it costs no memory: a contiguous
parameter is still broadcast in place, and model VRAM measured identical at 7.5 GiB per rank
across all three shapes.

## Implementation notes

A non-contiguous parameter's receive buffer only holds its data once the group closes, so those
copies back are deferred to after `nccl_group_end` — the same way `do_nccl_broadcast_grouped`
already handles them.

The obvious alternative, giving `do_nccl_broadcast_grouped` a `trainable_only` flag and calling
it from this branch, would change what gets sent: that function iterates `_buffer_state_dict` or
a raw `state_dict()`, whereas this branch iterates `rollout.model_param_map(weight_mapper)`,
which is HF-name-mapped and includes `get_quantized_tensors`. Names and membership both differ,
and `trainable_params` is keyed to the latter. Grouping in place keeps the set of tensors and
their order exactly as they were.

## Testing

`tests/test_r2r_broadcast_grouping.py`, CPU-only, with the transport stubbed by a fake that
records the call order and, like a real group, only fills a receive buffer at group end. Both
the grouping and the deferred copy-back fail against the pre-change code, so they are real
regression checks rather than restatements. Added to the pytest line in `tests/run_test.sh`.

## Validation

- `python -m pytest -q tests/test_r2r_broadcast_grouping.py tests/test_weight_sync.py tests/test_ranked_rollout_end_and_wst_fence.py` — 49 passed
- `uvx ruff@0.12.7 format --check` and `uvx ruff@0.12.7 check` on the changed files — clean
- Verified the new assertions fail with the change reverted
