### PR TITLE
perf(weight-sync): batch P2R and R2R transfers

### DIFF
--- a/cosmos_rl/policy/config/__init__.py
+++ b/cosmos_rl/policy/config/__init__.py
@@ -920,6 +920,14 @@ class TrainingConfig(BaseModel):
             "initialization and dynamic-scale state synchronization."
         ),
     )
+    p2r_sync_groups_per_round: int = Field(
+        default=0,
+        ge=0,
+        description=(
+            "Number of globally ordered parameter groups per P2R NCCL round. "
+            "Zero disables NCCL grouping."
+        ),
+    )
     coalesce_weight_sync: bool = Field(
         default=False,
         description="If True, the controller coalesces (drops) redundant P2R+R2R "
@@ -1559,6 +1567,18 @@ class RolloutConfig(BaseModel):
             "the buffer to the live model before each rollout_generation() call.  "
             "'inference' additionally syncs before each policy forward pass."
         ),
+    )
+    r2r_sync_pack_tensors: bool = Field(
+        default=False,
+        description=(
+            "Pack small tensors into byte-bounded buffers for rollout-to-rollout "
+            "weight synchronization."
+        ),
+    )
+    r2r_sync_bucket_size_bytes: int = Field(
+        default=512 * 1024 * 1024,
+        gt=0,
+        description="Maximum packed R2R transfer size in bytes.",
     )
 
     prefetch_rollout: bool = Field(

--- a/cosmos_rl/policy/worker/rl_worker.py
+++ b/cosmos_rl/policy/worker/rl_worker.py
@@ -40,6 +40,7 @@ from cosmos_rl.utils.util import is_master_rank, str2torch_dtype
 from cosmos_rl.utils.distributed import HighAvailabilitylNccl, destroy_distributed
 from cosmos_rl.utils.parallelism_map import (
     ParallelTopoMapperGroup,
+    iter_p2r_sync_rounds,
 )
 from cosmos_rl.utils.pynccl import (
     bounded_drain_or_abort,
@@ -480,6 +481,7 @@ class RLPolicyWorker(PolicyWorkerBase):
             if self.rl_mode == "colocated_separated"
             else self.p2r_collective_manager.query_nccl_comm_index(base_mesh_key)
         )
+        p2r_group_size = constant.get_p2r_nccl_group_size(self.config)
 
         with torch.cuda.stream(self.train_stream):
             with torch.no_grad():
@@ -498,10 +500,9 @@ class RLPolicyWorker(PolicyWorkerBase):
                     )
 
                     def grouped_send(grouped_send_ops):
-                        if (
-                            self.rl_mode != "colocated_separated"
-                            and constant.COSMOS_P2R_NCCL_GROUP_SIZE > 0
-                        ):
+                        if not grouped_send_ops:
+                            return
+                        if self.rl_mode != "colocated_separated" and p2r_group_size > 0:
                             # Only in non-colocated-separated mode, we could use NCCL group feature.
                             nccl_group_start(comm_id)
                         for view, r_rank, dest_name in grouped_send_ops:
@@ -511,72 +512,72 @@ class RLPolicyWorker(PolicyWorkerBase):
                             self.p2r_collective_manager.send(
                                 base_mesh_key, view, r_rank
                             )
-                        if (
-                            self.rl_mode != "colocated_separated"
-                            and constant.COSMOS_P2R_NCCL_GROUP_SIZE > 0
-                        ):
+                        if self.rl_mode != "colocated_separated" and p2r_group_size > 0:
                             nccl_group_end(comm_id)
                         grouped_send_ops.clear()
 
-                    grouped_send_ops = []
-                    num_groups = 0
-
                     transferred_params_cnt = 0
                     skipped_params_cnt = 0
-                    for insts_group in self.policy_to_rollout_insts:
-                        for insts_for_per_param in insts_group.param_instructions:
-                            dest_name = insts_for_per_param.param_name
-                            if (
-                                dest_name not in self.trainable_params
-                                and command.trainable_only
-                            ):
-                                logger.debug(
-                                    f"[Policy] Skip {dest_name} in P2R send due to non trainable."
-                                )
-                                skipped_params_cnt += 1
-                                continue
-                            transferred_params_cnt += 1
-
-                            for inst in insts_for_per_param.instructions:
-                                p_rank = inst.policy_rank
-                                r_rank = inst.rollout_rank
-                                tensor_split_strategys = inst.slice_strategy
+                    for sync_round in iter_p2r_sync_rounds(
+                        self.policy_to_rollout_insts,
+                        p2r_group_size,
+                    ):
+                        grouped_send_ops = []
+                        for insts_group in sync_round:
+                            for insts_for_per_param in insts_group.param_instructions:
+                                dest_name = insts_for_per_param.param_name
                                 if (
-                                    dest_name
-                                    not in self.trainer.map_w_from_policy_to_rollout
+                                    dest_name not in self.trainable_params
+                                    and command.trainable_only
                                 ):
