### PR TITLE
fix(rollout): stop an unseeded replica from broadcasting weights

### DIFF
--- a/cosmos_rl/policy/worker/rl_worker.py
+++ b/cosmos_rl/policy/worker/rl_worker.py
@@ -105,6 +105,40 @@ def _bind_p2p_nccl_hook(
     )
 
 
+class P2RDrainAborted(RuntimeError):
+    """The P2R stream never drained and every communicator was aborted."""
+
+
+def _drain_or_fail(
+    stream, timeout_s: float, context: str, src: str, dst: str, weight_step
+) -> None:
+    """Bounded-drain the P2R stream, and fail the replica if it had to abort.
+
+    ``bounded_drain_or_abort`` returns False only after calling
+    ``nccl_abort_all``: the peer vanished mid-collective and every communicator
+    on this replica is gone.  Ignoring that -- which this call site used to do
+    -- reports the weight sync as successful and returns to the main loop with
+    nothing left to talk to.  The policy then sits idle and never unregisters,
+    so the controller does not see a dead policy, its
+    COSMOS_SHUTDOWN_ON_NO_POLICY_REPLICAS escalation never fires, and the job
+    holds its nodes until the wall clock (job 2148080, silent for 16 minutes
+    after the abort while seven rollouts had already exited).
+
+    Raising instead takes the path the P2R send failure already takes, which
+    unregisters on the way down and exits non-zero -- a failed weight sync must
+    not look like a successful run to the scheduler.
+    """
+    if bounded_drain_or_abort(stream, timeout_s, context):
+        return
+    raise P2RDrainAborted(
+        f"[Policy] Weight sync to rollout {dst} at step {weight_step} never "
+        f"drained: in-flight GPU work on {src} exceeded {timeout_s:.0f}s and "
+        "every NCCL communicator was aborted, so this replica cannot continue. "
+        "The destination almost certainly failed its P2R receive; check its log "
+        "for a cancelled R2R round."
+    )
+
+
 class RLPolicyWorker(PolicyWorkerBase):
     """
     RL Policy Worker. This worker is responsible for the training of the RL.
@@ -578,6 +612,31 @@ class RLPolicyWorker(PolicyWorkerBase):
                                         view.numel() * view.element_size()
                                     )
                         grouped_send(grouped_send_ops)
+                except Exception as e:
+                    # Say what happened before the job dies.  Nothing here
+                    # recovers a P2R failure -- the handler deliberately
+                    # re-raises -- but the bare NCCL error that reaches the
+                    # launcher names neither the peer nor the weight step, and
+                    # the operator is left with "asynchronous error 6" and no
+                    # thread to pull.
+                    #
+                    # The usual cause is a failed receive on the destination
+                    # rollout, which this side has no direct way to learn:
+                    # NCCL leaves the posted sends pending rather than failing
+                    # them, so what surfaces here is the drain timeout firing
+                    # and tearing the communicator out from under the send.
+                    # Job 2147521 measured the interval at 120s whether or not
+                    # the destination aborts the pair on its way out.
+                    logger.error(
+                        "[Policy] Weight sync to rollout %s at step %s failed "
+                        "during the P2R send: %s. The job will stop. If the "
+                        "destination logged a failed P2R receive, that is the "
+                        "cause and this is its consequence.",
+                        command.dst_replica_name,
+                        command.weight_step,
+                        e,
+                    )
+                    raise
                 finally:
                     if self.config.policy.lora is not None:
                         # Always attempt to unmerge to restore training state
@@ -592,10 +651,13 @@ class RLPolicyWorker(PolicyWorkerBase):
                             "Trainable synced params count must match at each weight sync."
                         )
 
-        bounded_drain_or_abort(
+        _drain_or_fail(
             self.train_stream,
             COSMOS_P2R_STREAM_DRAIN_TIMEOUT_S,
             f"policy_P2R[{self.replica_name}@step{command.weight_step}]",
+            self.replica_name,
+            command.dst_replica_name,
+            command.weight_step,
         )
         time_eclapsed = time.time() - st
         logger.debug(

--- a/cosmos_rl/rollout/worker/weight_sync.py
+++ b/cosmos_rl/rollout/worker/weight_sync.py
@@ -115,6 +115,53 @@ class AsyncR2RSyncMode(Enum):
 _R2R_BARRIER_TIMEOUT_S = 120
 _SYNC_NOOP_LOG_INTERVAL = 50
 
+# Payload published on the barrier's go-channel to cancel a round, and the
+# companion key a late subscriber reads instead.  Both are needed: pub/sub only
+# reaches workers that have already subscribed, and the key only reaches
+# workers that look at it.
+_R2R_ABORT_SIGNAL = "abort"
+
+# Marker prefix on the stored abort reason.  The check has to be "this value is
+# an abort record", not "this key holds something": the abort key shares a
+# namespace with the barrier counter, and a client that answers a GET for a key
+# it was never given -- a loose test double, a misconfigured proxy -- would
+# otherwise cancel every healthy round.
+_R2R_ABORT_MARKER = "cosmos-r2r-abort:"
+
+
+class R2RAborted(RuntimeError):
+    """The R2R round was cancelled before any NCCL work was launched.
+
+    Raised on every participant, including the ones that were ready: the round
+    did not happen.  It is terminal for the job.
+
+    Nothing recovers a cancelled round.  Waiting for the next
+    ``sync_weight_interval`` does not: the rollouts keep the pre-cancellation
+    weights, so every prompt exceeds ``allowed_outdated_steps`` and is
+    rejected, no rollouts are reported, and the trainer never reaches the next
+    sync boundary -- the round that would break the cycle is gated behind the
+    thing the cancelled round stopped.  On Slurm job 2142899 the last
+    completed sync was step 6; the controller then logged "Soft throttle still
+    engaged" 67 times, out to 195s, until the job was killed.
+
+    Re-issuing the round does not either.  Retrying the same step needs its own
+    rendezvous, because these Redis keys are step-scoped and the barrier
+    counter is a monotonic INCR: on job 2143533 a second attempt kept
+    incrementing the first one's counter, every arriver read a count already
+    past the world size and declared itself the last worker -- 8/7 through 12/7
+    inside one second, five workers each publishing its own go signal -- and
+    the barrier stopped synchronising anything.  Rotating to a different source
+    does not work either: the P2R protocol negotiates shard instructions per
+    target, so a replica that has never been one starts from nothing.
+
+    So the rollout workers are failed loudly instead, at the point where the
+    cause is still attributable, rather than idling on a round that will never
+    complete.  Note this does not by itself release the allocation: the policy
+    hangs in its own teardown and never unregisters, so the controller's
+    dead-policy escalation does not fire.  That is pre-existing (job 2142899
+    behaves the same way without any of this) and is not addressed here.
+    """
+
 
 # ---------------------------------------------------------------------------
 # Config helpers
@@ -402,6 +449,11 @@ class WeightSyncThread:
         # transfers are superseded before they are ever adopted.
         self._max_qdepth = 0
         self._executed = 0
+        # Outcome of the most recent P2R, as opposed to ``_task_failed`` which
+        # latches any failure until a mesh rebuild clears it.  The R2R source
+        # guard needs "did the P2R I am about to broadcast actually land",
+        # which a sticky flag cannot answer.
+        self._p2r_failed = False
         self._thread = threading.Thread(
             target=self._run,
             daemon=True,
@@ -613,6 +665,18 @@ class WeightSyncThread:
                     self._execute_p2r(command)
                 elif cmd_type == "r2r":
                     self._execute_r2r(command)
+            except R2RAborted as exc:
+                # A cancelled round ends the job.  Continuing does not work:
+                # the rollouts hold weights the trainer has moved past, every
+                # prompt is rejected for staleness, nothing is reported, and
+                # the trainer never reaches the next sync boundary -- so the
+                # job stalls silently while holding its allocation.  Fail here
+                # instead, naming the source and the reason.
+                logger.error(
+                    "[WeightSyncThread] R2R round cancelled, failing the job: %s",
+                    exc,
+                )
+                _fail_the_job(self._worker)
             except Exception:
                 self._task_failed = True
                 logger.exception(
@@ -627,7 +691,12 @@ class WeightSyncThread:
     def _execute_p2r(self, command) -> None:
         """Run the P2R receive on the WST's CUDA stream."""
         t0 = time.monotonic()
