### PR TITLE
perf(policy): batch policy-to-policy state synchronization

### DIFF
--- a/cosmos_rl/policy/config/__init__.py
+++ b/cosmos_rl/policy/config/__init__.py
@@ -913,6 +913,13 @@ class TrainingConfig(BaseModel):
         default=1,
         description="The interval of train step for synchronizing weights between replicas.",
     )
+    p2p_sync_pack_tensors: bool = Field(
+        default=False,
+        description=(
+            "Pack small tensors into byte-bounded buffers for policy-to-policy "
+            "initialization and dynamic-scale state synchronization."
+        ),
+    )
     coalesce_weight_sync: bool = Field(
         default=False,
         description="If True, the controller coalesces (drops) redundant P2R+R2R "

--- a/cosmos_rl/policy/trainer/llm_trainer/llm_trainer.py
+++ b/cosmos_rl/policy/trainer/llm_trainer/llm_trainer.py
@@ -47,6 +47,17 @@ from cosmos_rl.policy.trainer.optm import build_lr_schedulers
 from functools import partial
 
 
+_P2P_SYNC_BUCKET_SIZE_BYTES = int(
+    os.getenv("COSMOS_P2P_SYNC_BUCKET_SIZE_BYTES", str(256 * 1024 * 1024))
+)
+_p2p_sync_pack_tensors_env = os.getenv("COSMOS_P2P_SYNC_PACK_TENSORS")
+_P2P_SYNC_PACK_TENSORS = (
+    None
+    if _p2p_sync_pack_tensors_env is None
+    else _p2p_sync_pack_tensors_env.lower() in {"1", "true", "yes", "on"}
+)
+
+
 class LLMTrainer(Trainer):
     def __init__(
         self,
@@ -330,6 +341,94 @@ class LLMTrainer(Trainer):
             len_params (int): The number of parameters synced.
         """
         len_params = 0
+        active_hook = send_hook if is_send else recv_hook
+        batch_hook = (
+            getattr(active_hook, "batch", None)
+            if _P2P_SYNC_BUCKET_SIZE_BYTES > 0
+            else None
+        )
+        config_pack_tensors = getattr(
+            getattr(getattr(self, "config", None), "train", None),
+            "p2p_sync_pack_tensors",
+            False,
+        )
+        pack_tensors_enabled = (
+            config_pack_tensors
+            if _P2P_SYNC_PACK_TENSORS is None
+            else _P2P_SYNC_PACK_TENSORS
+        )
+        pack_tensors = pack_tensors_enabled and getattr(
+            active_hook, "supports_packing", False
+        )
+        pending_transfers = []
+        pending_bytes = 0
+        unpacked_on_cuda = False
+
+        if _P2P_SYNC_BUCKET_SIZE_BYTES < 0:
+            raise ValueError("P2P sync bucket size cannot be negative")
+
+        def flush_pending_transfers():
+            nonlocal pending_transfers, pending_bytes, unpacked_on_cuda
+            if not pending_transfers:
+                return
+            tensors = [tensor for tensor, _ in pending_transfers]
+            if pack_tensors and len(tensors) > 1:
+                packed_buffer = getattr(self, "_p2p_sync_packed_buffer", None)
+                if (
+                    packed_buffer is None
+                    or packed_buffer.device != tensors[0].device
+                    or packed_buffer.numel() < pending_bytes
+                ):
+                    packed_buffer = torch.empty(
+                        pending_bytes,
+                        dtype=torch.uint8,
+                        device=tensors[0].device,
+                    )
+                    self._p2p_sync_packed_buffer = packed_buffer
+                payload = packed_buffer[:pending_bytes]
+                if is_send:
+                    offset = 0
+                    for tensor in tensors:
+                        tensor_bytes = tensor.view(-1).view(torch.uint8)
+                        end = offset + tensor_bytes.numel()
+                        payload[offset:end].copy_(tensor_bytes)
+                        offset = end
+                active_hook(payload)
+                if not is_send:
+                    offset = 0
+                    for tensor in tensors:
+                        tensor_bytes = tensor.view(-1).view(torch.uint8)
+                        end = offset + tensor_bytes.numel()
+                        tensor_bytes.copy_(payload[offset:end])
+                        offset = end
+                    unpacked_on_cuda = tensors[0].is_cuda
+            else:
+                batch_hook(tensors)
+            if not is_send:
+                for tensor, receive_callback in pending_transfers:
+                    receive_callback(tensor)
+            pending_transfers = []
+            pending_bytes = 0
+
+        def transfer_tensor(local_view, receive_callback=None):
+            nonlocal len_params, pending_bytes
+            if batch_hook is None:
+                active_hook(local_view)
+                if not is_send:
+                    receive_callback(local_view)
+            else:
+                nbytes = local_view.numel() * local_view.element_size()
+                if (
+                    pending_transfers
+                    and pending_bytes + nbytes > _P2P_SYNC_BUCKET_SIZE_BYTES
+                ):
+                    flush_pending_transfers()
+                pending_transfers.append((local_view, receive_callback))
+                pending_bytes += nbytes
+                if pending_bytes >= _P2P_SYNC_BUCKET_SIZE_BYTES:
+                    flush_pending_transfers()
+            len_params += 1
+
         if self.parallel_dims.pp_enabled:
             state_dict = {}
             for model_part in self.model_parts:
@@ -362,19 +461,20 @@ class LLMTrainer(Trainer):
                 local_view = wrap_to_cuda_tensor(
                     self.device, dest_name, obj, in_place=obj.is_cuda
                 )
-                if is_send:
-                    send_hook(local_view)
-                else:
-                    recv_hook(local_view)
-                    if isinstance(obj, torch.distributed.tensor.DTensor):
-                        to_write = obj.to_local()
+
+                def receive_model_state(received, original=obj):
+                    assert not is_send
+                    if isinstance(original, torch.distributed.tensor.DTensor):
+                        to_write = original.to_local()
                     else:
-                        to_write = obj
+                        to_write = original
 
                     # Copy again for offloaded tensor since it is not inplace received
                     if not to_write.is_cuda:
-                        to_write.copy_(local_view)
-                len_params += 1
+                        to_write.copy_(received)
+
+                transfer_tensor(local_view, receive_model_state)
+        flush_pending_transfers()
 
         # 2. Sync optimizer states
         optimizer_state = self.optimizers.state_dict()
@@ -384,19 +484,18 @@ class LLMTrainer(Trainer):
             if local_view.data_ptr() is None:
                 # skip the optimizer state if the data pointer is None
                 continue
-            if is_send:
-                # nccl send
-                send_hook(local_view)
-            else:
-                # nccl recv
-                recv_hook(local_view)
-                optimizer_state[dest_name] = extract_from_cuda_tensor(
+
+            def receive_optimizer_state(received, name=dest_name, original=obj):
+                assert not is_send
+                optimizer_state[name] = extract_from_cuda_tensor(
                     self.device,
-                    dest_name,
-                    obj,
-                    local_view,
+                    name,
+                    original,
+                    received,
                 )
-            len_params += 1
+
+            transfer_tensor(local_view, receive_optimizer_state)
+        flush_pending_transfers()
 
         if not is_send:
             self.optimizers.load_state_dict(optimizer_state)
@@ -407,19 +506,18 @@ class LLMTrainer(Trainer):
             for dest_name in sorted(lr_sheduler_state.keys()):
                 obj = lr_sheduler_state[dest_name]
                 local_view = wrap_to_cuda_tensor(self.device, dest_name, obj)
-                if is_send:
-                    # nccl send
-                    send_hook(local_view)
-                else:
-                    # nccl recv
-                    recv_hook(local_view)
-                    lr_sheduler_state[dest_name] = extract_from_cuda_tensor(
+
+                def receive_scheduler_state(received, name=dest_name, original=obj):
+                    assert not is_send
+                    lr_sheduler_state[name] = extract_from_cuda_tensor(
                         self.device,
-                        dest_name,
-                        obj,
-                        local_view,
+                        name,
+                        original,
+                        received,
                     )
-                len_params += 1
+
+                transfer_tensor(local_view, receive_scheduler_state)
+            flush_pending_transfers()
             if not is_send:
                 self.lr_schedulers.load_state_dict(lr_sheduler_state)
 
@@ -428,18 +526,19 @@ class LLMTrainer(Trainer):
         for dest_name in sorted(rng_state.keys()):
             obj = rng_state[dest_name]
             local_view = wrap_to_cuda_tensor(self.device, dest_name, obj)
-            if is_send:
-                # nccl send
-                send_hook(local_view)
-            else:
-                # nccl recv
-                recv_hook(local_view)
-                rng_state[dest_name] = extract_from_cuda_tensor(
-                    self.device, dest_name, obj, local_view
+
+            def receive_rng_state(received, name=dest_name, original=obj):
+                assert not is_send
+                rng_state[name] = extract_from_cuda_tensor(
+                    self.device, name, original, received
                 )
-            len_params += 1
+
+            transfer_tensor(local_view, receive_rng_state)
+        flush_pending_transfers()
         if not is_send:
             self.ckpt_manager.set_rng_state(rng_state)
+            if unpacked_on_cuda:
+                torch.cuda.synchronize(self.device)
         return len_params
 
     def export_safetensors(

--- a/cosmos_rl/policy/worker/rl_worker.py
+++ b/cosmos_rl/policy/worker/rl_worker.py
@@ -77,6 +77,33 @@ COSMOS_P2R_STREAM_DRAIN_TIMEOUT_S = float(
 )
 
 
+class _P2PNcclHook:
+    """Keep custom trainers callable-compatible while exposing batching."""
+
+    def __init__(self, single_hook: Callable, batch_hook: Optional[Callable]):
+        self._single_hook = single_hook
+        self._batch_hook = batch_hook
+        self.supports_packing = batch_hook is not None
+
+    def __call__(self, tensor: torch.Tensor):
+        return self._single_hook(tensor)
+
+    def batch(self, tensors):
+        if self._batch_hook is not None:
+            return self._batch_hook(tensors)
+        for tensor in tensors:
+            self._single_hook(tensor)
+
+
+def _bind_p2p_nccl_hook(
+    single_hook: Callable, batch_hook: Optional[Callable], **kwargs
+):
+    return _P2PNcclHook(
+        partial(single_hook, **kwargs),
+        partial(batch_hook, **kwargs) if batch_hook is not None else None,
+    )
+
+
 class RLPolicyWorker(PolicyWorkerBase):
     """
     RL Policy Worker. This worker is responsible for the training of the RL.
@@ -368,8 +395,10 @@ class RLPolicyWorker(PolicyWorkerBase):
             return True
         st = time.time()
         # TODO(zjx): there need failure tolerance for nccl send and recv, so get nccl param from command
-        send_recv_hook = partial(
-            self.inter_policy_nccl.broadcast, src_replica=command.src_replica_name
+        send_recv_hook = _bind_p2p_nccl_hook(
+            self.inter_policy_nccl.broadcast,
+            getattr(self.inter_policy_nccl, "broadcast_batch", None),
+            src_replica=command.src_replica_name,
         )
         len_params = self.sync_all_states(
             is_send=send,
@@ -394,11 +423,15 @@ class RLPolicyWorker(PolicyWorkerBase):
             return False
         st = time.time()
         # TODO(zjx): there need failure tolerance for nccl send and recv, so get nccl param from command
-        send_hook = partial(
-            self.inter_policy_nccl.send, dst_replica=command.dst_replica_name
+        send_hook = _bind_p2p_nccl_hook(
+            self.inter_policy_nccl.send,
+            getattr(self.inter_policy_nccl, "send_batch", None),
+            dst_replica=command.dst_replica_name,
         )
-        recv_hook = partial(
-            self.inter_policy_nccl.recv, src_replica=command.src_replica_name
+        recv_hook = _bind_p2p_nccl_hook(
+            self.inter_policy_nccl.recv,
+            getattr(self.inter_policy_nccl, "recv_batch", None),
+            src_replica=command.src_replica_name,
         )
         len_params = self.sync_all_states(
             is_send=send,

--- a/cosmos_rl/utils/distributed.py
+++ b/cosmos_rl/utils/distributed.py
@@ -704,6 +704,17 @@ class HighAvailabilitylNccl:
             self.api_client.post_clear_nccl_comm_store(unique_pair_name)
 
     def __do_nccl_op_with_retry(self, func: Callable, timeout_ms: int, **kwargs):
+        self.__do_nccl_ops_with_retry(func, timeout_ms, (kwargs,))
+
+    def __do_nccl_ops_with_retry(
+        self,
+        func: Callable,
+        timeout_ms: int,
+        operations: Iterable[dict],
+    ):
+        operations = tuple(operations)
+        if not operations:
+            return
         if self.is_single_peer.is_set():
             # single peer, no need to do nccl op
             return
@@ -724,11 +735,12 @@ class HighAvailabilitylNccl:
                     nccl_timeout_watchdog(wait_stream=True, timeout_ms=timeout_ms),
                     self.build_mesh_lock,
                 ):
-                    func(
-                        comm_idx=self.comm_idx,
-                        timeout_ms=timeout_ms,
-                        **kwargs,
-                    )
+                    for kwargs in operations:
+                        func(
+                            comm_idx=self.comm_idx,
+                            timeout_ms=timeout_ms,
+                            **kwargs,
+                        )
 
                 return
             except Exception as e:
@@ -746,8 +758,9 @@ class HighAvailabilitylNccl:
                         self.__log_prefix(),
                     )
                 logger.error(
-                    f"{self.__log_prefix()} recovering nccl op '{func.__name__}' "
-                    f"with kwargs {kwargs} after attempt {attempt}/{self.max_retry}: {e}"
+                    f"{self.__log_prefix()} recovering batch of {len(operations)} "
+                    f"nccl op(s) '{func.__name__}' after attempt "
+                    f"{attempt}/{self.max_retry}: {e}"
                 )
         raise RuntimeError(
             f"{self.__log_prefix()} nccl op '{func.__name__}' failed after "
@@ -825,12 +838,22 @@ class HighAvailabilitylNccl:
         return self.replica_name_to_rank[replica_name]
 
     def broadcast(self, tensor: torch.Tensor, src_replica: str, timeout_ms: int = None):
+        self.broadcast_batch((tensor,), src_replica, timeout_ms)
+
+    def broadcast_batch(
+        self,
+        tensors: Iterable[torch.Tensor],
+        src_replica: str,
+        timeout_ms: int = None,
+    ):
+        tensors = tuple(tensors)
+        if not tensors:
+            return
         src_rank = self.get_replica_rank(src_replica)
-        self.__do_nccl_op_with_retry(
+        self.__do_nccl_ops_with_retry(
             func=nccl_broadcast,
-            tensor=tensor,
-            rank=src_rank,
             timeout_ms=timeout_ms,
+            operations=({"tensor": tensor, "rank": src_rank} for tensor in tensors),
         )
 
     def allreduce(
@@ -849,21 +872,41 @@ class HighAvailabilitylNccl:
         )
 
     def send(self, tensor: torch.Tensor, dst_replica: str, timeout_ms: int = None):
+        self.send_batch((tensor,), dst_replica, timeout_ms)
+
+    def send_batch(
+        self,
+        tensors: Iterable[torch.Tensor],
+        dst_replica: str,
+        timeout_ms: int = None,
+    ):
+        tensors = tuple(tensors)
+        if not tensors:
+            return
         dst_rank = self.get_replica_rank(dst_replica)
-        self.__do_nccl_op_with_retry(
+        self.__do_nccl_ops_with_retry(
             func=nccl_send,
-            tensor=tensor,
-            peer=dst_rank,
             timeout_ms=timeout_ms,
+            operations=({"tensor": tensor, "peer": dst_rank} for tensor in tensors),
         )
 
     def recv(self, tensor: torch.Tensor, src_replica: str, timeout_ms: int = None):
+        self.recv_batch((tensor,), src_replica, timeout_ms)
+
+    def recv_batch(
+        self,
+        tensors: Iterable[torch.Tensor],
+        src_replica: str,
+        timeout_ms: int = None,
+    ):
+        tensors = tuple(tensors)
+        if not tensors:
+            return
         src_rank = self.get_replica_rank(src_replica)
-        self.__do_nccl_op_with_retry(
+        self.__do_nccl_ops_with_retry(
             func=nccl_recv,
-            tensor=tensor,
-            peer=src_rank,
             timeout_ms=timeout_ms,
+            operations=({"tensor": tensor, "peer": src_rank} for tensor in tensors),
         )
 
 

--- a/docs/quickstart/configuration.rst
+++ b/docs/quickstart/configuration.rst
@@ -3,3 +3,19 @@ Configuration
 
 .. jsonschema:: config.COSMOS_CONFIG_SCHEMA
     :lift_title: false
+
+Policy-to-policy state packing
+--------------------------------
+
+Policy initialization and dynamic scaling can pack small state tensors into
+byte-bounded NCCL transfers. Packing is disabled by default because it requires
+an additional device-side copy and scratch buffer. Enable it explicitly in the
+training configuration:
+
+.. code-block:: toml
+
+    [train]
+    p2p_sync_pack_tensors = true
+
+This setting affects policy-to-policy state synchronization only. It does not
+change policy-to-rollout or rollout-to-rollout weight synchronization.

--- a/tests/configs/test_simple_grpo.toml
+++ b/tests/configs/test_simple_grpo.toml
@@ -20,6 +20,7 @@ fsdp_offload = false
 fsdp_reshard_after_forward = "default"
 train_batch_per_replica = 8
 sync_weight_interval = 1
+p2p_sync_pack_tensors = true
 
 [rollout]
 gpu_memory_utilization = 0.7

--- a/tests/launch_test_worker.py
+++ b/tests/launch_test_worker.py
@@ -755,13 +755,25 @@ def policy_to_policy_sync_common(
                 src_rank = self.get_replica_rank(src_replica)
                 nccl_broadcast(tensor, src_rank, self.comm_idx)
 
+            def broadcast_batch(self, tensors, src_replica: str):
+                for tensor in tensors:
+                    self.broadcast(tensor, src_replica)
+
             def send(self, tensor: torch.Tensor, dst_replica: str):
                 dst_rank = self.get_replica_rank(dst_replica)
                 nccl_send(tensor, dst_rank, self.comm_idx)
 
+            def send_batch(self, tensors, dst_replica: str):
+                for tensor in tensors:
+                    self.send(tensor, dst_replica)
+
             def recv(self, tensor: torch.Tensor, src_replica: str):
                 src_rank = self.get_replica_rank(src_replica)
                 nccl_recv(tensor, src_rank, self.comm_idx)
+
+            def recv_batch(self, tensors, src_replica: str):
+                for tensor in tensors:
+                    self.recv(tensor, src_replica)
 
             def shutdown(self):
                 pass
@@ -780,53 +792,75 @@ def policy_to_policy_sync_common(
         policy_worker.mesh_ready = True
         policy_worker.replica_name_to_rank = replica_name_to_rank
 
-        def sample_tensor():
-            sample_tensors = []
-            self_state_dict = policy_worker.trainer.model.state_dict()
-            sample_tensors.append(self_state_dict[sorted(self_state_dict.keys())[0]])
-            sample_tensors.append(self_state_dict[sorted(self_state_dict.keys())[-1]])
+        model_state = policy_worker.trainer.model.state_dict()
 
-            optimizer_state = policy_worker.trainer.optimizers.state_dict()
-            sample_tensors.append(optimizer_state[sorted(optimizer_state.keys())[0]])
-            sample_tensors.append(optimizer_state[sorted(optimizer_state.keys())[-1]])
+        def local_tensor(tensor):
+            if isinstance(tensor, torch.distributed.tensor.DTensor):
+                return tensor.to_local()
+            return tensor
 
-            lr_sheduler_state = policy_worker.trainer.lr_schedulers.state_dict()
-            sample_tensors.append(
-                lr_sheduler_state[sorted(lr_sheduler_state.keys())[0]]
+        # Stamp two small, non-empty distributed model tensors on the source.
+        # This proves the receiver changed because of the command instead of
+        # merely matching an identically initialized model.
+        marker_names = [
+            name
+            for name, tensor in sorted(
+                model_state.items(),
+                key=lambda item: (local_tensor(item[1]).numel(), item[0]),
             )
-            sample_tensors.append(
-                lr_sheduler_state[sorted(lr_sheduler_state.keys())[-1]]
-            )
-            sample_tensors = [
-                tensor.to_local().cpu()
-                if isinstance(tensor, torch.distributed.tensor.DTensor)
-                else tensor.cpu()
-                if isinstance(tensor, torch.Tensor)
-                else tensor
-                for tensor in sample_tensors
-            ]
-            return sample_tensors
-
-        if not send:
-            sample_tensors = sample_tensor()
+            if local_tensor(tensor).numel() > 0
+        ][:2]
+        assert len(marker_names) == 2
+        marker_value = 37 + rank
+        if send:
+            with torch.no_grad():
+                for name in marker_names:
+                    local_tensor(model_state[name]).fill_(marker_value)
+        else:
+            before_sync = {
+                name: local_tensor(model_state[name]).detach().cpu().clone()
+                for name in marker_names
+            }
 
         if isinstance(command, PolicyToPolicyUnicastCommand):
             policy_worker.execute_policy_to_policy_unicast(command)
         elif isinstance(command, PolicyToPolicyBroadcastCommand):
             policy_worker.execute_policy_to_policy_broadcast(command)
 
+        if cosmos_config.train.p2p_sync_pack_tensors:
+            packed_buffer = policy_worker.trainer._p2p_sync_packed_buffer
+            assert packed_buffer.dtype == torch.uint8
+            assert packed_buffer.numel() > 0
+            dtensor_count = sum(
+                isinstance(tensor, torch.distributed.tensor.DTensor)
+                for tensor in policy_worker.trainer.model.state_dict().values()
+            )
+            assert dtensor_count > 0
+            operation = (
+                "UNICAST"
+                if isinstance(command, PolicyToPolicyUnicastCommand)
+                else "BROADCAST"
+            )
+            print(
+                f"P2P_POLICY_{operation}_PACKED_BUFFER_BYTES="
+                f"{packed_buffer.numel()} dtensors={dtensor_count} "
+                f"replica={policy_name} rank={rank}"
+            )
+
         if not send:
-            origin_sample_tensors = sample_tensors
-            sample_tensors = sample_tensor()
-            for tensor, origin_tensor in zip(sample_tensors, origin_sample_tensors):
-                if isinstance(tensor, torch.Tensor):
-                    assert torch.allclose(tensor, origin_tensor), (
-                        f"Tensor values do not match {tensor} {origin_tensor}"
-                    )
-                elif isinstance(tensor, bool):
-                    assert tensor == origin_tensor, (
-                        f"Tensor values do not match {tensor} {origin_tensor}"
-                    )
+            assert policy_worker.model_ready
+            for name in marker_names:
+                received = local_tensor(model_state[name]).detach().cpu()
+                expected = torch.full_like(received, marker_value)
+                assert not torch.equal(before_sync[name], expected), (
+                    f"Receiver tensor {name} already contained the source marker"
+                )
+                torch.testing.assert_close(received, expected)
+            if isinstance(command, PolicyToPolicyUnicastCommand):
+                print(
+                    "P2P_DYNAMIC_SCALE_UNICAST_VERIFIED="
+                    f"replica={policy_name} rank={rank} markers={len(marker_names)}"
+                )
     finally:
         # Detach from shared memory
         shm.close()

--- a/tests/test_p2p_batching.py
+++ b/tests/test_p2p_batching.py
@@ -1,0 +1,424 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+# All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for byte-bounded policy-to-policy NCCL batching."""
+
+from __future__ import annotations
+
+import threading
+from contextlib import contextmanager, nullcontext
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from cosmos_rl.policy.trainer.llm_trainer import llm_trainer as llm_trainer_module
+from cosmos_rl.utils import distributed as dist_utils
+
+
+def _communicator(*, max_retry: int = 3) -> dist_utils.HighAvailabilitylNccl:
+    communicator = dist_utils.HighAvailabilitylNccl.__new__(
+        dist_utils.HighAvailabilitylNccl
+    )
+    communicator.replica_name = "policy-0"
+    communicator.global_rank = 0
+    communicator.replica_name_to_rank = {"policy-0": 0, "policy-1": 1}
+    communicator.comm_idx = 7
+    communicator.max_retry = max_retry
+    communicator.default_timeout_ms = 10
+    communicator.is_single_peer = threading.Event()
+    communicator.is_comm_ready = threading.Event()
+    communicator.is_comm_ready.set()
+    communicator.build_mesh_lock = threading.Lock()
+    communicator.api_client = SimpleNamespace(post_nccl_comm_error=lambda *_: None)
+    communicator.wait_comm_ready = lambda timeout=0: None
+    return communicator
+
+
+@pytest.mark.parametrize(
+    ("method_name", "raw_name", "peer_name"),
+    [
+        ("broadcast_batch", "nccl_broadcast", "policy-0"),
+        ("send_batch", "nccl_send", "policy-1"),
+        ("recv_batch", "nccl_recv", "policy-1"),
+    ],
+)
+def test_p2p_batch_uses_one_ha_window_and_preserves_order(
+    monkeypatch: pytest.MonkeyPatch,
+    method_name: str,
+    raw_name: str,
+    peer_name: str,
+) -> None:
+    communicator = _communicator()
+    tensors = [torch.tensor([value]) for value in range(4)]
+    raw_calls: list[torch.Tensor] = []
+    watchdog_calls = 0
+
+    def record_raw_call(tensor: torch.Tensor, **_kwargs) -> None:
+        raw_calls.append(tensor)
+
+    @contextmanager
+    def record_watchdog(**_kwargs):
+        nonlocal watchdog_calls
+        watchdog_calls += 1
+        yield
+
+    monkeypatch.setattr(dist_utils, raw_name, record_raw_call)
+    monkeypatch.setattr(dist_utils, "nccl_timeout_watchdog", record_watchdog)
+
+    getattr(communicator, method_name)((tensor for tensor in tensors), peer_name)
+
+    assert raw_calls == tensors
+    assert watchdog_calls == 1
+
+
+def test_p2p_batch_retry_replays_the_whole_ordered_batch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    communicator = _communicator(max_retry=2)
+    tensors = [torch.tensor([value]) for value in range(3)]
+    raw_calls: list[torch.Tensor] = []
+    reports: list[Exception] = []
+    failed_once = False
+
+    def fail_once_on_second_tensor(tensor: torch.Tensor, **_kwargs) -> None:
+        nonlocal failed_once
+        raw_calls.append(tensor)
+        if tensor is tensors[1] and not failed_once:
+            failed_once = True
+            raise OSError("synthetic mid-batch failure")
+
+    communicator.api_client = SimpleNamespace(
+        post_nccl_comm_error=lambda _name, error: reports.append(error)
+    )
+    monkeypatch.setattr(dist_utils, "nccl_send", fail_once_on_second_tensor)
+    monkeypatch.setattr(
+        dist_utils,
+        "nccl_timeout_watchdog",
+        lambda **_kwargs: nullcontext(),
+    )
+
+    communicator.send_batch(tensors, "policy-1")
+
+    assert raw_calls == [tensors[0], tensors[1], *tensors]
+    assert len(reports) == 1
+
+
+def test_empty_p2p_batch_is_a_noop(monkeypatch: pytest.MonkeyPatch) -> None:
+    communicator = _communicator()
+    monkeypatch.setattr(
+        dist_utils,
+        "nccl_broadcast",
+        lambda **_kwargs: pytest.fail("empty batch issued a raw NCCL call"),
+    )
+
+    communicator.broadcast_batch([], "policy-0")
+
+
+class _StateManager:
+    def __init__(self, state: dict) -> None:
+        self.state = state
+
+    def state_dict(self) -> dict:
+        return self.state
+
+    def load_state_dict(self, state: dict) -> None:
+        self.state = state
+
+
+class _CheckpointManager:
+    def __init__(self, state: dict) -> None:
+        self.state = state
+
+    def get_rng_state(self) -> dict:
+        return self.state
+
+    def set_rng_state(self, state: dict) -> None:
+        self.state = state
+
+
+class _ModelState(torch.nn.Module):
+    def __init__(self, fill: int) -> None:
+        super().__init__()
+        self.register_buffer("a", torch.full((2,), fill, dtype=torch.float32))
+        self.register_buffer("b", torch.full((4,), fill, dtype=torch.int16))
+        self.register_buffer("c", torch.full((4,), fill, dtype=torch.uint8))
+        self.register_buffer("d", torch.full((4,), fill, dtype=torch.float32))
+
+
+class _SyncOnlyTrainer(llm_trainer_module.LLMTrainer):
+    def build_lr_schedulers(self) -> None:
+        pass
+
+    def step_training(self) -> None:
+        pass
+
+
+class _InMemoryBatchTransport:
+    def __init__(self) -> None:
+        self.payloads: list[list[torch.Tensor]] = []
+        self.sent_batch_sizes: list[int] = []
+        self.received_batch_sizes: list[int] = []
+
+    def reject_single(self, _tensor: torch.Tensor) -> None:
+        pytest.fail("state sync fell back to a single-tensor hook")
+
+    def send_batch(self, tensors) -> None:
+        tensors = list(tensors)
+        self.sent_batch_sizes.append(len(tensors))
+        self.payloads.append([tensor.clone() for tensor in tensors])
+
+    def recv_batch(self, tensors) -> None:
+        tensors = list(tensors)
+        self.received_batch_sizes.append(len(tensors))
+        payload = self.payloads.pop(0)
+        assert len(payload) == len(tensors)
+        for destination, source in zip(tensors, payload, strict=True):
+            destination.copy_(source)
+
+
+class _InMemoryPackedTransport:
+    def __init__(self) -> None:
+        self.payloads: list[tuple[str, list[torch.Tensor] | torch.Tensor]] = []
+        self.sent_call_kinds: list[str] = []
+        self.received_call_kinds: list[str] = []
+
+    def send(self, tensor: torch.Tensor) -> None:
+        self.sent_call_kinds.append("single")
+        self.payloads.append(("single", tensor.clone()))
+
+    def recv(self, tensor: torch.Tensor) -> None:
+        self.received_call_kinds.append("single")
+        kind, payload = self.payloads.pop(0)
+        assert kind == "single"
+        assert isinstance(payload, torch.Tensor)
+        tensor.copy_(payload)
+
+    def send_batch(self, tensors) -> None:
+        tensors = list(tensors)
+        self.sent_call_kinds.append("batch")
+        self.payloads.append(("batch", [tensor.clone() for tensor in tensors]))
+
+    def recv_batch(self, tensors) -> None:
+        tensors = list(tensors)
+        self.received_call_kinds.append("batch")
+        kind, payload = self.payloads.pop(0)
+        assert kind == "batch"
+        assert isinstance(payload, list)
+        assert len(payload) == len(tensors)
+        for destination, source in zip(tensors, payload, strict=True):
+            destination.copy_(source)
+
+
+def _state_sync_trainer(fill: int):
+    trainer = _SyncOnlyTrainer.__new__(_SyncOnlyTrainer)
+    trainer.parallel_dims = SimpleNamespace(pp_enabled=False)
+    trainer.model = _ModelState(fill)
+    trainer.reference_state_dict = {}
+    trainer.optimizers = _StateManager(
+        {"momentum": torch.full((4,), fill, dtype=torch.float32)}
+    )
+    trainer.lr_schedulers = _StateManager({"step": fill})
+    trainer.ckpt_manager = _CheckpointManager(
+        {"cpu_rng": torch.full((4,), fill, dtype=torch.uint8)}
+    )
+    trainer.device = torch.device("cpu")
+    return trainer
+
+
+def test_state_sync_uses_deterministic_byte_buckets_and_preserves_values(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Sorted model tensor sizes are 8, 8, 4, and 16 bytes. A 12-byte bound
+    # therefore creates [8], [8, 4], and one oversized [16] bucket.
+    monkeypatch.setattr(llm_trainer_module, "_P2P_SYNC_BUCKET_SIZE_BYTES", 12)
+    source = _state_sync_trainer(fill=7)
+    destination = _state_sync_trainer(fill=0)
+    transport = _InMemoryBatchTransport()
+
+    class Hook:
+        def __init__(self, single, batch) -> None:
+            self.single = single
+            self.batch = batch
+
+        def __call__(self, tensor) -> None:
+            self.single(tensor)
+
+    send_hook = Hook(transport.reject_single, transport.send_batch)
+    recv_hook = Hook(transport.reject_single, transport.recv_batch)
+
+    sent = source.sync_all_states(True, send_hook, recv_hook)
+    received = destination.sync_all_states(False, send_hook, recv_hook)
+
+    assert sent == received == 7
+    assert transport.sent_batch_sizes == [1, 2, 1, 1, 1, 1]
+    assert transport.received_batch_sizes == [1, 2, 1, 1, 1, 1]
+    assert transport.payloads == []
+    for name, source_tensor in source.model.state_dict().items():
+        torch.testing.assert_close(destination.model.state_dict()[name], source_tensor)
+    torch.testing.assert_close(
+        destination.optimizers.state["momentum"],
+        source.optimizers.state["momentum"],
+    )
+    assert destination.lr_schedulers.state == source.lr_schedulers.state
+    torch.testing.assert_close(
+        destination.ckpt_manager.state["cpu_rng"],
+        source.ckpt_manager.state["cpu_rng"],
+    )
+
+
+def test_state_sync_packs_multi_tensor_buckets_and_preserves_mixed_dtypes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(llm_trainer_module, "_P2P_SYNC_BUCKET_SIZE_BYTES", 12)
+    monkeypatch.setattr(llm_trainer_module, "_P2P_SYNC_PACK_TENSORS", True)
+    source = _state_sync_trainer(fill=7)
+    destination = _state_sync_trainer(fill=0)
+    transport = _InMemoryPackedTransport()
+
+    class Hook:
+        supports_packing = True
+
+        def __init__(self, single, batch) -> None:
+            self.single = single
+            self.batch = batch
+
+        def __call__(self, tensor) -> None:
+            self.single(tensor)
+
+    send_hook = Hook(transport.send, transport.send_batch)
+    recv_hook = Hook(transport.recv, transport.recv_batch)
+
+    sent = source.sync_all_states(True, send_hook, recv_hook)
+    received = destination.sync_all_states(False, send_hook, recv_hook)
+
+    assert sent == received == 7
+    assert transport.sent_call_kinds == [
+        "batch",
+        "single",
+        "batch",
+        "batch",
+        "batch",
+        "batch",
+    ]
+    assert transport.received_call_kinds == transport.sent_call_kinds
+    assert transport.payloads == []
+    assert source._p2p_sync_packed_buffer.dtype == torch.uint8
+    assert source._p2p_sync_packed_buffer.numel() == 12
+    for name, source_tensor in source.model.state_dict().items():
+        torch.testing.assert_close(destination.model.state_dict()[name], source_tensor)
+    torch.testing.assert_close(
+        destination.optimizers.state["momentum"],
+        source.optimizers.state["momentum"],
+    )
+    assert destination.lr_schedulers.state == source.lr_schedulers.state
+    torch.testing.assert_close(
+        destination.ckpt_manager.state["cpu_rng"],
+        source.ckpt_manager.state["cpu_rng"],
+    )
+
+
+def test_state_sync_packing_supports_pipeline_local_state(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(llm_trainer_module, "_P2P_SYNC_BUCKET_SIZE_BYTES", 12)
+    monkeypatch.setattr(llm_trainer_module, "_P2P_SYNC_PACK_TENSORS", True)
+    source = _state_sync_trainer(fill=7)
+    destination = _state_sync_trainer(fill=0)
+    source.parallel_dims.pp_enabled = True
+    destination.parallel_dims.pp_enabled = True
+    source.model_parts = [source.model]
+    destination.model_parts = [destination.model]
+    transport = _InMemoryPackedTransport()
+
+    class Hook:
+        supports_packing = True
+
+        def __init__(self, single, batch) -> None:
+            self.single = single
+            self.batch = batch
+
+        def __call__(self, tensor) -> None:
+            self.single(tensor)
+
+    send_hook = Hook(transport.send, transport.send_batch)
+    recv_hook = Hook(transport.recv, transport.recv_batch)
+
+    assert source.sync_all_states(True, send_hook, recv_hook) == 7
+    assert destination.sync_all_states(False, send_hook, recv_hook) == 7
+    assert transport.payloads == []
+    for name, source_tensor in source.model.state_dict().items():
+        torch.testing.assert_close(destination.model.state_dict()[name], source_tensor)
+
+
+def test_state_sync_packing_supports_scalar_tensors(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(llm_trainer_module, "_P2P_SYNC_BUCKET_SIZE_BYTES", 12)
+    monkeypatch.setattr(llm_trainer_module, "_P2P_SYNC_PACK_TENSORS", None)
+
+    class ScalarState:
+        def __init__(self, fill: int) -> None:
+            self.state = {
+                "a_vector": torch.full((4,), fill, dtype=torch.int16),
+                "b_scalar": torch.tensor(fill, dtype=torch.float32),
+            }
+
+        def state_dict(self):
+            return self.state
+
+        def named_buffers(self):
+            return ()
+
+    def trainer(fill: int):
+        instance = _state_sync_trainer(fill)
+        instance.model = ScalarState(fill)
+        instance.optimizers = _StateManager({})
+        instance.lr_schedulers = None
+        instance.ckpt_manager = _CheckpointManager({})
+        return instance
+
+    source = trainer(7)
+    destination = trainer(0)
+    source.config = SimpleNamespace(train=SimpleNamespace(p2p_sync_pack_tensors=True))
+    destination.config = SimpleNamespace(
+        train=SimpleNamespace(p2p_sync_pack_tensors=True)
+    )
+    transport = _InMemoryPackedTransport()
+
+    class Hook:
+        supports_packing = True
+
+        def __init__(self, single, batch) -> None:
+            self.single = single
+            self.batch = batch
+
+        def __call__(self, tensor) -> None:
+            self.single(tensor)
+
+    send_hook = Hook(transport.send, transport.send_batch)
+    recv_hook = Hook(transport.recv, transport.recv_batch)
+
+    assert source.sync_all_states(True, send_hook, recv_hook) == 2
+    assert destination.sync_all_states(False, send_hook, recv_hook) == 2
+    assert transport.sent_call_kinds == ["single"]
+    assert transport.received_call_kinds == ["single"]
+    for name, source_tensor in source.model.state_dict().items():
+        torch.testing.assert_close(destination.model.state_dict()[name], source_tensor)
+
+
+def test_state_sync_keeps_plain_single_tensor_hook_compatibility() -> None:
+    source = _state_sync_trainer(fill=7)
+    tensors: list[torch.Tensor] = []
+
+    sent = source.sync_all_states(True, tensors.append, tensors.append)
+
+    assert sent == len(tensors) == 7
+
+
+def test_p2p_packing_config_is_opt_in() -> None:
+    from cosmos_rl.policy.config import TrainingConfig
+
+    assert TrainingConfig().p2p_sync_pack_tensors is False
+    assert TrainingConfig(p2p_sync_pack_tensors=True).p2p_sync_pack_tensors is True

--- a/tests/test_p2p_batching_e2e.py
+++ b/tests/test_p2p_batching_e2e.py
@@ -1,0 +1,230 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+# All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Two-GPU correctness coverage for HA P2P batching."""
+
+from __future__ import annotations
+
+import threading
+from types import SimpleNamespace
+
+import pytest
+import torch
+import torch.multiprocessing as mp
+
+from cosmos_rl.policy.trainer.llm_trainer import llm_trainer as llm_trainer_module
+from cosmos_rl.utils.distributed import HighAvailabilitylNccl
+from cosmos_rl.utils.pynccl import create_nccl_comm, create_nccl_uid, nccl_abort
+
+
+def _communicator(rank: int, comm_idx: int) -> HighAvailabilitylNccl:
+    communicator = HighAvailabilitylNccl.__new__(HighAvailabilitylNccl)
+    communicator.replica_name = f"policy-{rank}"
+    communicator.global_rank = rank
+    communicator.replica_name_to_rank = {"policy-0": 0, "policy-1": 1}
+    communicator.comm_idx = comm_idx
+    communicator.max_retry = 1
+    communicator.default_timeout_ms = 30_000
+    communicator.is_single_peer = threading.Event()
+    communicator.is_comm_ready = threading.Event()
+    communicator.is_comm_ready.set()
+    communicator.build_mesh_lock = threading.Lock()
+    communicator.api_client = SimpleNamespace(post_nccl_comm_error=lambda *_: None)
+    return communicator
+
+
+def _payloads(device_rank: int, *, source: bool) -> list[torch.Tensor]:
+    device = torch.device(f"cuda:{device_rank}")
+    if source:
+        return [
+            torch.arange(17, dtype=torch.float32, device=device),
+            torch.arange(9, dtype=torch.int16, device=device),
+            torch.tensor(True, dtype=torch.bool, device=device),
+            torch.arange(33, dtype=torch.uint8, device=device),
+        ]
+    return [
+        torch.zeros(17, dtype=torch.float32, device=device),
+        torch.zeros(9, dtype=torch.int16, device=device),
+        torch.tensor(False, dtype=torch.bool, device=device),
+        torch.zeros(33, dtype=torch.uint8, device=device),
+    ]
+
+
+class _StateModel:
+    def __init__(self, tensors: list[torch.Tensor]) -> None:
+        self.tensors = {
+            name: tensor
+            for name, tensor in zip(
+                ("a_f32", "b_i16", "c_bool", "d_u8"), tensors, strict=True
+            )
+        }
+
+    def state_dict(self) -> dict[str, torch.Tensor]:
+        return self.tensors
+
+    def named_buffers(self):
+        return ()
+
+
+class _OffloadedStateModel:
+    def __init__(self, tensors: list[torch.Tensor]) -> None:
+        self.tensors = {
+            name: tensor
+            for name, tensor in zip(("a_vector", "b_scalar"), tensors, strict=True)
+        }
+
+    def state_dict(self) -> dict[str, torch.Tensor]:
+        return self.tensors
+
+    def named_buffers(self):
+        return ()
+
+
+class _EmptyStateManager:
+    def state_dict(self) -> dict:
+        return {}
+
+    def load_state_dict(self, _state: dict) -> None:
+        pass
+
+
+class _EmptyCheckpointManager:
+    def get_rng_state(self) -> dict:
+        return {}
+
+    def set_rng_state(self, _state: dict) -> None:
+        pass
+
+
+class _SyncOnlyTrainer(llm_trainer_module.LLMTrainer):
+    def build_lr_schedulers(self) -> None:
+        pass
+
+    def step_training(self) -> None:
+        pass
+
+
+class _TrainerHook:
+    supports_packing = True
+
+    def __init__(self, single, batch) -> None:
+        self.single = single
+        self.batch = batch
+
+    def __call__(self, tensor: torch.Tensor) -> None:
+        self.single(tensor)
+
+
+def _trainer(tensors: list[torch.Tensor], rank: int, model=None):
+    trainer = _SyncOnlyTrainer.__new__(_SyncOnlyTrainer)
+    trainer.parallel_dims = SimpleNamespace(pp_enabled=False)
+    trainer.model = model if model is not None else _StateModel(tensors)
+    trainer.reference_state_dict = {}
+    trainer.optimizers = _EmptyStateManager()
+    trainer.lr_schedulers = None
+    trainer.ckpt_manager = _EmptyCheckpointManager()
+    trainer.device = torch.device(f"cuda:{rank}")
+    return trainer
+
+
+def _check_payloads(tensors: list[torch.Tensor], rank: int) -> None:
+    expected = _payloads(rank, source=True)
+    for actual, source in zip(tensors, expected, strict=True):
+        torch.testing.assert_close(actual.cpu(), source.cpu())
+
+
+def _offloaded_payloads(*, source: bool) -> list[torch.Tensor]:
+    if source:
+        return [
+            torch.arange(9, dtype=torch.float32),
+            torch.tensor(17.5, dtype=torch.float32),
+        ]
+    return [torch.zeros(9, dtype=torch.float32), torch.tensor(0.0)]
+
+
+def _check_offloaded_payloads(tensors: list[torch.Tensor]) -> None:
+    expected = _offloaded_payloads(source=True)
+    for actual, source in zip(tensors, expected, strict=True):
+        assert actual.device.type == "cpu"
+        torch.testing.assert_close(actual, source)
+
+
+def _run_p2p_batching(rank: int, uid: list[int]) -> None:
+    torch.cuda.set_device(rank)
+    comm_idx = create_nccl_comm(uid, rank, 2)
+    communicator = _communicator(rank, comm_idx)
+    tensors = _payloads(rank, source=rank == 0)
+    try:
+        if rank == 0:
+            communicator.send_batch(tensors, "policy-1")
+        else:
+            communicator.recv_batch(tensors, "policy-0")
+            _check_payloads(tensors, rank)
+
+        # Reuse the communicator for a second ordered collective sequence and
+        # verify that broadcast batching has identical movement semantics.
+        tensors = _payloads(rank, source=rank == 0)
+        communicator.broadcast_batch(tensors, "policy-0")
+        _check_payloads(tensors, rank)
+
+        # Exercise LLMTrainer's production hybrid path: the 68-byte first
+        # tensor remains direct while the remaining mixed-dtype tensors pack
+        # into one 52-byte payload.
+        llm_trainer_module._P2P_SYNC_BUCKET_SIZE_BYTES = 64
+        llm_trainer_module._P2P_SYNC_PACK_TENSORS = True
+        tensors = _payloads(rank, source=rank == 0)
+        trainer = _trainer(tensors, rank)
+        send_hook = _TrainerHook(
+            lambda tensor: communicator.send(tensor, "policy-1"),
+            lambda batch: communicator.send_batch(batch, "policy-1"),
+        )
+        recv_hook = _TrainerHook(
+            lambda tensor: communicator.recv(tensor, "policy-0"),
+            lambda batch: communicator.recv_batch(batch, "policy-0"),
+        )
+        assert trainer.sync_all_states(rank == 0, send_hook, recv_hook) == 4
+        if rank == 1:
+            _check_payloads(tensors, rank)
+
+        tensors = _payloads(rank, source=rank == 0)
+        trainer = _trainer(tensors, rank)
+        broadcast_hook = _TrainerHook(
+            lambda tensor: communicator.broadcast(tensor, "policy-0"),
+            lambda batch: communicator.broadcast_batch(batch, "policy-0"),
+        )
+        assert trainer.sync_all_states(rank == 0, broadcast_hook, broadcast_hook) == 4
+        _check_payloads(tensors, rank)
+
+        # CPU/offloaded state takes a temporary CUDA path for NCCL, then must
+        # unpack and copy back into the original CPU tensors.
+        offloaded = _offloaded_payloads(source=rank == 0)
+        trainer = _trainer(
+            offloaded,
+            rank,
+            model=_OffloadedStateModel(offloaded),
+        )
+        assert trainer.sync_all_states(rank == 0, send_hook, recv_hook) == 2
+        if rank == 1:
+            _check_offloaded_payloads(offloaded)
+
+        offloaded = _offloaded_payloads(source=rank == 0)
+        trainer = _trainer(
+            offloaded,
+            rank,
+            model=_OffloadedStateModel(offloaded),
+        )
+        assert trainer.sync_all_states(rank == 0, broadcast_hook, broadcast_hook) == 2
+        _check_offloaded_payloads(offloaded)
+    finally:
+        nccl_abort(comm_idx)
+
+
+@pytest.mark.skipif(torch.cuda.device_count() < 2, reason="requires two CUDA GPUs")
+def test_real_nccl_p2p_batches_preserve_mixed_dtype_payloads() -> None:
+    mp.spawn(
+        _run_p2p_batching,
+        args=(create_nccl_uid(),),
+        nprocs=2,
+        join=True,
+    )

--- a/tests/test_policy_to_policy.py
+++ b/tests/test_policy_to_policy.py
@@ -36,7 +36,13 @@ class TestPolicyToPolicy(unittest.TestCase):
         nccl_uid = create_nccl_uid()
         nccl_uid_tensor = torch.tensor(nccl_uid, dtype=torch.int64)
         shms = []
-        world_size = 2
+        world_size = int(os.getenv("COSMOS_TEST_P2P_POLICY_WORLD_SIZE", "2"))
+        if world_size < 1:
+            raise ValueError("COSMOS_TEST_P2P_POLICY_WORLD_SIZE must be positive")
+        if torch.cuda.device_count() < 2 * world_size:
+            self.skipTest(
+                f"requires {2 * world_size} GPUs for two {world_size}-rank policies"
+            )
         for i in range(world_size):
             shms.append(
                 shared_memory.SharedMemory(
@@ -82,7 +88,9 @@ class TestPolicyToPolicy(unittest.TestCase):
                 "policy_recv_from_policy",
             ]
             policy_env = dict(os.environ)
-            policy_env["CUDA_VISIBLE_DEVICES"] = "0,1"
+            policy_env["CUDA_VISIBLE_DEVICES"] = ",".join(
+                str(device) for device in range(world_size)
+            )
             # Start the process
             policy_process = subprocess.Popen(
                 policy_cmd,
@@ -91,7 +99,9 @@ class TestPolicyToPolicy(unittest.TestCase):
                 env=policy_env,
             )
             policy_dst_env = dict(os.environ)
-            policy_dst_env["CUDA_VISIBLE_DEVICES"] = "2,3"
+            policy_dst_env["CUDA_VISIBLE_DEVICES"] = ",".join(
+                str(device) for device in range(world_size, 2 * world_size)
+            )
             policy_dst_process = subprocess.Popen(
                 policy_dst_cmd,
                 stdout=sys.stderr,


### PR DESCRIPTION
## Summary

- group ordered policy-to-policy state transfers into byte-bounded HA retry/watchdog windows
- optionally pack small mixed-dtype tensors into a reusable `uint8` buffer, while keeping oversized tensors direct
- keep packing disabled by default behind `[train].p2p_sync_pack_tensors`
- preserve the single-tensor hook contract for custom trainers
- cover retry ordering, DTensor state, CPU/offloaded state, scalar tensors, initialization broadcast, and dynamic-scale unicast

This changes policy-to-policy initialization and elasticity sync only. It does not alter P2R or R2R weight synchronization.

## Motivation

`LLMTrainer.sync_all_states` previously invoked the HA NCCL wrapper once per state entry. Each invocation waited for communicator readiness and entered a watchdog that records a CUDA event and drains the stream, so a model/optimizer state with hundreds of entries incurred hundreds of host-side drain points.

Byte-bounded HA batches reduce the retry/watchdog count. Packing additionally reduces the number of raw NCCL operations; this is the part that produced the material improvement.

## Benchmark

Measured on one 8x H100 80 GB node with a constructed Qwen2.5-7B-equivalent BF16 inventory: 7,615,616,512 parameters, 339 tensors, and 15,231,233,024 bytes. Results are medians of five order-rotated runs through the production `LLMTrainer.sync_all_states` path. Receivers were cleared before every run and every element was checked afterward.

| Topology | Per tensor | HA windows only | Packed 256 MiB buckets | Packed improvement |
| --- | ---: | ---: | ---: | ---: |
| Four concurrent FSDP4 unicast lanes (3.55 GiB/rank) | 454.9 ms | 439.2 ms | **30.2 ms** | **15.1x / 93.4% less time** |
| Eight-rank broadcast (14.19 GiB/rank) | 463.9 ms | 456.3 ms | **132.1 ms** | **3.51x / 71.5% less time** |

HA-window batching alone saved 1.6-3.4% because all 339 NCCL operations remained. Packing reduced the unicast case to 15 transfers and the broadcast case to 86 transfers. The largest scratch allocations observed were 267,924,992 bytes for FSDP4 unicast and 194,534,400 bytes for broadcast. Benchmark Slurm job: `2142761`.

## Configuration

Packing requires explicit enablement:

```toml
[train]
p2p_sync_pack_tensors = true
```

An explicitly set `COSMOS_P2P_SYNC_PACK_TENSORS` overrides the TOML value for A/B testing or emergency disablement. `COSMOS_P2P_SYNC_BUCKET_SIZE_BYTES=0` restores per-tensor behavior.

## Correctness and validation

- Unit/contract suite: **25 passed, 2 skipped, 129 subtests passed**. The two local skips require GPUs and were run separately below.
- Real-NCCL packed broadcast and unicast: job `2142743`.
- Config-driven initialization broadcast with four two-GPU Qwen2.5-3B policies: job `2142910`; 434 DTensor entries and a 263,235,632-byte packed buffer per rank.
- Real-NCCL CPU/offloaded state copyback for broadcast and unicast, including scalar state: job `2142911`.
- Full dynamic-scale `PolicyToPolicyUnicastCommand` worker integration with two four-rank Qwen2.5-3B policies on 8x H100: job `2142965`; all four destination ranks verified source-stamped values, with 434 DTensor entries and a 267,941,448-byte packed buffer per rank.
- Ruff format/check and `git diff --check` pass.

The dynamic-scale and initialization jobs left `COSMOS_P2P_SYNC_PACK_TENSORS` unset, proving that packing was selected by the TOML configuration.