-                                    raise RuntimeError(
-                                        f"dest_name {dest_name} not in trainer's map_w_from_policy_to_rollout"
+                                    logger.debug(
+                                        f"[Policy] Skip {dest_name} in P2R send due to non trainable."
                                     )
-                                local_view = self.trainer.map_w_from_policy_to_rollout[
-                                    dest_name
-                                ]
-                                if dest_name in pre_P2R_collected_tensors:
-                                    local_view = pre_P2R_collected_tensors[dest_name]
-                                elif isinstance(local_view, Callable):
-                                    local_view = local_view()
-                                else:
-                                    pass
-                                local_view = local_view.to(
-                                    str2torch_dtype(self.config.train.transfer_dtype)
-                                )
-                                view = (
-                                    local_view.cosmos_slice(tensor_split_strategys)
-                                    .contiguous()
-                                    .cuda()
-                                )
-                                assert self.global_rank == p_rank
-                                logger.debug(
-                                    f"[Policy] Sending {dest_name} from policy rank {self.global_rank} to rollout rank {r_rank}, {view.shape} with dtype: {view.dtype}."
-                                )
-                                grouped_send_ops.append((view, r_rank, dest_name))
-                                total_bytes_sent += view.numel() * view.element_size()
-                        num_groups += 1
-                        if num_groups >= constant.COSMOS_P2R_NCCL_GROUP_SIZE:
-                            grouped_send(grouped_send_ops)
-                            num_groups = 0
+                                    skipped_params_cnt += 1
+                                    continue
+                                transferred_params_cnt += 1
 
-                    grouped_send(grouped_send_ops)
+                                for inst in insts_for_per_param.instructions:
+                                    p_rank = inst.policy_rank
+                                    r_rank = inst.rollout_rank
+                                    tensor_split_strategys = inst.slice_strategy
+                                    if (
+                                        dest_name
+                                        not in self.trainer.map_w_from_policy_to_rollout
+                                    ):
+                                        raise RuntimeError(
+                                            f"dest_name {dest_name} not in trainer's map_w_from_policy_to_rollout"
+                                        )
+                                    local_view = (
+                                        self.trainer.map_w_from_policy_to_rollout[
+                                            dest_name
+                                        ]
+                                    )
+                                    if dest_name in pre_P2R_collected_tensors:
+                                        local_view = pre_P2R_collected_tensors[
+                                            dest_name
+                                        ]
+                                    elif isinstance(local_view, Callable):
+                                        local_view = local_view()
+                                    local_view = local_view.to(
+                                        str2torch_dtype(
+                                            self.config.train.transfer_dtype
+                                        )
+                                    )
+                                    view = (
+                                        local_view.cosmos_slice(tensor_split_strategys)
+                                        .contiguous()
+                                        .cuda()
+                                    )
+                                    assert self.global_rank == p_rank
+                                    logger.debug(
+                                        f"[Policy] Sending {dest_name} from policy rank {self.global_rank} to rollout rank {r_rank}, {view.shape} with dtype: {view.dtype}."
+                                    )
+                                    grouped_send_ops.append((view, r_rank, dest_name))
+                                    total_bytes_sent += (
+                                        view.numel() * view.element_size()
+                                    )
+                        grouped_send(grouped_send_ops)
                 finally:
                     if self.config.policy.lora is not None:
                         # Always attempt to unmerge to restore training state

--- a/cosmos_rl/rollout/trtllm_rollout/trtllm_worker.py
+++ b/cosmos_rl/rollout/trtllm_rollout/trtllm_worker.py
@@ -29,6 +29,7 @@ from cosmos_rl.rollout import State
 from cosmos_rl.utils.parallelism_map import (
     ParallelTopoMapperGroup,
     WeightSyncInstructionsGroup,
+    iter_p2r_sync_rounds,
 )
 from cosmos_rl.dispatcher.command import (
     BuildMeshCommand,
@@ -478,7 +479,6 @@ class CosmosTRTLLMWorker(TrtLLMRolloutWorker, PyExecutor):
 
             pending_bytes = [0]
             pending_completions = []
-            pending_groups = 0
 
             def flush_completions(pending_bytes, pending_completions):
                 recv_ready = torch.cuda.Event()
@@ -493,34 +493,28 @@ class CosmosTRTLLMWorker(TrtLLMRolloutWorker, PyExecutor):
                     pending_bytes[0] = 0
                     pending_completions.clear()
 
-            if constant.COSMOS_P2R_NCCL_GROUP_SIZE > 0:
-                nccl_group_start(communicator_index)
-
-            for insts_group in self.policy_to_rollout_recv_insts:
-                # insts_group: WeightSyncInstructionsGroup -> inst collection for a full weight tensor
-                # handle inst group
-                bytes_received, completion_fn = self.recv_weight_shard(
-                    self.global_rank,
-                    insts_group,
-                    communicator_index,
-                    command.do_weight_sync_check,
-                )
-                pending_bytes[0] += bytes_received
-                pending_completions.append(completion_fn)
-                total_bytes_received += bytes_received
-
-                pending_groups += 1
-                if pending_groups >= constant.COSMOS_P2R_NCCL_GROUP_SIZE:
-                    if constant.COSMOS_P2R_NCCL_GROUP_SIZE > 0:
-                        nccl_group_end(communicator_index)
-                    flush_completions(pending_bytes, pending_completions)
-                    if constant.COSMOS_P2R_NCCL_GROUP_SIZE > 0:
-                        nccl_group_start(communicator_index)
-                    pending_groups = 0
-
-            if constant.COSMOS_P2R_NCCL_GROUP_SIZE > 0:
-                nccl_group_end(communicator_index)
-            flush_completions(pending_bytes, pending_completions)
+            p2r_group_size = constant.get_p2r_nccl_group_size(self.config)
+            for sync_round in iter_p2r_sync_rounds(
+                self.policy_to_rollout_recv_insts,
+                p2r_group_size,
+            ):
+                if p2r_group_size > 0:
+                    nccl_group_start(communicator_index)
+                for insts_group in sync_round:
+                    # insts_group: WeightSyncInstructionsGroup -> inst
+                    # collection for a full weight tensor.
+                    bytes_received, completion_fn = self.recv_weight_shard(
+                        self.global_rank,
+                        insts_group,
+                        communicator_index,
+                        command.do_weight_sync_check,
+                    )
+                    pending_bytes[0] += bytes_received
+                    pending_completions.append(completion_fn)
+                    total_bytes_received += bytes_received
+                if p2r_group_size > 0:
+                    nccl_group_end(communicator_index)
+                flush_completions(pending_bytes, pending_completions)
 
             with torch.cuda.stream(copy_stream):
                 copy_finished = torch.cuda.Event()

--- a/cosmos_rl/rollout/worker/rollout_control.py
+++ b/cosmos_rl/rollout/worker/rollout_control.py
@@ -52,13 +52,13 @@ from cosmos_rl.utils.pynccl import (
     create_nccl_uid,
     create_nccl_comm,
     bounded_drain_or_abort,
-    nccl_broadcast,
     nccl_group_start,
     nccl_group_end,
 )
 from cosmos_rl.utils.parallelism_map import (
     ParallelTopoMapperGroup,
     WeightSyncInstructionsGroup,
+    iter_p2r_sync_rounds,
 )
 from cosmos_rl.dispatcher.data.packer.base import BaseDataPacker
 import cosmos_rl.utils.distributed as dist_util
@@ -85,6 +85,7 @@ from cosmos_rl.rollout.worker.weight_sync import (
     sync_buffer_to_live,
     process_wst_deferred_actions,
     do_nccl_broadcast_grouped,
+    do_nccl_broadcast_tensors,
     install_inference_sync,
 )
 
@@ -1390,7 +1391,6 @@ class DisaggregatedRolloutControlWorker(RolloutWorkerBase):
 
             pending_bytes = [0]
             pending_completions = []
-            pending_groups = 0
 
             def flush_completions(pending_bytes, pending_completions):
                 recv_ready = torch.cuda.Event()
@@ -1405,73 +1405,68 @@ class DisaggregatedRolloutControlWorker(RolloutWorkerBase):
                     pending_bytes[0] = 0
                     pending_completions.clear()
 
-            if (
-                self.rl_mode != "colocated_separated"
-                and constant.COSMOS_P2R_NCCL_GROUP_SIZE > 0
-            ):
-                nccl_group_start(comm_id)
-
             skipped_params_cnt = 0
             transferred_params_cnt = 0
             skipped_groups_cnt = 0
             transferred_groups_cnt = 0
+            p2r_group_size = constant.get_p2r_nccl_group_size(self.config)
 
-            for insts_group in self.policy_to_rollout_recv_insts:
-                (
-                    bytes_received,
-                    completion_fn,
-                    skipped_cnt,
-                ) = self.recv_weight_shard(
-                    self.global_rank,
-                    insts_group,
-                    base_mesh_key,
-                    command.trainable_only,
-                    command.do_weight_sync_check,
-                )
-                skipped_params_cnt += skipped_cnt
-                transferred_params_cnt += (
-                    len(insts_group.param_instructions) - skipped_cnt
+            for sync_round in iter_p2r_sync_rounds(
+                self.policy_to_rollout_recv_insts,
+                p2r_group_size,
+            ):
+                round_has_transfers = not command.trainable_only or any(
+                    param_insts.param_name in self.trainable_params
+                    for insts_group in sync_round
+                    for param_insts in insts_group.param_instructions
                 )
                 if (
-                    self.weight_mapper.get_unsplited_weight_name(
-                        insts_group.param_instructions[0].param_name
-                    )
-                    != insts_group.param_instructions[0].param_name
+                    round_has_transfers
+                    and self.rl_mode != "colocated_separated"
+                    and p2r_group_size > 0
                 ):
-                    skipped_groups_cnt += 1 if skipped_cnt > 0 else 0
-                    transferred_groups_cnt += 0 if skipped_cnt > 0 else 1
-                else:
-                    skipped_groups_cnt += skipped_cnt
-                    transferred_groups_cnt += (
+                    nccl_group_start(comm_id)
+                for insts_group in sync_round:
+                    (
+                        bytes_received,
+                        completion_fn,
+                        skipped_cnt,
+                    ) = self.recv_weight_shard(
+                        self.global_rank,
+                        insts_group,
+                        base_mesh_key,
+                        command.trainable_only,
+                        command.do_weight_sync_check,
+                    )
+                    skipped_params_cnt += skipped_cnt
+                    transferred_params_cnt += (
                         len(insts_group.param_instructions) - skipped_cnt
                     )
-
-                pending_bytes[0] += bytes_received
-                pending_completions.append(completion_fn)
-                total_bytes_received += bytes_received
-
-                pending_groups += 1
-                if pending_groups >= constant.COSMOS_P2R_NCCL_GROUP_SIZE:
                     if (
-                        self.rl_mode != "colocated_separated"
-                        and constant.COSMOS_P2R_NCCL_GROUP_SIZE > 0
+                        self.weight_mapper.get_unsplited_weight_name(
+                            insts_group.param_instructions[0].param_name
+                        )
+                        != insts_group.param_instructions[0].param_name
                     ):
-                        nccl_group_end(comm_id)
-                    flush_completions(pending_bytes, pending_completions)
-                    if (
-                        self.rl_mode != "colocated_separated"
-                        and constant.COSMOS_P2R_NCCL_GROUP_SIZE > 0
-                    ):
-                        nccl_group_start(comm_id)
-                    pending_groups = 0
+                        skipped_groups_cnt += 1 if skipped_cnt > 0 else 0
+                        transferred_groups_cnt += 0 if skipped_cnt > 0 else 1
+                    else:
+                        skipped_groups_cnt += skipped_cnt
+                        transferred_groups_cnt += (
+                            len(insts_group.param_instructions) - skipped_cnt
+                        )
 
-            if (
-                self.rl_mode != "colocated_separated"
-                and constant.COSMOS_P2R_NCCL_GROUP_SIZE > 0
-            ):
-                nccl_group_end(comm_id)
+                    pending_bytes[0] += bytes_received
+                    pending_completions.append(completion_fn)
+                    total_bytes_received += bytes_received
 
-            flush_completions(pending_bytes, pending_completions)
+                if (
+                    round_has_transfers
+                    and self.rl_mode != "colocated_separated"
+                    and p2r_group_size > 0
+                ):
+                    nccl_group_end(comm_id)
+                flush_completions(pending_bytes, pending_completions)
 
             with torch.cuda.stream(copy_stream):
                 copy_finished = torch.cuda.Event()
@@ -1578,58 +1573,53 @@ class DisaggregatedRolloutControlWorker(RolloutWorkerBase):
                 if not trainable_only:
                     self.non_trainable_params_received = True
             else:
-                # Original synchronous per-param broadcast path.
+                # Synchronous trainable-aware broadcast path.
                 self.prepare_trainable_params()
                 skipped_params_cnt = 0
-                transferred_params_cnt = 0
                 logger.info(
                     "[Rollout] Starting broadcasting of parameters to all replicas."
                 )
-                with torch.cuda.stream(self.inference_stream):
-                    assert self.rank_in_rollout_repicas >= 0, (
-                        "[Rollout] rank in rollout replicas should be set before broadcast."
-                    )
-                    # The mesh communicator is skipped when the job has no
-                    # policy replicas. Reaching a broadcast anyway means that
-                    # assumption was wrong; fail here rather than hand -1 to
-                    # NCCL.
-                    assert self.global_commnicator_idex >= 0, (
-                        "[Rollout] global mesh communicator was never built, "
-                        "but a rollout-to-rollout broadcast was requested."
-                    )
-                    assert len(dst_replica_names) == len(self.replica_name_to_rank), (
-                        "[Rollout] The vaild dst replicas num should match the replicas num that this worker holds."
-                    )
+                assert self.rank_in_rollout_repicas >= 0, (
+                    "[Rollout] rank in rollout replicas should be set before broadcast."
+                )
+                # The mesh communicator is skipped when the job has no policy
+                # replicas. Reaching a broadcast anyway means that assumption
+                # was wrong; fail here rather than hand -1 to NCCL.
+                assert self.global_commnicator_idex >= 0, (
+                    "[Rollout] global mesh communicator was never built, "
+                    "but a rollout-to-rollout broadcast was requested."
+                )
+                assert len(dst_replica_names) == len(self.replica_name_to_rank), (
+                    "[Rollout] The vaild dst replicas num should match the replicas num that this worker holds."
+                )
 
-                    src_rank = self.replica_name_to_rank[src_replica_name]
-                    with torch.inference_mode():
-                        for name, parameter in self.rollout.model_param_map(
-                            self.weight_mapper
-                        ).items():
-                            if name not in self.trainable_params and trainable_only:
-                                logger.debug(
-                                    f"[Rollout] Skip {name} in R2R due to non trainable."
-                                )
-                                skipped_params_cnt += 1
-                                continue
-                            transferred_params_cnt += 1
-
-                            recv_tensor = parameter
-                            if not parameter.is_contiguous():
-                                recv_tensor = parameter.contiguous()
-
-                            nccl_broadcast(
-                                recv_tensor, src_rank, self.global_commnicator_idex
-                            )
-
-                            if not parameter.is_contiguous():
-                                parameter.copy_(recv_tensor)
-
-                    if not self.state.weight_synced():
-                        assert not trainable_only, (
-                            "[Rollout] Trainable only must be set to False for the first broadcast."
+                transfer_tensors = []
+                for name, parameter in self.rollout.model_param_map(
+                    self.weight_mapper
+                ).items():
+                    if name not in self.trainable_params and trainable_only:
+                        logger.debug(
+                            f"[Rollout] Skip {name} in R2R due to non trainable."
                         )
-                        self.state.set_weight_synced()
+                        skipped_params_cnt += 1
+                        continue
+                    transfer_tensors.append(parameter)
+
+                src_rank = self.replica_name_to_rank[src_replica_name]
+                transferred_params_cnt, _ = do_nccl_broadcast_tensors(
+                    self,
+                    transfer_tensors,
+                    src_rank,
+                    self.global_commnicator_idex,
+                    self.inference_stream,
+                    group_unpacked=False,
+                )
+
+                if not self.state.weight_synced():
+                    assert not trainable_only, (
+                        "[Rollout] Trainable only must be set to False for the first broadcast."
+                    )
+                    self.state.set_weight_synced()
 
                 logger.info(
                     f"[Rollout] Finished broadcasting of parameters to all replicas. While {skipped_params_cnt} unsplitted non-trainable params skipped and {transferred_params_cnt} unsplitted params transferred."

--- a/cosmos_rl/rollout/worker/weight_sync.py
+++ b/cosmos_rl/rollout/worker/weight_sync.py
@@ -56,7 +56,7 @@ import queue
 import threading
 import time
 from enum import Enum
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING, Optional, Sequence
 
 import torch
 from torch.distributed.tensor import DTensor
@@ -68,6 +68,12 @@ from cosmos_rl.utils.pynccl import (
     nccl_broadcast,
     nccl_group_end,
     nccl_group_start,
+)
+from cosmos_rl.utils.tensor_packing import (
+    iter_tensor_byte_buckets,
+    pack_tensors_into_buffer,
+    packed_nbytes,
+    unpack_tensors_from_buffer,
 )
 
 # Bounded wait for in-flight GPU work on the WeightSyncThread stream during
@@ -908,59 +914,146 @@ def r2r_barrier(
 # ---------------------------------------------------------------------------
 
 
+def _require_r2r_communicator(comm_idx: int) -> None:
+    if comm_idx < 0:
+        raise RuntimeError(
+            "[Rollout] rollout-to-rollout broadcast requested but no global "
+            "mesh communicator exists (the controller reported the mesh "
+            "unused when it was last rebuilt). This replica cannot "
+            "participate; a peer that did build one will wait for it."
+        )
+
+
+def do_nccl_broadcast_tensors(
+    worker,
+    tensors: Sequence[torch.Tensor],
+    src_rank: int,
+    comm_idx: int,
+    stream,
+    *,
+    group_unpacked: bool,
+) -> tuple[int, int]:
+    """Broadcast an ordered tensor selection, optionally packed by bytes.
+
+    ``group_unpacked`` preserves the caller's legacy behavior when packing is
+    disabled: the full-state R2R path uses one NCCL group, while the default
+    trainable-aware path issues its broadcasts individually.
+    """
+    _require_r2r_communicator(comm_idx)
+
+    # FSDP2 state_dict entries are DTensors. R2R peers have matching FSDP
+    # layouts, so each corresponding-rank communicator must broadcast the
+    # local shard rather than the global DTensor wrapper. Besides being the
+    # actual NCCL allocation, the local tensor also makes byte accounting and
+    # packing operate on the transferred size instead of the global size.
+    transfer_source = [
+        tensor.to_local() if isinstance(tensor, DTensor) else tensor
+        for tensor in tensors
+    ]
+    if not transfer_source:
+        return 0, 0
+
+    bytes_broadcast = sum(
+        param.nelement() * param.element_size() for param in transfer_source
+    )
+    non_contig: list[tuple[torch.Tensor, torch.Tensor]] = []
+    with torch.cuda.stream(stream):
+        pack_tensors = getattr(
+            getattr(worker.config, "rollout", None),
+            "r2r_sync_pack_tensors",
+            False,
+        )
+        bucket_size_bytes = getattr(
+            getattr(worker.config, "rollout", None),
+            "r2r_sync_bucket_size_bytes",
+            512 * 1024 * 1024,
+        )
+
+        with torch.inference_mode():
+            transfer_tensors = []
+            for param in transfer_source:
+                if param.is_contiguous():
+                    transfer_tensor = param
+                else:
+                    transfer_tensor = param.contiguous()
+                    non_contig.append((param, transfer_tensor))
+                transfer_tensors.append(transfer_tensor)
+
+            buckets = (
+                list(iter_tensor_byte_buckets(transfer_tensors, bucket_size_bytes))
+                if pack_tensors
+                else []
+            )
+            multi_tensor_buckets = [bucket for bucket in buckets if len(bucket) > 1]
+            if multi_tensor_buckets:
+                required_buffer_bytes = max(
+                    packed_nbytes(bucket) for bucket in multi_tensor_buckets
+                )
+                packed_buffer = getattr(worker, "_r2r_sync_packed_buffer", None)
+                if (
+                    packed_buffer is None
+                    or packed_buffer.device != transfer_tensors[0].device
+                    or packed_buffer.numel() < required_buffer_bytes
+                ):
+                    packed_buffer = torch.empty(
+                        required_buffer_bytes,
+                        dtype=torch.uint8,
+                        device=transfer_tensors[0].device,
+                    )
+                    worker._r2r_sync_packed_buffer = packed_buffer
+
+                is_src = worker.rank_in_rollout_repicas == src_rank
+                for bucket in buckets:
+                    if len(bucket) == 1:
+                        nccl_broadcast(bucket[0], src_rank, comm_idx)
+                        continue
+                    payload = (
+                        pack_tensors_into_buffer(bucket, packed_buffer)
+                        if is_src
+                        else packed_buffer[: packed_nbytes(bucket)]
+                    )
+                    nccl_broadcast(payload, src_rank, comm_idx)
+                    if not is_src:
+                        unpack_tensors_from_buffer(payload, bucket)
+            else:
+                if group_unpacked:
+                    nccl_group_start(comm_idx)
+                for transfer_tensor in transfer_tensors:
+                    nccl_broadcast(transfer_tensor, src_rank, comm_idx)
+                if group_unpacked:
+                    nccl_group_end(comm_idx)
+            for param, recv_tensor in non_contig:
+                param.copy_(recv_tensor)
+    return len(transfer_source), bytes_broadcast
+
+
 def do_nccl_broadcast_grouped(worker, src_replica_name: str, stream) -> tuple:
-    """Grouped NCCL broadcast of all model params using group start/end.
+    """NCCL broadcast of all model params, optionally packed by bytes.
 
     Uses buffer tensors when ``_buffer_state_dict`` exists.
     Returns ``(param_count, bytes_broadcast)``.
     """
-    bytes_broadcast = 0
-    transferred_cnt = 0
-    non_contig: list[tuple[torch.Tensor, torch.Tensor]] = []
-    with torch.cuda.stream(stream):
-        assert worker.rank_in_rollout_repicas >= 0
-        assert len(worker.replica_name_to_rank) > 0
-        comm_idx = worker.global_commnicator_idex
-        if comm_idx < 0:
-            # No mesh communicator was ever built -- the controller reported
-            # the mesh unused, so BuildMeshCommand skipped the collective.
-            #
-            # Every R2R broadcast path funnels through here, which is why the
-            # check lives here rather than at one of the three call sites.
-            # Without it comm_idx=-1 reaches _COMM_REGISTRY and raises a bare
-            # KeyError, and on the async path that KeyError is swallowed as a
-            # generic task failure -- the replica keeps running and silently
-            # never syncs weights, which is worse than stopping.
-            raise RuntimeError(
-                "[Rollout] rollout-to-rollout broadcast requested but no global "
-                "mesh communicator exists (the controller reported the mesh "
-                "unused when it was last rebuilt). This replica cannot "
-                "participate; a peer that did build one will wait for it."
-            )
-        src_rank = worker.replica_name_to_rank[src_replica_name]
+    assert worker.rank_in_rollout_repicas >= 0
+    assert len(worker.replica_name_to_rank) > 0
+    comm_idx = worker.global_commnicator_idex
+    _require_r2r_communicator(comm_idx)
+    src_rank = worker.replica_name_to_rank[src_replica_name]
 
-        buffer_sd = getattr(worker, "_buffer_state_dict", None)
-        if buffer_sd is not None:
-            params_iter = buffer_sd.items()
-        else:
-            model = worker.rollout.get_underlying_model()
-            params_iter = model.state_dict().items()
+    buffer_sd = getattr(worker, "_buffer_state_dict", None)
+    if buffer_sd is not None:
+        tensors = list(buffer_sd.values())
+    else:
+        model = worker.rollout.get_underlying_model()
+        tensors = list(model.state_dict().values())
 
-        with torch.inference_mode():
-            nccl_group_start(comm_idx)
-            for _, param in params_iter:
-                if param.is_contiguous():
-                    nccl_broadcast(param, src_rank, comm_idx)
-                else:
-                    recv_tensor = param.contiguous()
-                    nccl_broadcast(recv_tensor, src_rank, comm_idx)
-                    non_contig.append((param, recv_tensor))
-                bytes_broadcast += param.nelement() * param.element_size()
-                transferred_cnt += 1
-            nccl_group_end(comm_idx)
-            for param, recv_tensor in non_contig:
-                param.copy_(recv_tensor)
-    return transferred_cnt, bytes_broadcast
+    return do_nccl_broadcast_tensors(
+        worker,
+        tensors,
+        src_rank,
+        comm_idx,
+        stream,
+        group_unpacked=True,
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/cosmos_rl/utils/constant.py
+++ b/cosmos_rl/utils/constant.py
@@ -126,8 +126,26 @@ def _resolve_rollout_mesh_build_timeout_ms() -> int:
 
 
 COSMOS_ROLLOUT_MESH_BUILD_TIMEOUT_MS = _resolve_rollout_mesh_build_timeout_ms()
-# FIXME: (lms) Setting this greater than 1 could cause P2R NCCL hang when PP and FSDP are both enabled.
 COSMOS_P2R_NCCL_GROUP_SIZE = int(os.environ.get("COSMOS_P2R_NCCL_GROUP_SIZE", "0"))
+
+
+def get_p2r_nccl_group_size(config) -> int:
+    """Resolve P2R groups per NCCL round, preserving the legacy env override."""
+    raw_override = os.environ.get("COSMOS_P2R_NCCL_GROUP_SIZE")
+    if raw_override is not None:
+        try:
+            value = int(raw_override)
+        except ValueError as exc:
+            raise ValueError(
+                "COSMOS_P2R_NCCL_GROUP_SIZE must be a non-negative integer"
+            ) from exc
+    else:
+        value = getattr(getattr(config, "train", None), "p2r_sync_groups_per_round", 0)
+    if value < 0:
+        raise ValueError("P2R NCCL groups per round must be non-negative")
+    return value
+
+
 COSMOS_ROLLOUT_CMD_WAIT_TIMEOUT = int(
     os.environ.get("COSMOS_ROLLOUT_CMD_WAIT_TIMEOUT", "600")
 )

--- a/cosmos_rl/utils/parallelism_map.py
+++ b/cosmos_rl/utils/parallelism_map.py
@@ -18,7 +18,7 @@ import torch
 import asyncio
 import multiprocessing
 
-from typing import Dict, List, Tuple, Callable, Any, Optional
+from typing import Dict, List, Tuple, Callable, Any, Optional, Iterable, Iterator
 from concurrent.futures import ProcessPoolExecutor
 from torch.nn.parameter import Parameter
 
@@ -85,12 +85,20 @@ class WeightSyncInstructionsGroup:
     This class contains a list of WeightSyncInstructionsPerParam objects.
     """
 
-    def __init__(self, param_instructions: List[WeightSyncInstructionsPerParam]):
+    def __init__(
+        self,
+        param_instructions: List[WeightSyncInstructionsPerParam],
+        sync_group_index: Optional[int] = None,
+    ):
         """
         Initialize the WeightSyncInstructionsGroup with the given instructions.
         :param param_instructions: A list of WeightSyncInstructionsPerParam objects representing the synchronization instructions for multiple parameters in one group.
+        :param sync_group_index: Controller-assigned global ordinal for this
+            parameter group. All policy and rollout ranks use this ordinal to
+            derive matching NCCL group boundaries.
         """
         self.param_instructions = param_instructions
+        self.sync_group_index = sync_group_index
 
     def __repr__(self):
         # Returning a dictionary representation
@@ -120,7 +128,77 @@ class WeightSyncInstructionsGroup:
             )
             for insts in data["param_instructions"]
         ]
-        return cls(instructions)
+        return cls(instructions, data.get("sync_group_index"))
+
+
+def iter_p2r_sync_rounds(
+    instructions: Iterable[WeightSyncInstructionsGroup],
+    groups_per_round: int,
+) -> Iterator[List[WeightSyncInstructionsGroup]]:
+    """Yield locally relevant P2R instructions in globally aligned rounds.
+
+    A local instruction count is not a safe NCCL grouping boundary: PP and
+    FSDP can make one rollout rank receive a parameter from several policy
+    ranks. The controller-assigned ``sync_group_index`` identifies the same
+    parameter group on both sides, even when intervening groups are absent on
+    a rank.
+
+    A non-positive size preserves the ungrouped behavior by yielding one
+    instruction group at a time.
+    """
+    if groups_per_round <= 0:
+        for instruction in instructions:
+            yield [instruction]
+        return
+
+    pending: List[WeightSyncInstructionsGroup] = []
+    pending_round = None
+    previous_index = -1
+    for instruction in instructions:
+        group_index = instruction.sync_group_index
+        if group_index is None:
+            raise RuntimeError(
+                "P2R NCCL grouping requires controller-assigned sync_group_index"
+            )
+        if group_index < previous_index:
+            raise RuntimeError(
+                "P2R sync_group_index must be monotonically non-decreasing"
+            )
+        previous_index = group_index
+        round_index = group_index // groups_per_round
+        if pending and round_index != pending_round:
+            yield pending
+            pending = []
+        pending_round = round_index
+        pending.append(instruction)
+    if pending:
+        yield pending
+
+
+def build_p2r_sync_group_index(
+    sorted_params_all_rank_policy: Iterable[Iterable[str]],
+    sorted_params_all_rank_rollout: Iterable[Iterable[str]],
+    param_groups: Iterable[Iterable[str]],
+) -> Dict[str, int]:
+    """Assign a deterministic global ordinal to every P2R parameter group."""
+    normalized_groups = sorted(
+        (tuple(group) for group in param_groups), key=lambda group: group[0]
+    )
+    grouped_params = {name for group in normalized_groups for name in group}
+    all_params = {
+        name
+        for params_per_rank in (
+            list(sorted_params_all_rank_policy) + list(sorted_params_all_rank_rollout)
+        )
+        for name in params_per_rank
+    }
+    ungrouped_params = sorted(all_params - grouped_params)
+    sync_groups = [(name,) for name in ungrouped_params] + normalized_groups
+    return {
+        name: group_index
+        for group_index, group in enumerate(sync_groups)
+        for name in group
+    }
 
 
 class ParallelTopoMapper:
@@ -1033,6 +1111,11 @@ class ParallelizedShardMapper:
                 "[ParallelizedShardMapper] Finished unpacking shard infos for both policy and rollout."
             )
             self.param_groups = sorted(self.param_groups, key=lambda x: x[0])
+            self.sync_group_index_by_param = build_p2r_sync_group_index(
+                self.sorted_params_all_rank_policy,
+                self.sorted_params_all_rank_rollout,
+                self.param_groups,
+            )
             policy_parallelism = ParallelDims.from_config_for_analysis(
                 self.config.policy.parallelism,
                 self.policy_world_size,
@@ -1189,7 +1272,10 @@ class ParallelizedShardMapper:
                 )
             if insts_for_group:
                 policy_to_rollout_insts.append(
-                    WeightSyncInstructionsGroup(insts_for_group).__dict__
+                    WeightSyncInstructionsGroup(
+                        insts_for_group,
+                        self.sync_group_index_by_param[dest_name],
+                    ).__dict__
                 )
         for group in self.param_groups:
             insts_for_group = []
@@ -1247,7 +1333,12 @@ class ParallelizedShardMapper:
                     )
             if insts_for_group:
                 policy_to_rollout_insts.append(
-                    WeightSyncInstructionsGroup(insts_for_group).__dict__
+                    WeightSyncInstructionsGroup(
+                        insts_for_group,
+                        self.sync_group_index_by_param[
+                            insts_for_group[0]["param_name"]
+                        ],
+                    ).__dict__
                 )
         if len(name_in_group) > 0:
             logger.warning(
@@ -1374,7 +1465,10 @@ class ParallelizedShardMapper:
                 )
             if insts_for_group:
                 rollout_from_policy_insts.append(
-                    WeightSyncInstructionsGroup(insts_for_group).__dict__
+                    WeightSyncInstructionsGroup(
+                        insts_for_group,
+                        self.sync_group_index_by_param[dest_name],
+                    ).__dict__
                 )
             else:
                 raise ValueError(
@@ -1435,7 +1529,12 @@ class ParallelizedShardMapper:
                     )
             if insts_for_group:
                 rollout_from_policy_insts.append(
-                    WeightSyncInstructionsGroup(insts_for_group).__dict__
+                    WeightSyncInstructionsGroup(
+                        insts_for_group,
+                        self.sync_group_index_by_param[
+                            insts_for_group[0]["param_name"]
+                        ],
+                    ).__dict__
                 )
             else:
                 raise ValueError(

--- a/cosmos_rl/utils/tensor_packing.py
+++ b/cosmos_rl/utils/tensor_packing.py
@@ -1,0 +1,79 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+# All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Small utilities for deterministic byte packing of ordered tensors."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Iterator, Sequence
+
+import torch
+
+
+def tensor_nbytes(tensor: torch.Tensor) -> int:
+    return tensor.numel() * tensor.element_size()
+
+
+def iter_tensor_byte_buckets(
+    tensors: Iterable[torch.Tensor], bucket_size_bytes: int
+) -> Iterator[list[torch.Tensor]]:
+    """Yield ordered buckets, leaving an oversized tensor in its own bucket."""
+    if bucket_size_bytes <= 0:
+        raise ValueError("tensor packing bucket size must be positive")
+    pending = []
+    pending_bytes = 0
+    for tensor in tensors:
+        nbytes = tensor_nbytes(tensor)
+        if pending and pending_bytes + nbytes > bucket_size_bytes:
+            yield pending
+            pending = []
+            pending_bytes = 0
+        pending.append(tensor)
+        pending_bytes += nbytes
+        if pending_bytes >= bucket_size_bytes:
+            yield pending
+            pending = []
+            pending_bytes = 0
+    if pending:
+        yield pending
+
+
+def packed_nbytes(tensors: Sequence[torch.Tensor]) -> int:
+    return sum(tensor_nbytes(tensor) for tensor in tensors)
+
+
+def pack_tensors_into_buffer(
+    tensors: Sequence[torch.Tensor], buffer: torch.Tensor
+) -> torch.Tensor:
+    """Copy contiguous tensors into the leading bytes of ``buffer``."""
+    required = packed_nbytes(tensors)
+    if buffer.dtype != torch.uint8 or buffer.numel() < required:
+        raise ValueError("byte buffer is too small or has the wrong dtype")
+    payload = buffer[:required]
+    offset = 0
+    for tensor in tensors:
+        if not tensor.is_contiguous():
+            raise ValueError("tensor packing requires contiguous tensors")
+        tensor_bytes = tensor.view(-1).view(torch.uint8)
+        end = offset + tensor_bytes.numel()
+        payload[offset:end].copy_(tensor_bytes)
+        offset = end
+    return payload
+
+
+def unpack_tensors_from_buffer(
+    buffer: torch.Tensor, tensors: Sequence[torch.Tensor]
+) -> None:
+    """Copy leading bytes from ``buffer`` into contiguous tensors in order."""
+    required = packed_nbytes(tensors)
+    if buffer.dtype != torch.uint8 or buffer.numel() < required:
+        raise ValueError("byte buffer is too small or has the wrong dtype")
+    offset = 0
+    for tensor in tensors:
+        if not tensor.is_contiguous():
+            raise ValueError("tensor unpacking requires contiguous tensors")
+        tensor_bytes = tensor.view(-1).view(torch.uint8)
+        end = offset + tensor_bytes.numel()
+        tensor_bytes.copy_(buffer[offset:end])
+        offset = end

--- a/tests/launch_test_worker.py
+++ b/tests/launch_test_worker.py
@@ -101,6 +101,73 @@ POLICY_WORLD_SIZE = 4
 ROLLOUT_WORLD_SIZE = 4
 
 
+def parse_bool_arg(value: str) -> bool:
+    normalized = value.lower()
+    if normalized == "true":
+        return True
+    if normalized == "false":
+        return False
+    raise argparse.ArgumentTypeError("expected 'true' or 'false'")
+
+
+def test_p2r_policy_parallelism_config() -> ParallelismConfig:
+    tp_size = int(os.getenv("COSMOS_TEST_P2R_POLICY_TP_SIZE", "2"))
+    pp_size = int(os.getenv("COSMOS_TEST_P2R_POLICY_PP_SIZE", "1"))
+    model_parallel_size = tp_size * pp_size
+    assert POLICY_WORLD_SIZE % model_parallel_size == 0
+    return ParallelismConfig(
+        dp_shard_size=POLICY_WORLD_SIZE // model_parallel_size,
+        cp_size=1,
+        tp_size=tp_size,
+        pp_size=pp_size,
+    )
+
+
+def test_p2r_rollout_parallelism_config() -> ParallelismConfig:
+    tp_size = int(os.getenv("COSMOS_TEST_P2R_ROLLOUT_TP_SIZE", "4"))
+    pp_size = int(os.getenv("COSMOS_TEST_P2R_ROLLOUT_PP_SIZE", "1"))
+    dp_shard_size = int(os.getenv("COSMOS_TEST_P2R_ROLLOUT_DP_SHARD_SIZE", "1"))
+    model_parallel_size = dp_shard_size * tp_size * pp_size
+    assert ROLLOUT_WORLD_SIZE % model_parallel_size == 0
+    return ParallelismConfig(
+        dp_shard_size=dp_shard_size,
+        dp_replicate_size=ROLLOUT_WORLD_SIZE // model_parallel_size,
+        cp_size=1,
+        tp_size=tp_size,
+        pp_size=pp_size,
+    )
+
+
+def test_p2r_groups_per_round() -> int:
+    return int(os.getenv("COSMOS_TEST_P2R_GROUPS_PER_ROUND", "0"))
+
+
+def set_test_parallelism_info(
+    mapper: ParallelTopoMapper,
+    param_name: str,
+    dims_map: Dict[str, int],
+    pp_rank: int,
+) -> None:
+    tensor_dim_to_parallel_map = {}
+    for parallel_dim, tensor_dim in dims_map.items():
+        tensor_dim_to_parallel_map.setdefault(tensor_dim, []).append(parallel_dim)
+    mapper.parallelism_info_for_params[param_name] = (
+        dims_map,
+        tensor_dim_to_parallel_map,
+        pp_rank,
+        None,
+    )
+
+
+def test_param_pipeline_rank(param_name: str, pp_size: int, num_layers: int) -> int:
+    if pp_size == 1 or param_name == "model.embed_tokens.weight":
+        return 0
+    if param_name.startswith("model.layers."):
+        layer = int(param_name.split(".")[2])
+        return min(layer * pp_size // num_layers, pp_size - 1)
+    return pp_size - 1
+
+
 class TestDataset(Dataset):
     def __init__(self, config: CosmosConfig):
         pass
@@ -188,7 +255,7 @@ class TestModel:
             ("model.layers.9.post_attention_layernorm.weight", {}),
             ("model.layers.9.self_attn.k_proj.bias", {"tp": 0}),
             ("model.layers.9.self_attn.k_proj.weight", {"tp": 0}),
-            ("model.layers.9.self_attn.o_proj.weight", {"tp": 0}),
+            ("model.layers.9.self_attn.o_proj.weight", {"tp": 1}),
             ("model.layers.9.self_attn.q_proj.bias", {"tp": 0}),
             ("model.layers.9.self_attn.q_proj.weight", {"tp": 0}),
             ("model.layers.9.self_attn.v_proj.bias", {"tp": 0}),
@@ -213,29 +280,16 @@ class TestModel:
         self.config = AutoConfig.from_pretrained(self.model_path)
         self.device = device
         self.parallel_dims = parallel_dims
-        self.tensors = [
-            (
-                k,
-                (
-                    torch.arange(v.numel(), dtype=torch.float32, device=self.device)
-                    .reshape(v)
-                    .to(self.device)
-                    * 0.001
-                ).requires_grad_(True)
-                if k not in self.keys_to_freeze
-                else (
-                    torch.arange(v.numel(), dtype=torch.float32, device=self.device)
-                    .reshape(v)
-                    .to(self.device)
-                    * 0.001
-                ).requires_grad_(False),
-            )
-            for k, v in self.sorted_hf_key_n_rank
-        ]
         self.sharded_tensors = {}
-        for k, v in self.tensors:
+        for k, shape in self.sorted_hf_key_n_rank:
+            tensor = (
+                torch.arange(shape.numel(), dtype=torch.float32, device=self.device)
+                .reshape(shape)
+                .mul_(0.001)
+                .requires_grad_(k not in self.keys_to_freeze)
+            )
             self.sharded_tensors[k] = convert_weight_from_hf(
-                v, k, self.model_type, self.parallel_dims
+                tensor, k, self.model_type, self.parallel_dims
             )[1]
         self.sorted_sharded_params = [
             (k, self.sharded_tensors[k].ndim) for k, _ in self.sorted_hf_key_n_rank
@@ -288,9 +342,7 @@ class TestPolicyWorker:
         self.global_rank = int(os.environ.get("RANK", 0))
         self.role = Role.POLICY
         self.world_size = policy_world_size
-        policy_parallelism_dims = ParallelismConfig(
-            dp_shard_size=2, cp_size=1, tp_size=2, pp_size=1
-        )
+        policy_parallelism_dims = test_p2r_policy_parallelism_config()
         self.parallel_dims = ParallelDims.from_config(
             policy_parallelism_dims,
         )
@@ -299,6 +351,8 @@ class TestPolicyWorker:
 
         self.config = CosmosConfig()
         self.config.train.param_dtype = "float32"
+        self.config.train.transfer_dtype = "float32"
+        self.config.train.p2r_sync_groups_per_round = test_p2r_groups_per_round()
         cur_dir = os.path.dirname(os.path.abspath(__file__))
         self.config.train.train_policy.dataset.name = os.path.join(
             cur_dir, "data_fixtures", "test_dataset"
@@ -371,9 +425,7 @@ class TestRollout:
         self.global_rank = int(os.environ.get("RANK", 0))
         self.role = Role.ROLLOUT
         self.world_size = rollout_world_size
-        rollout_parallelism_config = ParallelismConfig(
-            dp_shard_size=1, cp_size=1, tp_size=4, pp_size=1
-        )
+        rollout_parallelism_config = test_p2r_rollout_parallelism_config()
         self.parallel_dims = ParallelDims.from_config(
             rollout_parallelism_config,
         )
@@ -393,10 +445,14 @@ class TestRollout:
             k: torch.zeros(v.shape, dtype=v.dtype).to(self.device)
             for k, v in compatibale_map.items()
         }
-        self.ref_compatibale_map = compatibale_map
+        self.ref_compatibale_map = {
+            key: tensor.detach().clone() for key, tensor in compatibale_map.items()
+        }
         self.quantization_type = None
         self.config = CosmosConfig()
-        self.config.train.param_dtype = "float32"  # keep the same as policy above.
+        self.config.train.param_dtype = "float32"
+        self.config.train.transfer_dtype = "float32"
+        self.config.train.p2r_sync_groups_per_round = test_p2r_groups_per_round()
         self.rl_mode = self.config.mode
 
         cur_dir = os.path.dirname(os.path.abspath(__file__))
@@ -414,7 +470,7 @@ class TestRollout:
         self.p2r_collective_manager.unique_ids_cache = policies_comm
         self.p2r_collective_manager.nccl_comm_cache = policies_comm
 
-        self.weight_inplace_view_map = compatibale_map
+        self.weight_inplace_view_map = operate_compatibale_map
         self.recv_param_key_n_rank_list = compatibale_list
         self.quantized_weight_map = {}
         self.hp_weight_map = {}
@@ -427,20 +483,15 @@ class TestRollout:
             DisaggregatedRolloutControlWorker.recv_weight_shard, self
         )
         # change the default parallelism config
-        self.config.rollout.parallelism.tp_size = 4
-        self.config.rollout.parallelism.pp_size = 1
+        self.config.rollout.parallelism = rollout_parallelism_config
 
         self.consume_command = types.MethodType(
             DisaggregatedRolloutControlWorker.consume_command, self
         )
 
-        # Imported here, not at module scope: this helper serves 13 modes and
-        # only the rollout ones need vLLM.  A top-level import made every mode
-        # -- including pure policy/SFT ones that never construct a rollout --
-        # hard-require it, so an image built without vLLM could not run them.
-        from cosmos_rl.rollout.vllm_rollout.vllm_rollout import vLLMRollout
-
-        self.rollout = vLLMRollout(self.config, None, torch.cuda.current_device())
+        # This harness binds the real P2R receive implementation but supplies
+        # its own model/view maps, so no rollout engine is needed.
+        self.rollout = None
 
         self.temp_recv_tensor_queue = Queue()
         self.prepare_trainable_params()
@@ -461,12 +512,8 @@ class TestRollout:
 
 
 async def generate_send_recv_insts(model: TestModel, is_send: bool, global_rank: int):
-    policy_parallelism_config = ParallelismConfig(
-        dp_shard_size=2, cp_size=1, tp_size=2, pp_size=1
-    )
-    rollout_parallelism_config = ParallelismConfig(
-        dp_shard_size=1, cp_size=1, tp_size=4, pp_size=1
-    )
+    policy_parallelism_config = test_p2r_policy_parallelism_config()
+    rollout_parallelism_config = test_p2r_rollout_parallelism_config()
     p_world_size = 4
     r_world_size = 4
 
@@ -501,21 +548,30 @@ async def generate_send_recv_insts(model: TestModel, is_send: bool, global_rank:
         weight_mapper=rollout_weight_mapper,
     )
 
-    def name_to_hf(name: str) -> str:
-        return name
-
     policy_mapper.mapper_group[0].parallelism_info_for_params = {}
     for k, v in model.parallel_spec:
-        policy_mapper.mapper_group[0].insert_to_parallelism_info(
-            param_name=k, dims_map=v | {"dp_shard_cp": 0}, name_to_hf=name_to_hf
+        set_test_parallelism_info(
+            policy_mapper.mapper_group[0],
+            k,
+            v | {"dp_shard_cp": 0},
+            test_param_pipeline_rank(
+                k,
+                policy_parallelism_config.pp_size,
+                model.num_hidden_layers,
+            ),
         )
 
     rollout_mapper.mapper_group[0].parallelism_info_for_params = {}
     for k, v in model.parallel_spec:
-        rollout_mapper.mapper_group[0].insert_to_parallelism_info(
-            param_name=k,
-            dims_map=v | {"dp_shard_cp": 0},
-            name_to_hf=name_to_hf,
+        set_test_parallelism_info(
+            rollout_mapper.mapper_group[0],
+            k,
+            v | {"dp_shard_cp": 0},
+            test_param_pipeline_rank(
+                k,
+                rollout_parallelism_config.pp_size,
+                model.num_hidden_layers,
+            ),
         )
 
     local_shards_p = [
@@ -637,6 +693,7 @@ async def run_rollout_recv_from_policy(shm_name, shm_size, rank, trainable_param
         ROLLOUT_WORLD_SIZE,
         trainable_only=trainable_param_sync,
     )
+
     try:
         # Get NCCL UID from shared memory
         uid_array = np.ndarray((shm_size + 1,), dtype=np.int64, buffer=shm.buf)
@@ -655,8 +712,9 @@ async def run_rollout_recv_from_policy(shm_name, shm_size, rank, trainable_param
             {policy_name + "_" + rollout_name: comm_idx},
             trainable_param_sync,
         )
-        rollout.policy_to_rollout_recv_insts = await generate_send_recv_insts(
-            rollout.model, False, rank
+        recv_insts = await generate_send_recv_insts(rollout.model, False, rank)
+        rollout.api_client = types.SimpleNamespace(
+            post_rollout_shard_recv_insts=lambda _rank: recv_insts
         )
         rollout.weight_mapper.map_to_unsplited_weight_name = {}
         rollout.policy_to_rollout_unicast = types.MethodType(
@@ -674,7 +732,16 @@ async def run_rollout_recv_from_policy(shm_name, shm_size, rank, trainable_param
         rollout.inference_stream.synchronize()
 
         for k, v in rollout.operate_compatibale_map.items():
-            torch.allclose(v, rollout.ref_compatibale_map[k])
+            if command.trainable_only and k not in rollout.trainable_params:
+                expected = torch.zeros_like(v)
+            else:
+                expected = rollout.ref_compatibale_map[k].to(
+                    util.str2torch_dtype(rollout.config.train.transfer_dtype)
+                )
+            try:
+                torch.testing.assert_close(v, expected.to(v.dtype), rtol=0, atol=0)
+            except AssertionError as exc:
+                raise AssertionError(f"P2R mismatch for {k}") from exc
 
     finally:
         # Detach from shared memory
@@ -1369,7 +1436,7 @@ async def parallel_map_check():
         ("model.layers.9.post_attention_layernorm.weight", {}),
         ("model.layers.9.self_attn.k_proj.bias", {"tp": 0}),
         ("model.layers.9.self_attn.k_proj.weight", {"tp": 0}),
-        ("model.layers.9.self_attn.o_proj.weight", {"tp": 0}),
+        ("model.layers.9.self_attn.o_proj.weight", {"tp": 1}),
         ("model.layers.9.self_attn.q_proj.bias", {"tp": 0}),
         ("model.layers.9.self_attn.q_proj.weight", {"tp": 0}),
         ("model.layers.9.self_attn.v_proj.bias", {"tp": 0}),
@@ -1480,6 +1547,46 @@ async def parallel_map_check():
                 assert p_rank >= p_rank_max
                 if p_rank > p_rank_max:
                     p_rank_max = p_rank
+
+    send_group_by_transfer = {}
+    for policy_rank in range(p_world_size):
+        rank_insts = msgpack.unpackb(
+            await generator.get_send_insts_for_policy(policy_rank),
+            strict_map_key=False,
+        )
+        group_indices = [inst["sync_group_index"] for inst in rank_insts]
+        assert group_indices == sorted(group_indices)
+        for inst_group in rank_insts:
+            for param_insts in inst_group["param_instructions"]:
+                for inst in param_insts["instructions"]:
+                    transfer = (
+                        param_insts["param_name"],
+                        inst["policy_rank"],
+                        inst["rollout_rank"],
+                    )
+                    assert transfer not in send_group_by_transfer
+                    send_group_by_transfer[transfer] = inst_group["sync_group_index"]
+
+    recv_group_by_transfer = {}
+    for rollout_rank in range(r_world_size):
+        rank_insts = msgpack.unpackb(
+            await generator.get_recv_insts_for_rollout(rollout_rank),
+            strict_map_key=False,
+        )
+        group_indices = [inst["sync_group_index"] for inst in rank_insts]
+        assert group_indices == sorted(group_indices)
+        for inst_group in rank_insts:
+            for param_insts in inst_group["param_instructions"]:
+                for inst in param_insts["instructions"]:
+                    transfer = (
+                        param_insts["param_name"],
+                        inst["policy_rank"],
+                        inst["rollout_rank"],
+                    )
+                    assert transfer not in recv_group_by_transfer
+                    recv_group_by_transfer[transfer] = inst_group["sync_group_index"]
+
+    assert send_group_by_transfer == recv_group_by_transfer
 
 
 def run_sft_for_sequence_packing(fsdp, tp, cp):
@@ -2670,7 +2777,7 @@ async def main():
     )
     parser.add_argument(
         "--trainable_param_sync",
-        type=bool,
+        type=parse_bool_arg,
         required=False,
         default=False,
         help="If only trainable params are synced. If set, part of the params will be frozen.",

--- a/tests/run_test.sh
+++ b/tests/run_test.sh
@@ -155,7 +155,7 @@ run python tests/test_put_rollouts.py
 run python tests/test_trajectory_iteration.py
 run python tests/test_gym_example.py
 # Pytest-style CPU suites; install pytest in case the image lacks it.
-run /bin/bash -c "python -m pip install --quiet pytest && python -m pytest -q tests/test_weight_sync.py tests/test_checkpoint.py tests/test_ranked_rollout_end_and_wst_fence.py tests/test_rollout_mesh_guard.py tests/test_terminal_checkpoint_trainer_hooks.py tests/test_terminal_drain_protocol.py tests/test_training_complete_checkpoint.py"
+run /bin/bash -c "python -m pip install --quiet pytest && python -m pytest -q tests/test_weight_sync.py tests/test_checkpoint.py tests/test_ranked_rollout_end_and_wst_fence.py tests/test_rollout_mesh_guard.py tests/test_terminal_checkpoint_trainer_hooks.py tests/test_terminal_drain_protocol.py tests/test_training_complete_checkpoint.py tests/test_p2r_grouping.py tests/test_tensor_packing.py"
 run python -m unittest -v tests.contracts.test_trainer_metrics_contract
 run python -m unittest -v tests.contracts.test_config_routing_contract
 run python -m unittest -v tests.contracts.test_model_registry_contract

--- a/tests/test_hf_models_tp.py
+++ b/tests/test_hf_models_tp.py
@@ -13,8 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
 import copy
+import gc
+import os
 import traceback
 from datetime import timedelta
 
@@ -227,6 +228,8 @@ class TestHFModelTP(unittest.TestCase):
                 }
                 model_class = cosmos_hf_model.model_class
                 del cosmos_hf_model
+                del cosmos_model_list
+                gc.collect()
                 torch.cuda.empty_cache()
 
                 # Load hf model

--- a/tests/test_p2r_grouping.py
+++ b/tests/test_p2r_grouping.py
@@ -1,0 +1,95 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+# All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Correctness tests for globally aligned P2R NCCL grouping."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from cosmos_rl.policy.config import Config
+from cosmos_rl.utils import constant
+from cosmos_rl.utils.parallelism_map import (
+    WeightSyncInstructionsGroup,
+    build_p2r_sync_group_index,
+    iter_p2r_sync_rounds,
+)
+
+
+def _instruction(group_index: int | None) -> WeightSyncInstructionsGroup:
+    return WeightSyncInstructionsGroup([], sync_group_index=group_index)
+
+
+def _round_indices(instructions, groups_per_round: int) -> list[list[int]]:
+    return [
+        [instruction.sync_group_index for instruction in sync_round]
+        for sync_round in iter_p2r_sync_rounds(instructions, groups_per_round)
+    ]
+
+
+def test_global_group_index_keeps_joined_parameters_together() -> None:
+    group_index = build_p2r_sync_group_index(
+        [["a", "k_proj", "q_proj", "z"], ["a", "z"]],
+        [["a", "k_proj", "q_proj", "z"]],
+        [("k_proj", "q_proj")],
+    )
+
+    assert group_index == {"a": 0, "z": 1, "k_proj": 2, "q_proj": 2}
+
+
+def test_rounds_use_global_indices_instead_of_local_counts() -> None:
+    # This is the shape of the #307 failure: a receiver sees an intervening
+    # group that a particular policy rank does not. Local batches of two put
+    # group 2 in different NCCL calls; global rounds keep it in round 1.
+    policy_rank = [_instruction(index) for index in (0, 2, 3)]
+    rollout_rank = [_instruction(index) for index in (0, 1, 2, 3)]
+
+    assert _round_indices(policy_rank, 2) == [[0], [2, 3]]
+    assert _round_indices(rollout_rank, 2) == [[0, 1], [2, 3]]
+
+
+def test_disabled_grouping_preserves_legacy_instructions() -> None:
+    instructions = [_instruction(None), _instruction(None)]
+
+    assert list(iter_p2r_sync_rounds(instructions, 0)) == [
+        [instructions[0]],
+        [instructions[1]],
+    ]
+
+
+def test_enabled_grouping_rejects_missing_or_reordered_metadata() -> None:
+    with pytest.raises(RuntimeError, match="requires controller-assigned"):
+        list(iter_p2r_sync_rounds([_instruction(None)], 2))
+
+    with pytest.raises(RuntimeError, match="monotonically"):
+        list(iter_p2r_sync_rounds([_instruction(2), _instruction(1)], 2))
+
+
+def test_p2r_group_size_uses_config_with_legacy_env_override(monkeypatch) -> None:
+    config = SimpleNamespace(train=SimpleNamespace(p2r_sync_groups_per_round=4))
+    monkeypatch.delenv("COSMOS_P2R_NCCL_GROUP_SIZE", raising=False)
+    assert constant.get_p2r_nccl_group_size(config) == 4
+
+    monkeypatch.setenv("COSMOS_P2R_NCCL_GROUP_SIZE", "8")
+    assert constant.get_p2r_nccl_group_size(config) == 8
+
+
+def test_batching_knobs_are_config_file_fields() -> None:
+    defaults = Config()
+    assert defaults.train.p2r_sync_groups_per_round == 0
+    assert defaults.rollout.r2r_sync_pack_tensors is False
+    assert defaults.rollout.r2r_sync_bucket_size_bytes == 512 * 1024 * 1024
+
+    configured = Config(
+        train={"p2r_sync_groups_per_round": 4},
+        rollout={
+            "r2r_sync_pack_tensors": True,
+            "r2r_sync_bucket_size_bytes": 256 * 1024 * 1024,
+        },
+    )
+    assert configured.train.p2r_sync_groups_per_round == 4
+    assert configured.rollout.r2r_sync_pack_tensors is True
+    assert configured.rollout.r2r_sync_bucket_size_bytes == 256 * 1024 * 1024

--- a/tests/test_policy_to_rollout.py
+++ b/tests/test_policy_to_rollout.py
@@ -29,7 +29,16 @@ from cosmos_rl.utils.pynccl import (
 
 
 class TestPolicyToRollout(unittest.TestCase):
-    def policy_to_rollout_wieght_sync(self, trainable_param_sync: bool = False):
+    def policy_to_rollout_wieght_sync(
+        self,
+        trainable_param_sync: bool = False,
+        *,
+        p2r_groups_per_round: int = 0,
+        policy_tp_size: int = 2,
+        policy_pp_size: int = 1,
+        rollout_tp_size: int = 4,
+        rollout_dp_shard_size: int = 1,
+    ):
         """Test NCCL communication between multiple ranks using torchrun."""
         cur_dir = os.path.dirname(os.path.abspath(__file__))
 
@@ -84,6 +93,16 @@ class TestPolicyToRollout(unittest.TestCase):
             ]
             policy_env = dict(os.environ)
             policy_env["CUDA_VISIBLE_DEVICES"] = "0,1,2,3"
+            policy_env.pop("COSMOS_P2R_NCCL_GROUP_SIZE", None)
+            policy_env.update(
+                {
+                    "COSMOS_TEST_P2R_GROUPS_PER_ROUND": str(p2r_groups_per_round),
+                    "COSMOS_TEST_P2R_POLICY_TP_SIZE": str(policy_tp_size),
+                    "COSMOS_TEST_P2R_POLICY_PP_SIZE": str(policy_pp_size),
+                    "COSMOS_TEST_P2R_ROLLOUT_TP_SIZE": str(rollout_tp_size),
+                    "COSMOS_TEST_P2R_ROLLOUT_DP_SHARD_SIZE": str(rollout_dp_shard_size),
+                }
+            )
             # Start the process
             policy_process = subprocess.Popen(
                 policy_cmd,
@@ -93,6 +112,16 @@ class TestPolicyToRollout(unittest.TestCase):
             )
             rollout_env = dict(os.environ)
             rollout_env["CUDA_VISIBLE_DEVICES"] = "4,5,6,7"
+            rollout_env.pop("COSMOS_P2R_NCCL_GROUP_SIZE", None)
+            rollout_env.update(
+                {
+                    "COSMOS_TEST_P2R_GROUPS_PER_ROUND": str(p2r_groups_per_round),
+                    "COSMOS_TEST_P2R_POLICY_TP_SIZE": str(policy_tp_size),
+                    "COSMOS_TEST_P2R_POLICY_PP_SIZE": str(policy_pp_size),
+                    "COSMOS_TEST_P2R_ROLLOUT_TP_SIZE": str(rollout_tp_size),
+                    "COSMOS_TEST_P2R_ROLLOUT_DP_SHARD_SIZE": str(rollout_dp_shard_size),
+                }
+            )
             rollout_process = subprocess.Popen(
                 rollout_cmd,
                 stdout=sys.stderr,
@@ -120,6 +149,31 @@ class TestPolicyToRollout(unittest.TestCase):
 
     def test_policy_to_rollout_wieght_sync_trainable_params(self):
         self.policy_to_rollout_wieght_sync(trainable_param_sync=True)
+
+    def test_policy_to_rollout_grouped_with_pp2_fsdp2(self):
+        self.policy_to_rollout_wieght_sync(
+            p2r_groups_per_round=4,
+            policy_tp_size=1,
+            policy_pp_size=2,
+            rollout_tp_size=2,
+        )
+
+    def test_policy_to_rollout_grouped_with_tp2_fsdp2(self):
+        self.policy_to_rollout_wieght_sync(
+            p2r_groups_per_round=4,
+            policy_tp_size=2,
+            policy_pp_size=1,
+            rollout_tp_size=4,
+        )
+
+    def test_policy_to_rollout_grouped_with_policy_and_rollout_tp2_fsdp2(self):
+        self.policy_to_rollout_wieght_sync(
+            p2r_groups_per_round=4,
+            policy_tp_size=2,
+            policy_pp_size=1,
+            rollout_tp_size=2,
+            rollout_dp_shard_size=2,
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_tensor_packing.py
+++ b/tests/test_tensor_packing.py
@@ -1,0 +1,268 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+# All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from contextlib import nullcontext
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import torch
+
+from cosmos_rl.dispatcher.command import RolloutToRolloutBroadcastCommand
+from cosmos_rl.rollout.worker.rollout_control import (
+    DisaggregatedRolloutControlWorker,
+)
+from cosmos_rl.rollout.worker import weight_sync
+from cosmos_rl.utils.tensor_packing import (
+    iter_tensor_byte_buckets,
+    pack_tensors_into_buffer,
+    unpack_tensors_from_buffer,
+)
+
+
+def test_byte_buckets_preserve_order_and_isolate_oversized_tensors() -> None:
+    tensors = [
+        torch.empty(2, dtype=torch.float32),
+        torch.empty(3, dtype=torch.float32),
+        torch.empty(5, dtype=torch.float32),
+        torch.empty(1, dtype=torch.float32),
+    ]
+
+    buckets = list(iter_tensor_byte_buckets(tensors, 16))
+
+    assert buckets == [[tensors[0]], [tensors[1]], [tensors[2]], [tensors[3]]]
+
+
+def test_pack_and_unpack_mixed_dtypes_and_scalar() -> None:
+    source = [
+        torch.tensor([1.5, -2.0], dtype=torch.float32),
+        torch.tensor([3, 4, 5], dtype=torch.int16),
+        torch.tensor(7, dtype=torch.int64),
+    ]
+    destination = [torch.zeros_like(tensor) for tensor in source]
+    buffer = torch.empty(64, dtype=torch.uint8)
+
+    payload = pack_tensors_into_buffer(source, buffer)
+    unpack_tensors_from_buffer(payload, destination)
+
+    assert len(payload) == sum(t.numel() * t.element_size() for t in source)
+    for actual, expected in zip(destination, source):
+        torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+
+
+class _StateModel:
+    def __init__(self, tensors: dict[str, torch.Tensor]) -> None:
+        self.tensors = tensors
+
+    def state_dict(self) -> dict[str, torch.Tensor]:
+        return self.tensors
+
+
+class _WeightState:
+    def __init__(self, synced: bool) -> None:
+        self.synced = synced
+
+    def weight_synced(self) -> bool:
+        return self.synced
+
+    def set_weight_synced(self) -> None:
+        self.synced = True
+
+
+def _r2r_worker(rank: int, tensors: dict[str, torch.Tensor], *, pack: bool):
+    return SimpleNamespace(
+        rank_in_rollout_repicas=rank,
+        replica_name_to_rank={"rollout-0": 0},
+        global_commnicator_idex=1,
+        config=SimpleNamespace(
+            rollout=SimpleNamespace(
+                r2r_sync_pack_tensors=pack,
+                r2r_sync_bucket_size_bytes=64,
+            )
+        ),
+        rollout=SimpleNamespace(
+            get_underlying_model=lambda: _StateModel(tensors),
+        ),
+    )
+
+
+def test_production_r2r_packing_round_trips_and_reduces_collectives() -> None:
+    source_tensors = {
+        "float": torch.tensor([1.0, 2.0, 3.0, 4.0]),
+        "bf16": torch.arange(8, dtype=torch.bfloat16),
+        "noncontiguous": torch.arange(6, dtype=torch.float32).reshape(2, 3).t(),
+        "scalar": torch.tensor(17, dtype=torch.int64),
+    }
+    destination_tensors = {
+        name: torch.zeros_like(tensor) for name, tensor in source_tensors.items()
+    }
+    source = _r2r_worker(0, source_tensors, pack=True)
+    destination = _r2r_worker(1, destination_tensors, pack=True)
+    payloads: list[torch.Tensor] = []
+    receiving = False
+    receive_index = 0
+
+    def fake_broadcast(tensor, _src_rank, _comm_idx):
+        nonlocal receive_index
+        if not receiving:
+            payloads.append(tensor.clone())
+        else:
+            tensor.copy_(payloads[receive_index])
+            receive_index += 1
+
+    with (
+        patch.object(torch.cuda, "stream", side_effect=lambda _stream: nullcontext()),
+        patch.object(weight_sync, "nccl_broadcast", side_effect=fake_broadcast),
+        patch.object(weight_sync, "nccl_group_start"),
+        patch.object(weight_sync, "nccl_group_end"),
+    ):
+        weight_sync.do_nccl_broadcast_grouped(source, "rollout-0", None)
+        receiving = True
+        weight_sync.do_nccl_broadcast_grouped(destination, "rollout-0", None)
+
+    assert len(payloads) == 1
+    assert len(payloads) < len(source_tensors)
+    for name, expected in source_tensors.items():
+        torch.testing.assert_close(destination_tensors[name], expected, rtol=0, atol=0)
+
+
+def test_r2r_packing_is_disabled_by_default() -> None:
+    tensors = {"a": torch.ones(2), "b": torch.ones(2)}
+    worker = _r2r_worker(0, tensors, pack=False)
+
+    with (
+        patch.object(torch.cuda, "stream", side_effect=lambda _stream: nullcontext()),
+        patch.object(weight_sync, "nccl_broadcast") as broadcast,
+        patch.object(weight_sync, "nccl_group_start") as group_start,
+        patch.object(weight_sync, "nccl_group_end") as group_end,
+    ):
+        weight_sync.do_nccl_broadcast_grouped(worker, "rollout-0", None)
+
+    assert broadcast.call_count == len(tensors)
+    group_start.assert_called_once_with(1)
+    group_end.assert_called_once_with(1)
+    assert not hasattr(worker, "_r2r_sync_packed_buffer")
+
+
+def test_selected_r2r_default_off_preserves_per_tensor_broadcasts() -> None:
+    tensors = {"a": torch.ones(2), "b": torch.ones(2)}
+    worker = _r2r_worker(0, tensors, pack=False)
+
+    with (
+        patch.object(torch.cuda, "stream", side_effect=lambda _stream: nullcontext()),
+        patch.object(weight_sync, "nccl_broadcast") as broadcast,
+        patch.object(weight_sync, "nccl_group_start") as group_start,
+        patch.object(weight_sync, "nccl_group_end") as group_end,
+    ):
+        weight_sync.do_nccl_broadcast_tensors(
+            worker,
+            list(tensors.values()),
+            src_rank=0,
+            comm_idx=1,
+            stream=None,
+            group_unpacked=False,
+        )
+
+    assert broadcast.call_count == len(tensors)
+    group_start.assert_not_called()
+    group_end.assert_not_called()
+    assert not hasattr(worker, "_r2r_sync_packed_buffer")
+
+
+class _FakeDTensor:
+    def __init__(self, local: torch.Tensor) -> None:
+        self.local = local
+
+    def to_local(self) -> torch.Tensor:
+        return self.local
+
+
+def test_r2r_broadcasts_local_fsdp_shards() -> None:
+    local_shards = [torch.ones(2), torch.ones(3)]
+    fsdp_state = [_FakeDTensor(tensor) for tensor in local_shards]
+
+    for pack in (False, True):
+        worker = _r2r_worker(0, {}, pack=pack)
+        with (
+            patch.object(weight_sync, "DTensor", _FakeDTensor),
+            patch.object(
+                torch.cuda, "stream", side_effect=lambda _stream: nullcontext()
+            ),
+            patch.object(weight_sync, "nccl_broadcast") as broadcast,
+        ):
+            count, nbytes = weight_sync.do_nccl_broadcast_tensors(
+                worker,
+                fsdp_state,
+                src_rank=0,
+                comm_idx=1,
+                stream=None,
+                group_unpacked=False,
+            )
+
+        assert count == len(local_shards)
+        assert nbytes == sum(tensor.nbytes for tensor in local_shards)
+        if pack:
+            assert broadcast.call_count == 1
+            assert broadcast.call_args.args[0].numel() == nbytes
+        else:
+            assert all(
+                call.args[0] is shard
+                for call, shard in zip(broadcast.call_args_list, local_shards)
+            )
+
+
+def test_default_sync_r2r_route_packs_only_trainable_tensors() -> None:
+    tensors = {
+        "trainable_a": torch.tensor([1.0, 2.0]),
+        "frozen": torch.tensor([3.0, 4.0]),
+        "trainable_b": torch.tensor([5.0, 6.0]),
+    }
+    worker = SimpleNamespace(
+        replica_name="rollout-0",
+        state=_WeightState(synced=True),
+        config=SimpleNamespace(
+            rollout=SimpleNamespace(
+                async_r2r_sync="disabled",
+                broadcast_all_params=False,
+                r2r_sync_pack_tensors=True,
+                r2r_sync_bucket_size_bytes=64,
+            )
+        ),
+        rank_in_rollout_repicas=0,
+        global_commnicator_idex=1,
+        replica_name_to_rank={"rollout-0": 0, "rollout-1": 1},
+        rollout=SimpleNamespace(model_param_map=lambda _mapper: tensors),
+        weight_mapper=object(),
+        trainable_params={"trainable_a", "trainable_b"},
+        prepare_trainable_params=lambda: None,
+        inference_stream=None,
+        non_trainable_params_received=True,
+        current_weight_version=-1,
+    )
+    command = RolloutToRolloutBroadcastCommand(
+        src_replica_name="rollout-0",
+        dst_replica_names=["rollout-0", "rollout-1"],
+        weight_step=None,
+        total_steps=None,
+        trainable_only=True,
+    )
+
+    with (
+        patch.object(torch.cuda, "stream", side_effect=lambda _stream: nullcontext()),
+        patch.object(weight_sync, "nccl_broadcast") as broadcast,
+        patch.object(weight_sync, "nccl_group_start") as group_start,
+        patch.object(weight_sync, "nccl_group_end") as group_end,
+    ):
+        DisaggregatedRolloutControlWorker.broadcast_to_all_rollout_replica(
+            worker, command
+        )
+
+    assert broadcast.call_count == 1
+    payload = broadcast.call_args.args[0]
+    assert payload.dtype == torch.uint8
+    assert payload.numel() == 2 * tensors["trainable_a"].nbytes
+    group_start.assert_not_called()
+    group_end.assert_not_called()
+    assert worker.r2r_synced_trainable_params_cnt == 2


### PR DESCRIPTION
## Summary

- make P2R NCCL batching safe for mixed PP/FSDP topologies by assigning each
  parameter group a deterministic controller-side global ordinal and deriving
  matching rounds on every policy sender and rollout receiver
- add opt-in R2R byte packing with deterministic byte-bounded buckets, direct
  oversized transfers, mixed-dtype/scalar support, non-contiguous copyback, and
  a reusable `uint8` scratch buffer
- route the default synchronous, trainable-aware R2R path through the same
  packing helper, while preserving its legacy per-tensor behavior when packing
  is disabled
- expose both paths through config-file knobs while keeping existing behavior
  as the default
- strengthen the policy-to-rollout integration oracle and cover policy
  PP2+FSDP2 to rollout TP2, policy TP2+FSDP2 to rollout TP4, and policy
  TP2+FSDP2 to rollout TP2+FSDP2 with grouping enabled
- broadcast the local shard of rollout-side FSDP2 `DTensor` state entries in
  both packed and unpacked R2R paths
- release the owning TP model list before loading the full HF comparison model,
  avoiding an independently reproducible 80 GB GPU OOM in full CI

## Configuration

Both optimizations require explicit enablement:

```toml
[train]
p2r_sync_groups_per_round = 4

[rollout]
r2r_sync_pack_tensors = true
r2r_sync_bucket_size_bytes = 536870912 # 512 MiB default when packing is enabled
```

`p2r_sync_groups_per_round = 0` and `r2r_sync_pack_tensors = false` preserve
the existing behavior. An explicitly set legacy
`COSMOS_P2R_NCCL_GROUP_SIZE` continues to override the P2R config value.

## Why global P2R rounds

The old grouping logic used a local parameter-group count. With PP and FSDP, a
rollout rank can receive an intervening shard group that a policy rank does not
send, shifting later local boundaries and making the NCCL groups disagree.

The controller now serializes one global ordinal per parameter group. Each rank
groups locally relevant operations by `ordinal // groups_per_round`, so absent
local groups no longer shift a boundary. Enabled mode rejects legacy metadata
without the ordinal instead of silently using the unsafe behavior.

## Performance

Measured on one 8xH100 node with a constructed Qwen2.5-7B-equivalent inventory:
7,615,616,512 parameters, 339 tensors, and 15,231,233,024 BF16 bytes globally.
Every destination tensor was checked after each transfer.

| Path | Existing path | Opt-in batching | Improvement |
|---|---:|---:|---:|
| P2R, policy PP2+FSDP2 to rollout TP2 | 668.19 ms | 276.15 ms, 4 groups/round | **2.42x** |
| R2R default sync, trainable-only route | 439.90 ms | 54.91 ms, 512 MiB buckets | **8.01x** |

P2R values are the median of five warm slowest-rank samples, excluding the cold
first pass (Slurm `2143523`). Each rollout rank received 7,263.01 MiB through
452 point-to-point receives.

The final R2R values are medians from the real
`broadcast_to_all_rollout_replica` default synchronous path (Slurm `2147000`).
The benchmark transferred 338 trainable tensors and verified all destinations
after every transfer; one frozen tensor was deliberately excluded and verified
unchanged on all seven receivers. The reusable packed scratch buffer was
524,852,224 bytes. An earlier full-state bucket sweep (`2143117`) showed 64 and
128 MiB slower than its grouped baseline, 256 MiB 3.4% slower, and 512 MiB
materially faster, which is why the configured default is 512 MiB.

## Validation

- P2R legacy plus config-enabled PP2+FSDP2 correctness on 8xH100: `2143360`
- config-enabled policy TP2+FSDP2 to rollout TP4 correctness on 8xH100:
  `2147906`
- config-enabled policy TP2+FSDP2 to rollout TP2+FSDP2 correctness on 8xH100:
  `2148040`
- real FSDP2 R2R across two four-rank rollout replicas, exact local-shard
  checks for unpacked and packed paths: `2148085`
- focused packing/grouping regressions: `2148118`, 13 passed
- realistic P2R performance and exact tensor checks: `2143523`
- production default-sync R2R routing, trainable filtering, packing performance,
  and exact tensor checks on 8xH100: `2147000`
- full repository CI on an exclusive 8xH100 node: `2146991`, exit 0 in 1:22:03,
  all tests passed; two UCXX suites skipped because they ran nothing
- final full repository CI after rollout-side FSDP2 coverage and the R2R
  `DTensor` fix: `2148134`, exit 0 in 1:23:42
- post-#737 rebase validation: `2151409`, exit 0 in 4:26; 25 focused
  P2P/P2R/R2R tests, both policy-to-policy integration cases, and the rollout
  TP2+FSDP2 P2R exact-value case passed
- local feature/regression batch: 160 tests and 12 subtests passed
- repository-pinned Ruff lint and format checks passed for all 13 modified
  Python files; shell syntax and `git diff --check` passed

The first diagnostic full run exposed an unrelated TP-test ownership bug. A
fresh exclusive-node reproduction (`2146278`) failed at the same Qwen2.5-VL
float32 case with the same 73.76 GiB allocated. Releasing the owning model list
and collecting cycles passed every Qwen2.5-VL, Qwen3-VL, and Phi-4 case
standalone (`2146639`) and in the final full-CI run.