-        self._worker._execute_p2r_recv(command, self._stream)
+        try:
+            self._worker._execute_p2r_recv(command, self._stream)
+        except BaseException:
+            self._p2r_failed = True
+            raise
+        self._p2r_failed = False
 
         self._last_event = torch.cuda.Event()
         self._last_event.record(self._stream)
@@ -643,6 +712,43 @@ class WeightSyncThread:
             self._queue.qsize(),
             self._executed,
         )
+
+    def _assert_seeded_before_broadcast(self, command, weight_step) -> None:
+        """Cancel the round unless this replica can legitimately be the source.
+
+        Only the source can tell: the destinations have nothing to compare
+        against, and the controller does not learn whether a P2R succeeded.
+        Cancelling here -- before the barrier and before any NCCL call -- is
+        what keeps the peers from paying the barrier and broadcast timeouts.
+        """
+        worker = self._worker
+        if getattr(worker, "replica_name", None) != getattr(
+            command, "src_replica_name", None
+        ):
+            return
+
+        # Never seeded: no P2R and no earlier R2R has landed, so the buffer
+        # still holds whatever the engine loaded at startup.
+        never_seeded = getattr(worker, "_buffer_version", 0) <= 0
+        # Seeded once, but the P2R staging *this* round threw.  Broadcasting
+        # now would hand out stale weights under the new step number.
+        stale = getattr(self, "_p2r_failed", False)
+        if not (never_seeded or stale):
+            return
+
+        reason = (
+            f"rollout {worker.replica_name} was selected as the R2R source for "
+            f"step {weight_step} but its own weights are not valid ("
+            + (
+                "no weight sync has ever completed"
+                if never_seeded
+                else "the P2R staging this round failed"
+            )
+            + "); cancelling the round rather than broadcasting stale or "
+            "uninitialised weights to every rollout replica"
+        )
+        abort_r2r_round(worker, weight_step, reason)
+        raise R2RAborted(reason)
 
     def _execute_r2r(self, command) -> None:
         """Redis barrier + grouped NCCL broadcast on buffer_model.
@@ -661,11 +767,32 @@ class WeightSyncThread:
             worker.data_packer.flush_pending_sends()
 
         weight_step = command.weight_step
+
+        # Refuse to broadcast weights this replica does not have.
+        #
+        # The controller picks the R2R source from
+        # ``weights_loaded_in_view_of_command``, which is set when the P2R is
+        # *published* and never cleared on failure, so a source whose P2R threw
+        # is still chosen.  ``_run`` turns that exception into a log line and a
+        # flag and then runs the next queued command -- the R2R -- so without
+        # this check the source broadcasts an unseeded buffer.  Every
+        # destination would accept it, set the sticky ``weight_synced`` bit, and
+        # start generating against base weights while reporting them as the
+        # current version.  Nothing raises; the wrong weights simply train.
         # Use the controller's authoritative recipient set for this round as the
         # barrier participant count so it stays in lockstep as replicas finish.
         expected_world_size = len(getattr(command, "dst_replica_names", None) or [])
+
+        # Only meaningful when weights actually leave this replica.  A
+        # single-member round broadcasts nothing (see the branch below), so
+        # there is no peer to protect and nothing to cancel.
+        if expected_world_size > 1:
+            self._assert_seeded_before_broadcast(command, weight_step)
+
         if expected_world_size > 1 and not r2r_barrier(
-            worker, weight_step, expected_world_size=expected_world_size
+            worker,
+            weight_step,
+            expected_world_size=expected_world_size,
         ):
             logger.info(
                 "[WeightSyncThread] R2R cancelled during teardown (step=%s)",
@@ -798,8 +925,95 @@ def setup_redis_barrier(worker) -> None:
     )
 
 
+def _read_abort_reason(r2r_redis, abort_key: str, weight_step: int):
+    """Return this round's cancellation reason, or None if it was not cancelled.
+
+    Only a value carrying :data:`_R2R_ABORT_MARKER` counts.  Anything else --
+    including whatever a client returns for a key that was never set -- is not
+    an abort record and must not cancel the round.
+    """
+    try:
+        raw = r2r_redis.get(abort_key)
+    except Exception:
+        return None
+    if isinstance(raw, bytes):
+        raw = raw.decode("utf-8", "replace")
+    if not isinstance(raw, str) or not raw.startswith(_R2R_ABORT_MARKER):
+        return None
+    reason = raw[len(_R2R_ABORT_MARKER) :]
+    return reason or f"R2R round for step {weight_step} was cancelled by its source"
+
+
+def _round_keys(prefix: str, weight_step: int) -> tuple:
+    """Barrier counter, go channel and abort marker for one round.
+
+    One round per step: a cancelled round ends the job rather than being
+    retried, so ``weight_step`` is a sufficient round identity and these are
+    the key names the fleet has always used.
+    """
+    return (
+        f"{prefix}:barrier:{weight_step}",
+        f"{prefix}:go:{weight_step}",
+        f"{prefix}:abort:{weight_step}",
+    )
+
+
+def _fail_the_job(worker) -> None:
+    """Bring the worker down after a cancelled round.
+
+    Uses the same signals as the ordinary teardown path
+    (``rollout_control.handle_shutdown``) rather than raising out of the
+    weight-sync thread, whose exceptions its own run loop catches -- that would
+    leave the worker alive but permanently unable to sync.
+    """
+    for attr in ("shutdown_signal", "shutdown_mp_signal"):
+        signal = getattr(worker, attr, None)
+        if signal is not None and not signal.is_set():
+            signal.set()
+
+
+def abort_r2r_round(worker, weight_step: int, reason: str) -> bool:
+    """Cancel this R2R round for every participant, as fast as Redis allows.
+
+    Publishes on the barrier's go-channel so workers already waiting wake on
+    their next ``get_message`` poll -- about a second -- and writes the reason
+    to a key so workers that have not subscribed yet still see it.  Without
+    both, a cancelled round costs the barrier timeout and then a full
+    ``COSMOS_NCCL_TIMEOUT_MS`` blocking in ``ncclBroadcast``.
+
+    Returns whether the signal was delivered; a Redis failure here is not
+    fatal, it only means the peers fall back to those timeouts.
+    """
+    r2r_redis = getattr(worker, "_r2r_redis", None)
+    if r2r_redis is None:
+        return False
+    prefix = getattr(worker, "_r2r_barrier_prefix", None)
+    if not prefix:
+        return False
+    try:
+        _, go_channel, abort_key = _round_keys(prefix, weight_step)
+        r2r_redis.set(abort_key, f"{_R2R_ABORT_MARKER}{reason}")
+        r2r_redis.expire(abort_key, 600)
+        r2r_redis.publish(go_channel, _R2R_ABORT_SIGNAL)
+        logger.error(
+            "[R2R Barrier] Cancelled step %s for all participants: %s",
+            weight_step,
+            reason,
+        )
+        return True
+    except Exception:
+        logger.exception(
+            "[R2R Barrier] Could not publish the abort for step %s; peers will "
+            "fall back to the barrier and NCCL timeouts.",
+            weight_step,
+        )
+        return False
+
+
 def r2r_barrier(
-    worker, weight_step: int, expected_world_size: Optional[int] = None
+    worker,
+    weight_step: int,
+    expected_world_size: Optional[int] = None,
 ) -> bool:
     """Redis-based barrier so all rollout workers start R2R broadcast together.
 
