### PR TITLE
feat(rollout): give the rollout backend a pause for weight sync

### DIFF
--- a/cosmos_rl/rollout/rollout_base.py
+++ b/cosmos_rl/rollout/rollout_base.py
@@ -14,6 +14,8 @@
 # limitations under the License.
 
 from abc import ABC, abstractmethod
+from collections.abc import Iterator
+from contextlib import contextmanager
 from typing import List, Callable, Dict, Tuple, Type
 from cosmos_rl.dispatcher.data.schema import RLPayload
 
@@ -134,6 +136,23 @@ class RolloutBase(ABC):
         """
         # In some case, the engine may create a child thread to run the generation, Rollout should release the resources before shutting down.
         pass
+
+    @contextmanager
+    def paused(self) -> Iterator[None]:
+        """
+        Quiesce generation for the duration of the block.
+
+        Weight sync overwrites the served model's tensors in place, which is
+        only safe while no forward is running. An engine whose generation call
+        blocks the caller is already quiesced whenever a weight sync can run, so
+        the default does nothing. An engine that keeps serving on its own thread
+        has to park here, and may only return once no forward is running and
+        none can start.
+
+        Yields:
+            Control, with generation quiesced.
+        """
+        yield
 
     def pre_get_params_for_sync_hook(
         self,

--- a/cosmos_rl/rollout/worker/rollout_control.py
+++ b/cosmos_rl/rollout/worker/rollout_control.py
@@ -81,6 +81,7 @@ from cosmos_rl.rollout.worker.weight_sync import (
     AsyncR2RSyncMode,
     get_async_r2r_sync_mode,
     get_broadcast_all_params,
+    holds_payload_egress,
     ensure_wst,
     sync_buffer_to_live,
     process_wst_deferred_actions,
@@ -1212,6 +1213,7 @@ class DisaggregatedRolloutControlWorker(RolloutWorkerBase):
                 ensure_wst(self)
 
     @RolloutWorkerBase.register_rollout_command_handler(PolicyToRolloutUnicastCommand)
+    @holds_payload_egress
     @torch.no_grad()
     def policy_to_rollout_unicast(self, command: PolicyToRolloutUnicastCommand):
         """Sync the weight from policy to rollout.
@@ -1415,6 +1417,7 @@ class DisaggregatedRolloutControlWorker(RolloutWorkerBase):
     @RolloutWorkerBase.register_rollout_command_handler(
         RolloutToRolloutBroadcastCommand
     )
+    @holds_payload_egress
     def broadcast_to_all_rollout_replica(
         self, broadcast_command: RolloutToRolloutBroadcastCommand
     ) -> None:
@@ -1431,13 +1434,6 @@ class DisaggregatedRolloutControlWorker(RolloutWorkerBase):
         """
         src_replica_name: str = broadcast_command.src_replica_name
         dst_replica_names: List[str] = broadcast_command.dst_replica_names
-
-        # Forward-compat: flush any pending async NCCL sends (e.g. from data
-        # packers) so they complete before weight sync reuses the communicator.
-        if hasattr(self, "data_packer") and hasattr(
-            self.data_packer, "flush_pending_sends"
-        ):
-            self.data_packer.flush_pending_sends()
 
         # lazy initialization of the rollout engine.
         if self.replica_name != src_replica_name:

--- a/cosmos_rl/rollout/worker/rollout_control.py
+++ b/cosmos_rl/rollout/worker/rollout_control.py
@@ -82,6 +82,7 @@ from cosmos_rl.rollout.worker.weight_sync import (
     get_async_r2r_sync_mode,
     get_broadcast_all_params,
     holds_payload_egress,
+    pauses_generation,
     ensure_wst,
     sync_buffer_to_live,
     process_wst_deferred_actions,
@@ -1214,6 +1215,7 @@ class DisaggregatedRolloutControlWorker(RolloutWorkerBase):
 
     @RolloutWorkerBase.register_rollout_command_handler(PolicyToRolloutUnicastCommand)
     @holds_payload_egress
+    @pauses_generation
     @torch.no_grad()
     def policy_to_rollout_unicast(self, command: PolicyToRolloutUnicastCommand):
         """Sync the weight from policy to rollout.