@@ -828,10 +1042,16 @@ def r2r_barrier(
         return True
 
     prefix = worker._r2r_barrier_prefix
-    barrier_key = f"{prefix}:barrier:{weight_step}"
-    go_channel = f"{prefix}:go:{weight_step}"
+    barrier_key, go_channel, abort_key = _round_keys(prefix, weight_step)
 
     try:
+        # A round cancelled by its source (see ``abort_r2r_round``) must not be
+        # joined at all.  Check before incrementing so this worker is not
+        # counted towards a go signal that will never be useful.
+        aborted = _read_abort_reason(r2r_redis, abort_key, weight_step)
+        if aborted is not None:
+            raise R2RAborted(aborted)
+
         count = r2r_redis.incr(barrier_key)
         r2r_redis.expire(barrier_key, 600)
 
@@ -857,6 +1077,12 @@ def r2r_barrier(
         pubsub = r2r_redis.pubsub()
         pubsub.subscribe(go_channel)
         try:
+            # Re-read after subscribing: an abort published between the
+            # check above and ``subscribe`` would otherwise be missed.
+            aborted = _read_abort_reason(r2r_redis, abort_key, weight_step)
+            if aborted is not None:
+                raise R2RAborted(aborted)
+
             recheck = int(r2r_redis.get(barrier_key) or 0)
             if recheck >= world_size:
                 elapsed_ms = (time.monotonic() - t0) * 1000
@@ -885,6 +1111,14 @@ def r2r_barrier(
                     return False
                 msg = pubsub.get_message(timeout=1.0)
                 if msg is not None and msg.get("type") == "message":
+                    payload = msg.get("data")
+                    if isinstance(payload, bytes):
+                        payload = payload.decode("utf-8", "replace")
+                    if payload == _R2R_ABORT_SIGNAL:
+                        raise R2RAborted(
+                            _read_abort_reason(r2r_redis, abort_key, weight_step)
+                            or f"R2R round for step {weight_step} was cancelled"
+                        )
                     break
             else:
                 logger.warning(
@@ -904,6 +1138,10 @@ def r2r_barrier(
             elapsed_ms,
         )
         return True
+    except R2RAborted:
+        # An explicit cancellation, not a Redis fault. Propagate it: proceeding
+        # would enter a collective whose source has already walked away.
+        raise
     except Exception as exc:
         logger.warning("[R2R Barrier] Redis error (%s); skipping barrier.", exc)
         return True

--- a/tests/run_test.sh
+++ b/tests/run_test.sh
@@ -22,6 +22,14 @@ RUN_IDX=0
 TEST_LOG_DIR="${TEST_LOG_DIR:-${PWD}/test-logs}"
 mkdir -p "${TEST_LOG_DIR}"
 echo "Per-suite logs: ${TEST_LOG_DIR}"
+# Ceiling on any ONE suite, so a hang costs that suite instead of the run.
+# Without it a suite that wedges -- CUDA init stalling on a shared runner, a
+# collective waiting on a peer that never arrives -- consumes whatever is left
+# of the outer job timeout, and the script is killed before it can print a
+# summary: every later suite goes unrun and the log ends mid-import with no
+# indication of which suite was to blame.
+# 20m is >2x the slowest legitimate suite (test_integration.py --stream, 593s).
+SUITE_TIMEOUT="${SUITE_TIMEOUT:-20m}"
 run() {
     RUN_IDX=$((RUN_IDX + 1))
     local rc log slug
@@ -38,7 +46,9 @@ run() {
     echo
     echo "================ RUN: $* ================"
     echo "---- log: ${log} ----"
-    "$@" 2>&1 | tee "${log}"
+    # --kill-after: a suite ignoring SIGTERM (a wedged CUDA context often
+    # does) must still die, or the ceiling buys nothing.
+    timeout --kill-after=30s "${SUITE_TIMEOUT}" "$@" 2>&1 | tee "${log}"
     rc=${PIPESTATUS[0]}
 
     # Classify by reading the FILE, not a copy held in memory.
@@ -49,6 +59,12 @@ run() {
         else
             echo "---- PASS: $* ----"
         fi
+    elif (( rc == 124 || rc == 137 )); then
+        # 124 = timeout fired, 137 = SIGKILL from --kill-after.  Called out
+        # separately because "hung" and "asserted" want different responses,
+        # and the suite log ends mid-run rather than at a failure.
+        echo "---- TIMEOUT(${SUITE_TIMEOUT}): $* ----"
+        FAILED+=("$* [timed out after ${SUITE_TIMEOUT}]")
     else
         echo "---- FAIL(rc=${rc}): $* ----"
         FAILED+=("$*")
@@ -155,7 +171,7 @@ run python tests/test_put_rollouts.py
 run python tests/test_trajectory_iteration.py
 run python tests/test_gym_example.py
 # Pytest-style CPU suites; install pytest in case the image lacks it.
-run /bin/bash -c "python -m pip install --quiet pytest && python -m pytest -q tests/test_weight_sync.py tests/test_checkpoint.py tests/test_ranked_rollout_end_and_wst_fence.py tests/test_rollout_mesh_guard.py tests/test_terminal_checkpoint_trainer_hooks.py tests/test_terminal_drain_protocol.py tests/test_training_complete_checkpoint.py tests/test_p2r_grouping.py tests/test_tensor_packing.py"
+run /bin/bash -c "python -m pip install --quiet pytest && python -m pytest -q tests/test_weight_sync.py tests/test_checkpoint.py tests/test_ranked_rollout_end_and_wst_fence.py tests/test_rollout_mesh_guard.py tests/test_r2r_unseeded_source.py tests/test_terminal_checkpoint_trainer_hooks.py tests/test_terminal_drain_protocol.py tests/test_training_complete_checkpoint.py tests/test_p2r_grouping.py tests/test_tensor_packing.py"
 run python -m unittest -v tests.contracts.test_trainer_metrics_contract
 run python -m unittest -v tests.contracts.test_config_routing_contract
 run python -m unittest -v tests.contracts.test_model_registry_contract

--- a/tests/test_r2r_unseeded_source.py
+++ b/tests/test_r2r_unseeded_source.py
@@ -1,0 +1,475 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""An R2R source must hold real weights before it broadcasts them.
+
+The controller chooses the R2R source from
+``weights_loaded_in_view_of_command``, which records that a P2R was *published*
+and is never cleared when one fails.  ``WeightSyncThread._run`` turns a failed
+P2R into a log line and then executes the next queued command, so the source
+would go on to broadcast a buffer that was never seeded.  Every destination
+accepts it, sets the sticky ``weight_synced`` bit, and generates against base
+weights while reporting the current version -- silently.
+
+These tests pin the guard that stops it, and the cancellation path that keeps
+the peers from paying the 120 s barrier timeout plus a full
+``COSMOS_NCCL_TIMEOUT_MS`` inside ``ncclBroadcast``.
+"""
+
+import unittest
+from unittest import mock
+
+from cosmos_rl.rollout.worker import weight_sync as ws
+
+
+class FakeRedis:
+    """Enough of the redis client for the barrier: keys plus one pub/sub."""
+
+    def __init__(self):
+        self.store = {}
+        self.published = []
+        self.counters = {}
+        self._queued_messages = []
+        self.incr_calls = 0
+
+    # --- key/value ---
+    def get(self, key):
+        return self.store.get(key)
+
+    def set(self, key, value):
+        self.store[key] = value
+
+    def expire(self, key, ttl):
+        return True
+
+    def incr(self, key):
+        self.incr_calls += 1
+        self.counters[key] = self.counters.get(key, 0) + 1
+        self.store[key] = str(self.counters[key])
+        return self.counters[key]
+
+    # --- pub/sub ---
+    def publish(self, channel, payload):
+        self.published.append((channel, payload))
+
+    def pubsub(self):
+        return FakePubSub(self)
+
+
+class FakePubSub:
+    def __init__(self, client):
+        self.client = client
+        self.subscribed = []
+        self.closed = False
+
+    def subscribe(self, channel):
+        self.subscribed.append(channel)
+
+    def unsubscribe(self, channel):
+        pass
+
+    def close(self):
+        self.closed = True
+
+    def get_message(self, timeout=None):
+        if self.client._queued_messages:
+            return self.client._queued_messages.pop(0)
+        return None
+
+
+class FakeWorker:
+    def __init__(self, replica_name="rollout-a", buffer_version=1):
+        self.replica_name = replica_name
+        self._buffer_version = buffer_version
+        self._r2r_redis = FakeRedis()
+        self._r2r_barrier_prefix = "cosmos:r2r"
+        self._r2r_world_size = 3
+        self.replica_name_to_rank = {"rollout-a": 0, "rollout-b": 1, "rollout-c": 2}
+        self.device = "cpu"
+
+
+class FakeCommand:
+    def __init__(self, src="rollout-a", dsts=("rollout-a", "rollout-b", "rollout-c")):
+        self.src_replica_name = src
+        self.dst_replica_names = list(dsts)
+        self.weight_step = 7
+        self.total_steps = 20
+
+    def replica_should_stop(self):
+        return False
+
+
+def make_thread(worker):
+    """A WeightSyncThread without starting its thread or touching CUDA."""
+    thread = ws.WeightSyncThread.__new__(ws.WeightSyncThread)
+    thread._worker = worker
+    thread._p2r_failed = False
+    thread._task_failed = False
+    return thread
+
+
+def make_last_arriver(worker, weight_step=7, world_size=3):
+    """Pre-seed the barrier counter so this worker completes the quorum.
+
+    ``r2r_barrier`` returns as soon as the last arriver publishes the go
+    signal.  A non-final arriver instead waits out the real
+    ``_R2R_BARRIER_TIMEOUT_S`` and only then proceeds, so a test that cares
+    about the abort check rather than the wait would take two minutes and
+    reach its assertion down the timeout path instead of the intended one.
+    """
+    barrier_key, _, _ = ws._round_keys(worker._r2r_barrier_prefix, weight_step)
+    worker._r2r_redis.counters[barrier_key] = world_size - 1
+
+
+class TestTheSourceRefusesToBroadcastWeightsItDoesNotHave(unittest.TestCase):
+    def test_never_seeded_source_cancels_the_round(self):
+        worker = FakeWorker(buffer_version=0)
+        thread = make_thread(worker)
+        with self.assertRaises(ws.R2RAborted) as caught:
+            thread._assert_seeded_before_broadcast(FakeCommand(), 7)
+        self.assertIn("no weight sync has ever completed", str(caught.exception))
+
+    def test_source_whose_p2r_failed_this_round_cancels(self):
+        worker = FakeWorker(buffer_version=5)
+        thread = make_thread(worker)
+        thread._p2r_failed = True
+        with self.assertRaises(ws.R2RAborted) as caught:
+            thread._assert_seeded_before_broadcast(FakeCommand(), 7)
+        self.assertIn("P2R staging this round failed", str(caught.exception))
+
+    def test_a_seeded_source_proceeds(self):
+        thread = make_thread(FakeWorker(buffer_version=3))
+        thread._assert_seeded_before_broadcast(FakeCommand(), 7)
+
+    def test_destinations_are_not_judged_by_their_own_buffer(self):
+        """A destination has no weights yet -- that is what R2R is for."""
+        worker = FakeWorker(replica_name="rollout-b", buffer_version=0)
+        thread = make_thread(worker)
+        thread._p2r_failed = True
+        thread._assert_seeded_before_broadcast(FakeCommand(src="rollout-a"), 7)
+
+    def test_the_cancellation_reaches_redis(self):
+        worker = FakeWorker(buffer_version=0)
+        thread = make_thread(worker)
+        with self.assertRaises(ws.R2RAborted):
+            thread._assert_seeded_before_broadcast(FakeCommand(), 7)
+        # The marker is scoped to the source: the controller re-issues at the
+        # same step off a different replica, and a step-only key would cancel
+        # that round too (job 2143219).
+        self.assertIn("cosmos:r2r:abort:7", worker._r2r_redis.store)
+        self.assertEqual(
+            worker._r2r_redis.published, [("cosmos:r2r:go:7", ws._R2R_ABORT_SIGNAL)]
+        )
+
+
+class TestASingleMemberRoundIsNotCancelled(unittest.TestCase):
+    """One replica broadcasts to nobody, so there is no peer to protect.
+
+    ``_execute_r2r`` skips both the barrier and the collective when the
+    recipient set has one member; cancelling there would break a legitimate
+    round -- it only bumps the local version and validation bookkeeping.
+    """
+
+    def test_lone_replica_with_an_empty_buffer_still_proceeds(self):
+        worker = FakeWorker(buffer_version=0)
+        worker.current_weight_version = 0
+        worker.state = mock.MagicMock()
+        worker.state.weight_synced.return_value = False
+        worker.config = mock.MagicMock()
+        worker.config.validation.enable = False
+        thread = make_thread(worker)
+        thread._stream = object()
+        thread._queue = mock.MagicMock()
+        thread._queue.qsize.return_value = 0
+        thread._executed = 0
+        command = FakeCommand(src="rollout-a", dsts=("rollout-a",))
+        with (
+            mock.patch.object(ws, "r2r_barrier") as barrier,
+            mock.patch.object(ws, "do_nccl_broadcast_grouped") as broadcast,
+            mock.patch("torch.cuda.Event"),
+        ):
+            thread._execute_r2r(command)
+        barrier.assert_not_called()
+        broadcast.assert_not_called()
+        self.assertEqual(worker._buffer_version, 1)
+
+
+class TestNoNcclWorkIsLaunchedForACancelledRound(unittest.TestCase):
+    def test_execute_r2r_aborts_before_the_barrier_and_the_broadcast(self):
+        worker = FakeWorker(buffer_version=0)
+        thread = make_thread(worker)
+        with (
+            mock.patch.object(ws, "r2r_barrier") as barrier,
+            mock.patch.object(ws, "do_nccl_broadcast_grouped") as broadcast,
+        ):
+            with self.assertRaises(ws.R2RAborted):
+                thread._execute_r2r(FakeCommand())
+        barrier.assert_not_called()
+        broadcast.assert_not_called()
+
+
+class TestWaitingWorkersLearnQuickly(unittest.TestCase):
+    def test_barrier_refuses_a_round_already_marked_aborted(self):
+        worker = FakeWorker()
+        worker._r2r_redis.store["cosmos:r2r:abort:7"] = (
+            ws._R2R_ABORT_MARKER + "source had no weights"
+        )
+        with self.assertRaises(ws.R2RAborted) as caught:
+            ws.r2r_barrier(worker, 7, expected_world_size=3)
+        self.assertIn("source had no weights", str(caught.exception))
+
+    def test_an_aborted_round_does_not_count_the_worker_towards_go(self):
+        worker = FakeWorker()
+        worker._r2r_redis.store["cosmos:r2r:abort:7"] = ws._R2R_ABORT_MARKER + "nope"
+        with self.assertRaises(ws.R2RAborted):
+            ws.r2r_barrier(worker, 7, expected_world_size=3)
+        self.assertEqual(worker._r2r_redis.incr_calls, 0)
+
+    def test_abort_published_while_waiting_wakes_the_worker(self):
+        worker = FakeWorker()
+        redis = worker._r2r_redis
+        redis.store["cosmos:r2r:abort:7"] = (
+            ws._R2R_ABORT_MARKER + "source had no weights"
+        )
+        redis._queued_messages.append(
+            {"type": "message", "data": ws._R2R_ABORT_SIGNAL.encode()}
+        )
+        # Not yet marked when the barrier first looks; only the message carries it.
+        real_get = redis.get
+        first = {"n": 0}
+
+        def get_hiding_the_key_at_first(key):
+            if key.startswith("cosmos:r2r:abort:7") and first["n"] < 2:
+                first["n"] += 1
+                return None
+            return real_get(key)
+
+        redis.get = get_hiding_the_key_at_first
+        with self.assertRaises(ws.R2RAborted):
+            ws.r2r_barrier(worker, 7, expected_world_size=3)
+
+    def test_abort_landing_between_the_check_and_subscribe_is_caught(self):
+        worker = FakeWorker()
+        redis = worker._r2r_redis
+        real_get = redis.get
+        state = {"seen": 0}
+
+        def get_that_appears_after_the_first_look(key):
+            if key.startswith("cosmos:r2r:abort:7"):
+                state["seen"] += 1
+                if state["seen"] == 1:
+                    return None
+                return ws._R2R_ABORT_MARKER + "raced in"
+            return real_get(key)
+
+        redis.get = get_that_appears_after_the_first_look
+        with self.assertRaises(ws.R2RAborted) as caught:
+            ws.r2r_barrier(worker, 7, expected_world_size=3)
+        self.assertIn("raced in", str(caught.exception))
+
+
+class TestOnlyAnAbortRecordCancelsARound(unittest.TestCase):
+    """A GET answered for a key that was never set must not cancel the round.
+
+    Caught on the Slurm CI run: a redis double whose ``get`` ignores the key
+    returned the barrier counter for the abort key, and an ``is not None``
+    check read that as a cancellation, failing three pre-existing barrier
+    tests. Requiring the marker makes the check about the value, not the key.
+    """
+
+    def test_a_client_answering_every_get_does_not_cancel(self):
+        worker = FakeWorker()
+        worker._r2r_redis.get = lambda key: 2  # the barrier count, for any key
+        make_last_arriver(worker)
+        self.assertTrue(ws.r2r_barrier(worker, 7, expected_world_size=3))
+
+    def test_an_unmarked_value_is_not_an_abort(self):
+        worker = FakeWorker()
+        worker._r2r_redis.store["cosmos:r2r:abort:7"] = "some other writer"
+        make_last_arriver(worker)
+        self.assertTrue(ws.r2r_barrier(worker, 7, expected_world_size=3))
+
+    def test_the_stored_record_carries_the_marker(self):
+        worker = FakeWorker()
+        ws.abort_r2r_round(worker, 7, "because")
+        stored = worker._r2r_redis.store["cosmos:r2r:abort:7"]
+        self.assertTrue(stored.startswith(ws._R2R_ABORT_MARKER))
+        self.assertIn("because", stored)
+
+
+class TestARedisOutageStillDoesNotBlockWeightSync(unittest.TestCase):
+    """Pre-existing behaviour: a broken Redis must not stop the round."""
+
+    def test_barrier_still_proceeds_when_redis_raises(self):
+        worker = FakeWorker()
+
+        def boom(*a, **k):
+            raise ConnectionError("redis down")
+
+        worker._r2r_redis.get = boom
+        make_last_arriver(worker)
+        self.assertTrue(ws.r2r_barrier(worker, 7, expected_world_size=3))
+
+    def test_publishing_an_abort_without_redis_is_not_fatal(self):
+        worker = FakeWorker()
+        worker._r2r_redis = None
+        self.assertFalse(ws.abort_r2r_round(worker, 7, "reason"))
+
+    def test_publishing_an_abort_survives_a_redis_error(self):
+        worker = FakeWorker()
+
+        def boom(*a, **k):
+            raise ConnectionError("redis down")
+
+        worker._r2r_redis.set = boom
+        self.assertFalse(ws.abort_r2r_round(worker, 7, "reason"))
+
+
+class TestACancelledRoundFailsTheJob(unittest.TestCase):
+    """Drives the real ``_run`` loop, not a copy of its except clauses.
+
+    A cancelled round is terminal. Waiting does not help: the cancelled round
+    is exactly what stops the trainer reaching the next sync boundary, so the
+    job stalls silently while holding its allocation -- on job 2142899 the
+    last completed sync was step 6 and the controller then soft-throttled out
+    to 195s until it was killed. Failing here keeps the cause attributable.
+    """
+
+    def _run_once_raising(self, exc):
+        import queue as queue_mod
+        import threading
+
+        worker = FakeWorker()
+        worker.shutdown_signal = threading.Event()
+        worker.shutdown_mp_signal = threading.Event()
+        thread = make_thread(worker)
+        thread._queue = queue_mod.PriorityQueue()
+        thread._stop = threading.Event()
+        thread._idle = threading.Event()
+        thread._seq = 0
+
+        def explode(command):
+            # Stop after this one command so ``_run`` returns.
+            thread._stop.set()
+            raise exc
+
+        thread._execute_r2r = explode
+        thread._queue.put((1, 1, ("r2r", FakeCommand())))
+        with mock.patch("torch.cuda.set_device"):
+            ws.WeightSyncThread._run(thread)
+        return thread, worker
+
+    def test_a_cancellation_brings_the_worker_down(self):
+        _, worker = self._run_once_raising(ws.R2RAborted("cancelled"))
+        self.assertTrue(worker.shutdown_signal.is_set())
+        self.assertTrue(worker.shutdown_mp_signal.is_set())
+
+    def test_cancellation_does_not_latch_a_failure(self):
+        """The latch would cost the next mesh rebuild a spurious discard."""
+        thread, _ = self._run_once_raising(ws.R2RAborted("cancelled"))
+        self.assertFalse(thread._task_failed)
+
+    def test_an_ordinary_error_latches_and_does_not_fail_the_job(self):
+        """Only a cancelled round is terminal; other failures stay recoverable."""
+        thread, worker = self._run_once_raising(RuntimeError("nccl exploded"))
+        self.assertTrue(thread._task_failed)
+        self.assertFalse(worker.shutdown_signal.is_set())
+
+    def test_a_worker_without_shutdown_signals_does_not_raise(self):
+        worker = FakeWorker()
+        ws._fail_the_job(worker)
+
+
+class TestP2ROutcomeIsRecordedSeparatelyFromTheStickyFlag(unittest.TestCase):
+    def _thread_with_p2r(self, recv):
+        worker = FakeWorker()
+        worker._execute_p2r_recv = recv
+        worker.current_weight_version = 0
+        thread = make_thread(worker)
+        thread._stream = mock.MagicMock()
+        thread._executed = 0
+        thread._queue = mock.MagicMock()
+        thread._queue.qsize.return_value = 0
+        return thread
+
+    def test_a_failed_p2r_is_recorded(self):
+        def boom(command, stream):
+            raise RuntimeError("p2r failed")
+
+        thread = self._thread_with_p2r(boom)
+        with mock.patch("torch.cuda.Event"):
+            with self.assertRaises(RuntimeError):
+                thread._execute_p2r(FakeCommand())
+        self.assertTrue(thread._p2r_failed)
+
+    def test_a_successful_p2r_clears_the_record(self):
+        thread = self._thread_with_p2r(lambda command, stream: None)
+        thread._p2r_failed = True
+        with mock.patch("torch.cuda.Event"):
+            thread._execute_p2r(FakeCommand())
+        self.assertFalse(thread._p2r_failed)
+
+
+class TestTheP2RDrainDoesNotReportSuccessAfterAborting(unittest.TestCase):
+    """A drain that had to abort every communicator is not a completed sync.
+
+    ``bounded_drain_or_abort`` returns False only after ``nccl_abort_all``.
+    The P2R call site used to discard that, so the policy reported the sync as
+    successful and returned to a main loop with no communicators: it never
+    unregistered, the controller never saw a dead policy, and the job held its
+    nodes until the wall clock. Job 2148080 sat silent for 16 minutes that way
+    while all seven rollouts had already exited 13s after the injection.
+    """
+
+    def _call(self, drained):
+        from cosmos_rl.policy.worker import rl_worker
+
+        with mock.patch.object(
+            rl_worker, "bounded_drain_or_abort", return_value=drained
+        ) as drain:
+            rl_worker._drain_or_fail(
+                "stream", 120.0, "policy_P2R[src@step8]", "src", "dst", 8
+            )
+        return drain
+
+    def test_a_clean_drain_returns_quietly(self):
+        drain = self._call(True)
+        drain.assert_called_once_with("stream", 120.0, "policy_P2R[src@step8]")
+
+    def test_an_aborted_drain_fails_the_replica(self):
+        from cosmos_rl.policy.worker import rl_worker
+
+        with self.assertRaises(rl_worker.P2RDrainAborted) as caught:
+            self._call(False)
+        message = str(caught.exception)
+        self.assertIn("dst", message)
+        self.assertIn("step 8", message)
+        self.assertIn("aborted", message)
+
+    def test_the_p2r_call_site_uses_the_checked_helper(self):
+        """The unchecked call must not come back; the failure it causes is
+        silent, so nothing else would catch its return."""
+        import inspect
+        from cosmos_rl.policy.worker import rl_worker
+
+        body = inspect.getsource(
+            rl_worker.RLPolicyWorker.execute_policy_to_rollout_unicast
+        )
+        self.assertIn("_drain_or_fail(", body)
+        self.assertNotIn("bounded_drain_or_abort(", body)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
A rollout whose P2R failed could still be told to broadcast, and every other
replica would accept what it sent. Nothing raised; the wrong weights simply
trained until the next sync overwrote them.

## The bug

The controller picks the R2R source from `weights_loaded_in_view_of_command`,
which is set when a P2R is *published* and cleared nowhere — it records intent,
not outcome. `WeightSyncThread._run` caught a failed P2R, recorded it in a flag,
and ran the next queued command (the R2R) without consulting that flag. The
source broadcast a buffer that was never seeded; every destination accepted it,
set the sticky `weight_synced` bit, and generated against base weights while
reporting them as current.

## The change

Four files.

- **The guard.** Only the source can detect this, so the check sits there,
  before the barrier and before any NCCL call. It cancels the round when
  nothing ever seeded this replica, or when this round's P2R failed.
- **Cancellation reaches peers over the barrier's own channel** — publish on the
  go channel for subscribers, plus a `cosmos-r2r-abort:` marker for anyone not
  yet subscribed. Peers fail in ~1 s instead of 120 s of barrier timeout plus a
  full `COSMOS_NCCL_TIMEOUT_MS` inside `ncclBroadcast`.
- **A cancelled round ends the job**, rather than stalling on the allocation.
- **The policy's P2R drain no longer discards its result.**
  `bounded_drain_or_abort` returns False only after `nccl_abort_all`; treating
  that as a successful sync left the policy idle with no communicators, never
  unregistering, holding its nodes until the wall clock.

## Verification

26 new cases in `tests/test_r2r_unseeded_source.py`, registered in
`run_test.sh`. Suites importing any changed file go 233 → 259.

On Slurm, with a P2R failure injected at step 8:

| job | outcome |
|---|---|
| 2142899 | guard fires, 7 cancellations in one second, no stale broadcast — then the job hangs, which is why cancellation is now terminal |
| 2143533 | a retry sharing the step's barrier counter degrades it to a no-op: 8/7 through 12/7 in one second, five workers each declaring itself last |
| 2147521 | `ncclCommAbort` on the pair does **not** reach the peer: 120 s to the policy's drain either way. Reverted. |
| 2148080 | rollouts exit 13 s after injection, but the job sat 16 more minutes on the discarded drain result |
| 2148338 | the whole chain: rollouts unregistered by +11 s, drain raises at +120 s naming the rollout and step, policy unregisters, controller escalates, job gone at +143 s |

## Not addressed

Surviving a P2R failure. The controller's recovery path does not work for this
case: `post_ncclerror` unregisters non-reporting replicas and never triggers the
BuildMesh its docstring promises, and the rollout branches of both
`set_replica_ncclerror` and `post_ncclerror` raise `NotImplementedError`.