@@ -1418,6 +1420,7 @@ class DisaggregatedRolloutControlWorker(RolloutWorkerBase):
         RolloutToRolloutBroadcastCommand
     )
     @holds_payload_egress
+    @pauses_generation
     def broadcast_to_all_rollout_replica(
         self, broadcast_command: RolloutToRolloutBroadcastCommand
     ) -> None:

--- a/cosmos_rl/rollout/worker/weight_sync.py
+++ b/cosmos_rl/rollout/worker/weight_sync.py
@@ -176,6 +176,47 @@ def holds_payload_egress(handler: Callable) -> Callable:
 
 
 # ---------------------------------------------------------------------------
+# Generation safe point
+# ---------------------------------------------------------------------------
+
+
+@contextmanager
+def generation_paused(worker) -> Iterator[None]:
+    """Quiesce generation while weight sync writes the served model in place.
+
+    A weight sync that runs while a forward is in flight can overwrite the
+    tensors that forward is reading.  Nothing runs concurrently for an engine
+    whose generation call blocks the main loop, which is why the backend's
+    ``paused`` does nothing by default, but stream generation feeds a scheduler
+    that keeps working while the main loop dequeues a command, and an engine
+    that serves on a thread of its own never stops on its own account.
+
+    A sync in one of the async modes is exempt: it writes a buffer clone and
+    ``install_inference_sync`` swaps that in at its own safe point, so the
+    served tensors are never written under a forward.
+
+    Yields:
+        Control, with generation quiesced for as long as the block runs.
+    """
+    if get_async_r2r_sync_mode(worker) != AsyncR2RSyncMode.DISABLED:
+        yield
+        return
+    with worker.rollout.paused():
+        yield
+
+
+def pauses_generation(handler: Callable) -> Callable:
+    """Run a weight-sync command handler with generation quiesced."""
+
+    @functools.wraps(handler)
+    def handler_with_generation_paused(self, command: Any, *args, **kwargs):
+        with generation_paused(self):
+            return handler(self, command, *args, **kwargs)
+
+    return handler_with_generation_paused
+
+
+# ---------------------------------------------------------------------------
 # Buffer model helpers
 # ---------------------------------------------------------------------------
 

--- a/cosmos_rl/rollout/worker/weight_sync.py
+++ b/cosmos_rl/rollout/worker/weight_sync.py
@@ -51,12 +51,15 @@ to ``true`` for models with non-trainable params that must be synced
 
 from __future__ import annotations
 
+import functools
 import os
 import queue
 import threading
 import time
+from collections.abc import Iterator
+from contextlib import contextmanager
 from enum import Enum
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING, Any, Callable, Optional
 
 import torch
 from torch.distributed.tensor import DTensor
@@ -123,6 +126,53 @@ def get_async_r2r_sync_mode(worker) -> AsyncR2RSyncMode:
 def get_broadcast_all_params(worker) -> bool:
     """Read ``broadcast_all_params`` from ``[rollout]`` in worker config."""
     return worker.config.rollout.broadcast_all_params
+
+
+# ---------------------------------------------------------------------------
+# Payload egress
+# ---------------------------------------------------------------------------
+
+
+@contextmanager
+def payload_egress_held(worker) -> Iterator[None]:
+    """Keep a data packer's payload egress off this device's NCCL for a sync.
+
+    NCCL gives no guarantee for two communicators at once on one device, so a
+    packer that ships payloads over NCCL must have no send in flight while
+    weight sync uses the device.  ``flush_pending_sends`` drains what is
+    already in flight, but nothing stops the packer claiming the next payload
+    the moment it returns, and a sync spends most of its wall time between that
+    drain and its transfer, waiting on a barrier for its peers.  A packer that
+    implements ``hold_sends`` gets the guarantee for the whole sync instead:
+    egress resumes when it is over.
+
+    Both are optional, so a packer that ships nothing over this device's NCCL
+    needs neither.
+
+    Yields:
+        Control, with payload egress held for as long as the block runs.
+    """
+    packer = getattr(worker, "data_packer", None)
+    hold_sends = getattr(packer, "hold_sends", None)
+    if hold_sends is not None:
+        with hold_sends():
+            yield
+        return
+    flush_pending_sends = getattr(packer, "flush_pending_sends", None)
+    if flush_pending_sends is not None:
+        flush_pending_sends()
+    yield
+
+
+def holds_payload_egress(handler: Callable) -> Callable:
+    """Run a weight-sync command handler with payload egress held."""
+
+    @functools.wraps(handler)
+    def handler_with_egress_held(self, command: Any, *args, **kwargs):
+        with payload_egress_held(self):
+            return handler(self, command, *args, **kwargs)
+
+    return handler_with_egress_held
 
 
 # ---------------------------------------------------------------------------
@@ -558,10 +608,11 @@ class WeightSyncThread:
                 self._idle.set()
                 continue
             try:
-                if cmd_type == "p2r":
-                    self._execute_p2r(command)
-                elif cmd_type == "r2r":
-                    self._execute_r2r(command)
+                with payload_egress_held(self._worker):
+                    if cmd_type == "p2r":
+                        self._execute_p2r(command)
+                    elif cmd_type == "r2r":
+                        self._execute_r2r(command)
             except Exception:
                 self._task_failed = True
                 logger.exception(
@@ -599,15 +650,10 @@ class WeightSyncThread:
         When commands are routed directly from the background command
         thread (bypassing the main-thread handler), the WST is
         responsible for bookkeeping that would normally be done in the
-        handler: ``flush_pending_sends``, ``set_weight_synced``.
+        handler: ``set_weight_synced``.  Payload egress is held for it by
+        the run loop, around this whole command.
         """
         worker = self._worker
-
-        # Flush any pending async NCCL sends before reusing the communicator.
-        if hasattr(worker, "data_packer") and hasattr(
-            worker.data_packer, "flush_pending_sends"
-        ):
-            worker.data_packer.flush_pending_sends()
 
         weight_step = command.weight_step
         # Use the controller's authoritative recipient set for this round as the

--- a/tests/run_test.sh
+++ b/tests/run_test.sh
@@ -151,7 +151,7 @@ run python tests/test_put_rollouts.py
 run python tests/test_trajectory_iteration.py
 run python tests/test_gym_example.py
 # Pytest-style CPU suites; install pytest in case the image lacks it.
-run /bin/bash -c "python -m pip install --quiet pytest && python -m pytest -q tests/test_weight_sync.py tests/test_weight_sync_payload_egress.py tests/test_checkpoint.py tests/test_ranked_rollout_end_and_wst_fence.py tests/test_terminal_checkpoint_trainer_hooks.py tests/test_terminal_drain_protocol.py tests/test_training_complete_checkpoint.py"
+run /bin/bash -c "python -m pip install --quiet pytest && python -m pytest -q tests/test_weight_sync.py tests/test_weight_sync_payload_egress.py tests/test_weight_sync_generation_pause.py tests/test_checkpoint.py tests/test_ranked_rollout_end_and_wst_fence.py tests/test_terminal_checkpoint_trainer_hooks.py tests/test_terminal_drain_protocol.py tests/test_training_complete_checkpoint.py"
 run python -m unittest -v tests.contracts.test_trainer_metrics_contract
 run python -m unittest -v tests.contracts.test_config_routing_contract
 run python -m unittest -v tests.contracts.test_model_registry_contract

--- a/tests/run_test.sh
+++ b/tests/run_test.sh
@@ -151,7 +151,7 @@ run python tests/test_put_rollouts.py
 run python tests/test_trajectory_iteration.py
 run python tests/test_gym_example.py
 # Pytest-style CPU suites; install pytest in case the image lacks it.
-run /bin/bash -c "python -m pip install --quiet pytest && python -m pytest -q tests/test_weight_sync.py tests/test_checkpoint.py tests/test_ranked_rollout_end_and_wst_fence.py tests/test_terminal_checkpoint_trainer_hooks.py tests/test_terminal_drain_protocol.py tests/test_training_complete_checkpoint.py"
+run /bin/bash -c "python -m pip install --quiet pytest && python -m pytest -q tests/test_weight_sync.py tests/test_weight_sync_payload_egress.py tests/test_checkpoint.py tests/test_ranked_rollout_end_and_wst_fence.py tests/test_terminal_checkpoint_trainer_hooks.py tests/test_terminal_drain_protocol.py tests/test_training_complete_checkpoint.py"
 run python -m unittest -v tests.contracts.test_trainer_metrics_contract
 run python -m unittest -v tests.contracts.test_config_routing_contract
 run python -m unittest -v tests.contracts.test_model_registry_contract

--- a/tests/test_weight_sync_generation_pause.py
+++ b/tests/test_weight_sync_generation_pause.py
@@ -1,0 +1,170 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for quiescing generation across a weight sync (CPU-only).
+
+The backends here record when they are parked and released; the transport
+calls are stubbed, so the ordering of those records against the transfer is
+what is being checked.
+"""
+
+from contextlib import contextmanager
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import torch
+
+from cosmos_rl.dispatcher.command import (
+    PolicyToRolloutUnicastCommand,
+    RolloutToRolloutBroadcastCommand,
+)
+from cosmos_rl.rollout.rollout_base import RolloutBase
+from cosmos_rl.rollout.worker.rollout_control import DisaggregatedRolloutControlWorker
+from cosmos_rl.rollout.worker.weight_sync import (
+    AsyncR2RSyncMode,
+    generation_paused,
+)
+
+
+class _ParkingBackend:
+    """A backend that keeps serving until it is asked to park."""
+
+    def __init__(self, events):
+        self._events = events
+
+    @contextmanager
+    def paused(self):
+        self._events.append("park")
+        try:
+            yield
+        finally:
+            self._events.append("resume")
+
+    def model_param_map(self, _weight_mapper):
+        return {"a.weight": torch.zeros(2)}
+
+
+def _make_worker(events):
+    worker = object.__new__(DisaggregatedRolloutControlWorker)
+    worker.rollout = _ParkingBackend(events)
+    worker.replica_name = "rollout-0"
+    worker.rank_in_rollout_repicas = 0
+    worker.replica_name_to_rank = {"rollout-0": 0, "rollout-1": 1}
+    worker.global_commnicator_idex = 7
+    worker.inference_stream = None
+    worker.weight_mapper = None
+    worker.trainable_params = {"a.weight"}
+    worker.non_trainable_params_received = True
+    worker.current_weight_version = 3
+    worker.prepare_trainable_params = lambda: None
+    worker.state = SimpleNamespace(
+        weight_synced=lambda: True, set_weight_synced=lambda: None
+    )
+    worker.config = SimpleNamespace(
+        validation=SimpleNamespace(enable=False, val_before_train=False, freq=1)
+    )
+    worker.lazy_initialize_rollout_engine = lambda _load_format: None
+    return worker
+
+
+def _broadcast(worker, events, async_mode=AsyncR2RSyncMode.DISABLED):
+    command = RolloutToRolloutBroadcastCommand(
+        src_replica_name="rollout-0",
+        dst_replica_names=["rollout-0", "rollout-1"],
+        weight_step=4,
+        total_steps=10,
+        trainable_only=True,
+    )
+    with (
+        patch(
+            "cosmos_rl.rollout.worker.rollout_control.nccl_broadcast",
+            lambda *_args: events.append("broadcast"),
+        ),
+        patch(
+            "cosmos_rl.rollout.worker.weight_sync.get_async_r2r_sync_mode",
+            lambda _worker: async_mode,
+        ),
+        patch(
+            "cosmos_rl.rollout.worker.rollout_control.get_async_r2r_sync_mode",
+            lambda _worker: async_mode,
+        ),
+        patch(
+            "cosmos_rl.rollout.worker.rollout_control.get_broadcast_all_params",
+            lambda _worker: False,
+        ),
+    ):
+        worker.broadcast_to_all_rollout_replica(command)
+
+
+def test_r2r_writes_the_served_model_with_generation_parked():
+    events = []
+    worker = _make_worker(events)
+
+    _broadcast(worker, events)
+
+    assert events == ["park", "broadcast", "resume"]
+
+
+def test_p2r_receives_with_generation_parked():
+    events = []
+    worker = _make_worker(events)
+    worker.lazy_initialize_rollout_engine = lambda _load_format: events.append(
+        "lazy init"
+    )
+    # Addressed to a peer, so the handler initializes the engine and returns
+    # without a transfer of its own.
+    command = PolicyToRolloutUnicastCommand(
+        src_replica_name="policy-0",
+        dst_replica_name="rollout-1",
+        src_replica_size=1,
+        dst_replica_size=1,
+    )
+
+    with patch(
+        "cosmos_rl.rollout.worker.weight_sync.get_async_r2r_sync_mode",
+        lambda _worker: AsyncR2RSyncMode.DISABLED,
+    ):
+        worker.policy_to_rollout_unicast(command)
+
+    assert events == ["park", "lazy init", "resume"]
+
+
+def test_an_async_sync_leaves_generation_running():
+    # The async modes write a buffer clone, and the swap into the served model
+    # takes its own safe point, so there is nothing to park for.
+    events = []
+    worker = SimpleNamespace(rollout=_ParkingBackend(events))
+
+    with patch(
+        "cosmos_rl.rollout.worker.weight_sync.get_async_r2r_sync_mode",
+        lambda _worker: AsyncR2RSyncMode.GENERATION,
+    ):
+        with generation_paused(worker):
+            events.append("sync")
+
+    assert events == ["sync"]
+
+
+class _BlockingBackend(RolloutBase):
+    """A backend whose generation call blocks, as every in-tree one does."""
+
+    def post_init_hook(self, **kwargs):
+        pass
+
+    def rollout_generation(self, *args, **kwargs):
+        pass
+
+    def init_engine(self, *args, **kwargs):
+        pass
+
+    def get_underlying_model(self):
+        pass
+
+
+def test_a_blocking_engine_needs_no_pause_of_its_own():
+    # The default: an engine whose generation call blocks the main loop is
+    # already quiesced by the time a command can be dequeued.
+    backend = object.__new__(_BlockingBackend)
+
+    with backend.paused():
+        pass

--- a/tests/test_weight_sync_payload_egress.py
+++ b/tests/test_weight_sync_payload_egress.py
@@ -10,7 +10,7 @@ being checked.
 
 import queue
 import threading
-from contextlib import contextmanager
+from contextlib import contextmanager, nullcontext
 from types import SimpleNamespace
 from unittest.mock import patch
 
@@ -68,7 +68,8 @@ def _make_worker(events, packer):
     worker.current_weight_version = 3
     worker.prepare_trainable_params = lambda: None
     worker.rollout = SimpleNamespace(
-        model_param_map=lambda _mapper: {"a.weight": torch.zeros(2)}
+        model_param_map=lambda _mapper: {"a.weight": torch.zeros(2)},
+        paused=nullcontext,
     )
     worker.state = SimpleNamespace(
         weight_synced=lambda: True, set_weight_synced=lambda: None
@@ -97,6 +98,10 @@ def _broadcast(worker, events):
         ),
         patch(
             "cosmos_rl.rollout.worker.rollout_control.get_async_r2r_sync_mode",
+            lambda _worker: AsyncR2RSyncMode.DISABLED,
+        ),
+        patch(
+            "cosmos_rl.rollout.worker.weight_sync.get_async_r2r_sync_mode",
             lambda _worker: AsyncR2RSyncMode.DISABLED,
         ),
         patch(
@@ -137,7 +142,11 @@ def test_p2r_holds_egress_too():
         dst_replica_size=1,
     )
 
-    worker.policy_to_rollout_unicast(command)
+    with patch(
+        "cosmos_rl.rollout.worker.weight_sync.get_async_r2r_sync_mode",
+        lambda _worker: AsyncR2RSyncMode.DISABLED,
+    ):
+        worker.policy_to_rollout_unicast(command)
 
     assert events == ["hold", "lazy init", "release"]
 

--- a/tests/test_weight_sync_payload_egress.py
+++ b/tests/test_weight_sync_payload_egress.py
@@ -1,0 +1,174 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for holding payload egress across a weight sync (CPU-only).
+
+The packers here record when they are held and released; the transport calls
+are stubbed, so the ordering of those records against the broadcast is what is
+being checked.
+"""
+
+import queue
+import threading
+from contextlib import contextmanager
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import torch
+
+from cosmos_rl.dispatcher.command import (
+    PolicyToRolloutUnicastCommand,
+    RolloutToRolloutBroadcastCommand,
+)
+from cosmos_rl.rollout.worker import weight_sync
+from cosmos_rl.rollout.worker.rollout_control import DisaggregatedRolloutControlWorker
+from cosmos_rl.rollout.worker.weight_sync import (
+    AsyncR2RSyncMode,
+    WeightSyncThread,
+    payload_egress_held,
+)
+
+
+class _HoldingPacker:
+    """A packer that can keep its egress off the device for a whole sync."""
+
+    def __init__(self, events):
+        self._events = events
+
+    @contextmanager
+    def hold_sends(self):
+        self._events.append("hold")
+        try:
+            yield
+        finally:
+            self._events.append("release")
+
+
+class _FlushingPacker:
+    """A packer from before ``hold_sends``, which can only drain on demand."""
+
+    def __init__(self, events):
+        self._events = events
+
+    def flush_pending_sends(self):
+        self._events.append("flush")
+
+
+def _make_worker(events, packer):
+    worker = object.__new__(DisaggregatedRolloutControlWorker)
+    worker.data_packer = packer
+    worker.replica_name = "rollout-0"
+    worker.rank_in_rollout_repicas = 0
+    worker.replica_name_to_rank = {"rollout-0": 0, "rollout-1": 1}
+    worker.global_commnicator_idex = 7
+    worker.inference_stream = None
+    worker.weight_mapper = None
+    worker.trainable_params = {"a.weight"}
+    worker.non_trainable_params_received = True
+    worker.current_weight_version = 3
+    worker.prepare_trainable_params = lambda: None
+    worker.rollout = SimpleNamespace(
+        model_param_map=lambda _mapper: {"a.weight": torch.zeros(2)}
+    )
+    worker.state = SimpleNamespace(
+        weight_synced=lambda: True, set_weight_synced=lambda: None
+    )
+    worker.config = SimpleNamespace(
+        validation=SimpleNamespace(enable=False, val_before_train=False, freq=1)
+    )
+    worker.lazy_initialize_rollout_engine = lambda _load_format: events.append(
+        "lazy init"
+    )
+    return worker
+
+
+def _broadcast(worker, events):
+    command = RolloutToRolloutBroadcastCommand(
+        src_replica_name="rollout-0",
+        dst_replica_names=["rollout-0", "rollout-1"],
+        weight_step=4,
+        total_steps=10,
+        trainable_only=True,
+    )
+    with (
+        patch(
+            "cosmos_rl.rollout.worker.rollout_control.nccl_broadcast",
+            lambda *_args: events.append("broadcast"),
+        ),
+        patch(
+            "cosmos_rl.rollout.worker.rollout_control.get_async_r2r_sync_mode",
+            lambda _worker: AsyncR2RSyncMode.DISABLED,
+        ),
+        patch(
+            "cosmos_rl.rollout.worker.rollout_control.get_broadcast_all_params",
+            lambda _worker: False,
+        ),
+    ):
+        worker.broadcast_to_all_rollout_replica(command)
+
+
+def test_r2r_holds_egress_for_the_whole_broadcast():
+    events = []
+    worker = _make_worker(events, _HoldingPacker(events))
+
+    _broadcast(worker, events)
+
+    assert events == ["hold", "broadcast", "release"]
+
+
+def test_r2r_still_drains_a_packer_that_cannot_hold():
+    events = []
+    worker = _make_worker(events, _FlushingPacker(events))
+
+    _broadcast(worker, events)
+
+    assert events == ["flush", "broadcast"]
+
+
+def test_p2r_holds_egress_too():
+    events = []
+    worker = _make_worker(events, _HoldingPacker(events))
+    # Addressed to a peer, so the handler initializes the engine and returns
+    # without a transfer of its own.
+    command = PolicyToRolloutUnicastCommand(
+        src_replica_name="policy-0",
+        dst_replica_name="rollout-1",
+        src_replica_size=1,
+        dst_replica_size=1,
+    )
+
+    worker.policy_to_rollout_unicast(command)
+
+    assert events == ["hold", "lazy init", "release"]
+
+
+def test_the_weight_sync_thread_holds_egress_around_a_command():
+    events = []
+    wst = object.__new__(WeightSyncThread)
+    wst._queue = queue.PriorityQueue()
+    wst._stop = threading.Event()
+    wst._idle = threading.Event()
+    wst._worker = SimpleNamespace(device="cpu", data_packer=_HoldingPacker(events))
+    wst._queue.put((0, 0, ("r2r", object())))
+
+    def execute_r2r(_command):
+        events.append("r2r")
+        wst._stop.set()
+
+    wst._execute_r2r = execute_r2r
+    with patch.object(weight_sync.torch.cuda, "set_device"):
+        wst._run()
+
+    assert events == ["hold", "r2r", "release"]
+
+
+def test_a_packer_that_ships_nothing_over_nccl_needs_neither_hook():
+    worker = SimpleNamespace(data_packer=SimpleNamespace())
+
+    with payload_egress_held(worker):
+        pass
+
+
+def test_a_worker_without_a_packer_is_left_alone():
+    with payload_egress_held(SimpleNamespace()):
+        pass


### PR DESCRIPTION
> Stacked on #724 (`pkarkus/hold-payload-egress-for-weight-sync`), which adds the bracket
> this hooks into. Please review that one first.

## Summary

Weight sync overwrites the served model's tensors in place, which is only safe while no forward
is running. Nothing enforces that today: the main loop dequeues a command whenever it comes
round, and whether generation happens to be idle at that moment is a property of the backend
rather than anything the sync checks.

`RolloutBase.paused()` is where a backend that is not idle parks, and the sync brackets itself
with it. The default does nothing, which is correct for an engine whose generation call blocks
the main loop — every in-tree backend today.

## Why it matters

Two cases are not idle when a command is dequeued:

- **Stream generation.** `main_loop` calls `consume_command` on every iteration while
  `RolloutTaskScheduler` keeps working, so a P2R receive or an R2R broadcast can land on tensors
  an active task is reading.
- **A backend that serves on a thread of its own** — an out-of-tree simulator-driven one, where
  generation is a long-running episode rather than a call — never stops on its own account.

The async modes are exempt: they write a buffer clone and `install_inference_sync` swaps it in at
its own safe point, so the served tensors are never written under a forward.

## Open question for a maintainer

`RolloutTaskScheduler` already has the `paused()` this needs — added for weight sync, with a
docstring that says so, and never called from anywhere. Wiring it up is the obvious next step and
is left out here deliberately: `paused(wait_for_active_tasks=True)` waits out active tasks, and
whether that can strand a task whose results `main_loop` is responsible for collecting needs a
stream-generation run to answer. Happy to add it here if you can tell me it is safe, or to leave
it for someone who can run that mode.

## Testing

`tests/test_weight_sync_generation_pause.py`, CPU-only. A backend that records when it parks
shows the R2R broadcast and the P2R receive both happening inside the park, an async-mode sync
leaving generation running, and the base class's default doing nothing. Added to the pytest line
in `tests/run_test.sh`.

## Validation

- `python -m pytest -q tests/test_weight_sync_generation_pause.py tests/test_weight_sync_payload_egress.py tests/test_weight_sync.py tests/test_ranked_rollout_end_and_wst_fence.py` — 56 passed
- `uvx ruff@0.12.7 format --check` and `uvx ruff@0.12.7 check` on the changed files — clean
