### PR TITLE
feat(reward): add per-completion training admission

### DIFF
--- a/cosmos_rl/dispatcher/algo/base.py
+++ b/cosmos_rl/dispatcher/algo/base.py
@@ -21,6 +21,8 @@ REGISTERED_ALGOs = {}
 
 
 class RuleBasedAlgo(ABC):
+    minimum_trainable_completions = 1
+
     def __init__(self, config: Any = None, **kwargs):
         """Store the run config so an algo can read its own settings.
 

--- a/cosmos_rl/dispatcher/algo/grpo.py
+++ b/cosmos_rl/dispatcher/algo/grpo.py
@@ -20,6 +20,9 @@ from cosmos_rl.utils.constant import Algo
 
 
 class GRPO(RuleBasedAlgo):
+    # A single completion has no useful group-relative advantage.
+    minimum_trainable_completions = 2
+
     def __init__(
         self, reward_fn: Callable, unbiased: bool = False, eps: float = 1e-6, **kwargs
     ):

--- a/cosmos_rl/dispatcher/controller.py
+++ b/cosmos_rl/dispatcher/controller.py
@@ -146,6 +146,13 @@ class Controller:
         )
         self.is_diffusers = self.config.policy.is_diffusers
         self.weight_version_to_prompt_num = {}  # Only for on-policy.
+        # Completion-level rejection can leave an on-policy step short after
+        # its normal prompt quota has already been issued.  Credits reopen
+        # prompt slots for that same weight version without erasing the total
+        # attempt count used by max_retry_for_on_policy.
+        self.weight_version_to_replacement_prompt_num: Dict[int, int] = {}
+        self.weight_version_to_replacement_prompt_issued: Dict[int, int] = {}
+        self.weight_version_to_discarded_sample_num: Dict[int, int] = {}
 
         self.data_fetcher = ControllerDataFetcher(
             config=config,
@@ -291,6 +298,101 @@ maxmemory-policy allkeys-lfu
         return await self._get_batched_prompt_impl(n, validation_step, rank_in_mesh)
 
     _SOFT_THROTTLE_HEARTBEAT_S = 5.0
+
+    def register_discarded_samples_for_refill(
+        self, weight_version: int, discarded_samples: int
+    ) -> int:
+        """Reopen same-weight prompt capacity after terminal sample loss.
+
+        Prompt quotas are counted in prompts while discard reports are counted
+        in generated completions.  One replacement prompt can replenish up to
+        ``n_generation`` discarded completions; any surplus completions are
+        handled by the existing staleness filter after the current step fills.
+        """
+
+        train_policy = self.config.train.train_policy
+        if (
+            discarded_samples <= 0
+            or not getattr(train_policy, "on_policy", False)
+            or train_policy.variant == "dapo"
+            or self.config.mode == "colocated"
+        ):
+            return 0
+        if type(weight_version) is not int or weight_version < 0:
+            logger.warning(
+                "[Controller] Ignoring discarded-sample refill without a valid "
+                "weight version: version=%r count=%d",
+                weight_version,
+                discarded_samples,
+            )
+            return 0
+
+        credits = getattr(self, "weight_version_to_replacement_prompt_num", None)
+        if credits is None:
+            credits = self.weight_version_to_replacement_prompt_num = {}
+        issued = getattr(self, "weight_version_to_replacement_prompt_issued", None)
+        if issued is None:
+            issued = self.weight_version_to_replacement_prompt_issued = {}
+        discarded = getattr(self, "weight_version_to_discarded_sample_num", None)
+        if discarded is None:
+            discarded = self.weight_version_to_discarded_sample_num = {}
+
+        discarded[weight_version] = discarded.get(weight_version, 0) + discarded_samples
+        required_replacement_prompts = math.ceil(
+            discarded[weight_version] / self.config.rollout.n_generation
+        )
+        replacement_prompts = max(
+            0,
+            required_replacement_prompts
+            - issued.get(weight_version, 0)
+            - credits.get(weight_version, 0),
+        )
+        credits[weight_version] = credits.get(weight_version, 0) + replacement_prompts
+        logger.info(
+            "[Controller] Reopened %d replacement prompt slot(s) for weight "
+            "version %d after %d discarded completion(s)",
+            replacement_prompts,
+            weight_version,
+            discarded_samples,
+        )
+        return replacement_prompts
+
+    def _assign_prompt_weight_versions(
+        self,
+        payloads: List[RLPayload],
+        *,
+        starting_weight_version: int,
+        prompt_quota: int,
+    ) -> None:
+        """Assign prompt versions, consuming same-version refill credits first."""
+
+        weight_version = starting_weight_version
+        credits = getattr(self, "weight_version_to_replacement_prompt_num", None)
+        if credits is None:
+            credits = self.weight_version_to_replacement_prompt_num = {}
+        issued_replacements = getattr(
+            self, "weight_version_to_replacement_prompt_issued", None
+        )
+        if issued_replacements is None:
+            issued_replacements = self.weight_version_to_replacement_prompt_issued = {}
+        for payload in payloads:
+            while True:
+                refill_credit = credits.get(weight_version, 0)
+                issued = self.weight_version_to_prompt_num.get(weight_version, 0)
+                if refill_credit > 0:
+                    credits[weight_version] = refill_credit - 1
+                    issued_replacements[weight_version] = (
+                        issued_replacements.get(weight_version, 0) + 1
+                    )
+                    break
+                if issued < prompt_quota:
+                    break
+                weight_version += 1
+
+            payload.weight_version = weight_version
+            self.weight_version_to_prompt_num[weight_version] = (
+                self.weight_version_to_prompt_num.get(weight_version, 0) + 1
+            )
 
     def _update_soft_throttle_state(
         self,
@@ -516,41 +618,11 @@ maxmemory-policy allkeys-lfu
             )
             current_fetch_count = len(payloads_list)
             if self.config.train.train_policy.variant != "dapo":
-                weight_version_for_each_payload = weight_version_for_current_batch
-                for payload in payloads_list:
-                    # Fully Synchronized mode is enabled and no dapo variant, we need to ensure that for each weight version, we fetch exactly global_batch_size prompts.
-                    while (
-                        weight_version_for_each_payload
-                        in self.weight_version_to_prompt_num
-                        and self.weight_version_to_prompt_num[
-                            weight_version_for_each_payload
-                        ]
-                        >= global_batch_size
-                    ):
-                        assert (
-                            self.weight_version_to_prompt_num[
-                                weight_version_for_each_payload
-                            ]
-                            == global_batch_size
-                        ), (
-                            f"[Controller] For weight version {weight_version_for_each_payload}, the number of fetched prompts {self.weight_version_to_prompt_num[weight_version_for_each_payload]} exceeds the global batch size {global_batch_size}."
-                        )
-                        weight_version_for_each_payload += 1
-                    # record the number of valid prompts for each weight version
-                    # tag the payload with the corresponding weight version
-                    if (
-                        weight_version_for_each_payload
-                        not in self.weight_version_to_prompt_num
-                    ):
-                        payload.weight_version = weight_version_for_each_payload
-                        self.weight_version_to_prompt_num[
-                            weight_version_for_each_payload
-                        ] = 1
-                    else:
-                        payload.weight_version = weight_version_for_each_payload
-                        self.weight_version_to_prompt_num[
-                            weight_version_for_each_payload
-                        ] += 1
+                self._assign_prompt_weight_versions(
+                    payloads_list,
+                    starting_weight_version=weight_version_for_current_batch,
+                    prompt_quota=global_batch_size,
+                )
             else:
                 # record the number of valid prompts for current weight version
                 if (

--- a/cosmos_rl/dispatcher/data/schema.py
+++ b/cosmos_rl/dispatcher/data/schema.py
@@ -87,6 +87,22 @@ class RLPayload(BaseModel):
         description="The original input conversation for the rollout, In multi-turn conversation, it is a list of conversation history for each turn.",
     )
 
+    completion_trainable: Optional[List[bool]] = Field(
+        default=None,
+        description="Whether each completion may be used for training. None admits every completion for backward compatibility.",
+    )
+
+    completion_drop_reasons: Optional[List[Optional[str]]] = Field(
+        default=None,
+        description="Optional stable, machine-readable producer reason for excluding each completion from training. Unknown values are grouped under 'other' in metrics.",
+    )
+
+    completion_admission_metrics: Optional[Dict[str, Union[int, float]]] = Field(
+        default=None,
+        exclude=True,
+        description="Internal group-level completion-admission counters consumed by the rollout worker.",
+    )
+
     n_ignore_prefix_tokens: Optional[List[int]] = Field(
         default=None,
         description="The number of prefix tokens to ignore when computing reward.",

--- a/cosmos_rl/dispatcher/run_web_panel.py
+++ b/cosmos_rl/dispatcher/run_web_panel.py
@@ -56,6 +56,11 @@ from cosmos_rl.dispatcher.protocol import (
     Role,
 )
 from cosmos_rl.policy.config import Config as CosmosConfig
+from cosmos_rl.reward.admission import (
+    COMPLETION_ADMISSION_METRIC_PREFIX,
+    COMPLETION_ADMISSION_REPORT_ID_KEY,
+    DISCARDED_WEIGHT_VERSION_KEY,
+)
 from cosmos_rl.utils.network_util import bind_available_port
 from cosmos_rl.utils.logging import logger
 from cosmos_rl.utils.constant import (
@@ -705,15 +710,30 @@ async def put_rollout_group(rollout: RolloutRequest):
         ]
         policy_status = controller.policy_status_manager
         is_dapo = controller.config.train.train_policy.variant == "dapo"
+        if any(
+            key.startswith(COMPLETION_ADMISSION_METRIC_PREFIX)
+            for key in rollout.metrics
+        ):
+            admission_training_step = policy_status.next_rollout_training_step()
+            policy_status.update_completion_admission_statistics(
+                rollout.metrics,
+                source_replica=rollout.src_replica_name,
+                report_id=rollout.metrics.get(COMPLETION_ADMISSION_REPORT_ID_KEY),
+                training_step=admission_training_step,
+            )
         if "discarded_samples" in rollout.metrics:
             discarded_samples = policy_status._parse_non_negative_count(
                 rollout.metrics, "discarded_samples"
             )
-            policy_status.settle_discarded_samples(
+            settled_count = policy_status.settle_discarded_samples(
                 source_replica=rollout.src_replica_name,
                 report_id=rollout.metrics.get("discard_report_id"),
                 count=discarded_samples,
             )
+            if settled_count > 0:
+                controller.register_discarded_samples_for_refill(
+                    rollout.metrics.get(DISCARDED_WEIGHT_VERSION_KEY), settled_count
+                )
         if policy_status.rollout_admission_closed():
             policy_status.cleanup_terminal_rollouts(
                 rollouts,

--- a/cosmos_rl/dispatcher/status.py
+++ b/cosmos_rl/dispatcher/status.py
@@ -15,6 +15,7 @@
 
 import time
 import math
+from collections import OrderedDict
 from queue import Empty, Queue
 from strenum import StrEnum
 from typing import Dict, List, Iterator, Any, Optional, Callable
@@ -35,6 +36,11 @@ from cosmos_rl.dispatcher.data.data_fetcher import ControllerDataFetcher
 from transformers import AutoTokenizer
 import numpy as np
 from cosmos_rl.utils.util import aggregate_report_data
+
+
+# HTTP retries are immediate; retaining the most recent reports bounds memory
+# while covering a much larger window than any request can remain in flight.
+_REPORT_DEDUP_WINDOW = 4096
 
 
 # Debug-only accounting log for ``samples_on_the_fly``. Only the mutation
@@ -282,7 +288,10 @@ class PolicyStatusManager:
         self.rollout_buffer = Queue()
         self.remain_samples_num = 0
         self.samples_on_the_fly = 0
-        self._applied_discard_report_ids: Dict[str, set[str]] = {}
+        self._applied_discard_report_ids: Dict[str, OrderedDict[str, None]] = {}
+        self._applied_completion_admission_report_ids: Dict[
+            str, OrderedDict[str, None]
+        ] = {}
 
         # Actual rollout count for each in-flight real training command.
         # Entries are keyed by the command step and consumed after its full
@@ -310,6 +319,7 @@ class PolicyStatusManager:
 
         # Record filter rewards distribution for dynamic sampling
         self.filter_records = {}
+        self.completion_admission_records: Dict[int, Dict[str, int | float]] = {}
 
         # Non-validation RL: explicit end-of-data phase (see ``JobPhase``).
         self.job_phase = JobPhase.RUNNING
@@ -1109,6 +1119,23 @@ class PolicyStatusManager:
             return sum(q.qsize() for q in self.rollout_buffer_per_rank)
         return self.rollout_buffer.qsize()
 
+    def next_rollout_training_step(self) -> int:
+        """Return the training step targeted by the next arriving rollout.
+
+        Policy execution is serial, but rollout production may fill multiple
+        future batches while the current policy step is running. Existing
+        buffered rollouts therefore determine which undispatched step owns a
+        new admission report; generation weight alone does not when outdated
+        rollouts are allowed.
+        """
+
+        required_rollouts = self.config.train.train_batch_per_replica * max(
+            len(self.get_all_atoms_arrived_replicas()), 1
+        )
+        return (
+            self.current_step + self.total_pending_rollouts() // required_rollouts + 1
+        )
+
     @staticmethod
     def _parse_non_negative_count(metrics: Dict[str, Any], key: str) -> int:
         value = metrics.get(key, 0)
@@ -1163,10 +1190,14 @@ class PolicyStatusManager:
             )
             return 0
 
-        applied_ids = self._applied_discard_report_ids.setdefault(source_replica, set())
+        applied_ids = self._applied_discard_report_ids.setdefault(
+            source_replica, OrderedDict()
+        )
         if report_id in applied_ids:
             return 0
-        applied_ids.add(report_id)
+        applied_ids[report_id] = None
+        if len(applied_ids) > _REPORT_DEDUP_WINDOW:
+            applied_ids.popitem(last=False)
 
         self.filter_records["rollout_failed"] = (
             self.filter_records.get("rollout_failed", 0) + count
@@ -1177,6 +1208,7 @@ class PolicyStatusManager:
     def forget_discard_reports(self, source_replica: str) -> None:
         """Release discard-report deduplication state for an ended replica."""
         self._applied_discard_report_ids.pop(source_replica, None)
+        self._applied_completion_admission_report_ids.pop(source_replica, None)
 
     def _discard_rollouts(self, rollouts: List[Rollout], source: str) -> int:
         if not rollouts:
@@ -1332,6 +1364,76 @@ class PolicyStatusManager:
         # Filtered DAPO generations have no payload and can never reach a
         # training ACK, so settle their prompt-side in-flight accounting here.
         self._settle_samples_on_the_fly(filtered_count, "dapo_filter")
+
+    def update_completion_admission_statistics(
+        self,
+        metrics: Optional[Dict[str, Any]],
+        *,
+        source_replica: str,
+        report_id: Any,
+        training_step: Any,
+    ) -> bool:
+        """Idempotently accumulate admission counters by target training step."""
+
+        if not isinstance(report_id, str) or not report_id:
+            logger.warning(
+                "[Controller] Ignoring completion-admission telemetry from %s "
+                "without a non-empty report ID",
+                source_replica,
+            )
+            return False
+        if type(training_step) is not int or training_step < 1:
+            logger.warning(
+                "[Controller] Ignoring completion-admission telemetry from %s "
+                "with invalid training step %r",
+                source_replica,
+                training_step,
+            )
+            return False
+
+        applied_ids = self._applied_completion_admission_report_ids.setdefault(
+            source_replica, OrderedDict()
+        )
+        if report_id in applied_ids:
+            return False
+        applied_ids[report_id] = None
+        if len(applied_ids) > _REPORT_DEDUP_WINDOW:
+            applied_ids.popitem(last=False)
+
+        records = self.completion_admission_records.setdefault(training_step, {})
+
+        for key in metrics or {}:
+            if not key.startswith("rollout/completion_admission_"):
+                continue
+            if key.startswith(
+                "rollout/completion_admission_excluded_reward_"
+            ) and key.endswith("_sum"):
+                value = metrics.get(key)
+                if (
+                    isinstance(value, (int, float, np.number))
+                    and not isinstance(value, bool)
+                    and math.isfinite(float(value))
+                ):
+                    increment: int | float = float(value)
+                else:
+                    logger.warning(
+                        "[Controller] Ignoring malformed admission telemetry "
+                        "%s=%r; expected a finite number",
+                        key,
+                        value,
+                    )
+                    continue
+            else:
+                increment = self._parse_non_negative_count(metrics, key)
+            records[key] = records.get(key, 0) + increment
+        return True
+
+    def _take_completion_admission_statistics(
+        self, training_step: int
+    ) -> Dict[str, int | float]:
+        """Return admission metrics assigned to one training step."""
+
+        return self.completion_admission_records.pop(training_step, {})
 
     def filter_outdated_rollouts(self, rollouts: List[Rollout]) -> List[Rollout]:
         """
@@ -1598,6 +1700,11 @@ class PolicyStatusManager:
         self.set_status(replica_name, PolicyStatus.REDUCED)
 
         if self.all_reduced():
+            # Admission metadata is step-scoped. Snapshot and clear it at the
+            # step boundary even when logging is disabled or reporting fails.
+            completion_admission_records = self._take_completion_admission_statistics(
+                step
+            )
             _sotf_before = self.samples_on_the_fly
             # Settle exactly the rollout count recorded for this real command.
             _missing_dispatch = object()
@@ -1719,6 +1826,7 @@ class PolicyStatusManager:
                     policy_report_data = aggregate_report_data(
                         self.report_data_list, policy_report_data
                     )
+                    policy_report_data.update(completion_admission_records)
                     if self.config.mode == "colocated":
                         for data in self.report_data_list:
                             # Handle dynamic sampling statistics update in colocated mode

--- a/cosmos_rl/reward/admission.py
+++ b/cosmos_rl/reward/admission.py
@@ -1,0 +1,422 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from collections import Counter
+from dataclasses import dataclass
+import math
+from numbers import Real
+import re
+from typing import TYPE_CHECKING, Any, Dict, Iterable, List, Optional, Sequence
+import uuid
+
+from cosmos_rl.dispatcher.data.schema import RLPayload
+
+if TYPE_CHECKING:
+    from cosmos_rl.rollout.schema import RolloutResult
+
+
+COMPLETION_ADMISSION_METRIC_PREFIX = "rollout/completion_admission_"
+COMPLETION_ADMISSION_REPORT_ID_KEY = "completion_admission_report_id"
+COMPLETION_ADMISSION_WEIGHT_VERSION_KEY = "completion_admission_weight_version"
+DISCARDED_SAMPLES_KEY = "discarded_samples"
+DISCARD_REPORT_ID_KEY = "discard_report_id"
+DISCARDED_WEIGHT_VERSION_KEY = "discarded_weight_version"
+
+
+_COMPLETION_ALIGNED_FIELDS = (
+    "completions",
+    "completed_conversations",
+    "n_ignore_prefix_tokens",
+    "rewards",
+    "advantages",
+    "filter_rewards",
+    "completion_token_ids",
+    "completion_logprobs",
+    "cumulative_logprob",
+    "report_metrics",
+    "teacher_result_uuids",
+)
+
+_ROLLOUT_RESULT_COMPLETION_ALIGNED_FIELDS = (
+    "completions",
+    "completed_conversations",
+    "completion_trainable",
+    "completion_drop_reasons",
+    "completion_logprobs",
+    "completion_token_ids",
+    "cumulative_logprob",
+)
+
+_KNOWN_DROP_REASONS = frozenset(
+    {
+        "empty_completion",
+        "generation_error",
+        "invalid_completion",
+        "missing_log_probs",
+        "timeout",
+        "unspecified",
+    }
+)
+
+
+def _metric_reason(reason: Optional[str]) -> str:
+    value = (reason or "unspecified").strip().lower()
+    value = re.sub(r"[^a-z0-9]+", "_", value).strip("_")
+    value = value or "unspecified"
+    return value if value in _KNOWN_DROP_REASONS else "other"
+
+
+def _metric_component(value: Any) -> str:
+    component = re.sub(r"[^a-z0-9]+", "_", str(value).strip().lower()).strip("_")
+    return (component or "metric")[:64]
+
+
+def aggregate_excluded_reward_metrics(
+    reward_metrics: Iterable[Optional[Dict[str, Any]]],
+) -> Dict[str, int | float]:
+    """Aggregate numeric telemetry for completions excluded from training.
+
+    Admission metadata is the only reporting path that survives when an entire
+    group is rejected, so emit sum/count pairs there. Non-numeric and non-finite
+    values are intentionally skipped; they cannot be safely reduced across
+    workers.
+    """
+
+    sums: Dict[str, float] = {}
+    counts: Dict[str, int] = {}
+    for metrics in reward_metrics:
+        for key, value in (metrics or {}).items():
+            if hasattr(value, "item"):
+                try:
+                    value = value.item()
+                except (RuntimeError, TypeError, ValueError):
+                    continue
+            if isinstance(value, bool) or not isinstance(value, Real):
+                continue
+            numeric = float(value)
+            if not math.isfinite(numeric):
+                continue
+            component = _metric_component(key)
+            sums[component] = sums.get(component, 0.0) + numeric
+            counts[component] = counts.get(component, 0) + 1
+
+    aggregate: Dict[str, int | float] = {}
+    for component, total in sums.items():
+        prefix = f"rollout/completion_admission_excluded_reward_{component}"
+        aggregate[f"{prefix}_sum"] = total
+        aggregate[f"{prefix}_count"] = counts[component]
+    return aggregate
+
+
+@dataclass(frozen=True)
+class CompletionAdmission:
+    """Resolved training admission for one completion group."""
+
+    explicit: bool
+    original_size: int
+    eligible_indices: List[int]
+    excluded_indices: List[int]
+    drop_reason_counts: Dict[str, int]
+    minimum_trainable_completions: int
+    group_excluded: bool
+
+    @property
+    def eligible_size(self) -> int:
+        return len(self.eligible_indices)
+
+    @property
+    def training_discarded_count(self) -> int:
+        if not self.explicit:
+            return 0
+        return self.original_size if self.group_excluded else len(self.excluded_indices)
+
+    def metrics(self) -> Dict[str, int]:
+        if not self.explicit:
+            return {}
+        metrics = {
+            "rollout/completion_admission_group_count": 1,
+            "rollout/completion_admission_original_count": self.original_size,
+            "rollout/completion_admission_eligible_count": self.eligible_size,
+            "rollout/completion_admission_excluded_count": len(self.excluded_indices),
+            "rollout/completion_admission_insufficient_group_count": int(
+                self.group_excluded
+            ),
+            "rollout/completion_admission_training_discarded_count": self.training_discarded_count,
+        }
+        for reason, count in self.drop_reason_counts.items():
+            metrics[f"rollout/completion_admission_reason_{reason}_count"] = count
+        return metrics
+
+
+def resolve_completion_admission(
+    payload: RLPayload,
+    minimum_trainable_completions: int,
+    *,
+    enabled: bool = True,
+) -> CompletionAdmission:
+    """Validate and resolve a producer-provided completion admission mask.
+
+    Admission is explicit only when ``enabled`` is true and a mask is present.
+    This distinction preserves the historical behavior for producers that do
+    not provide a mask, including one-completion groups.
+    """
+
+    if payload.completions is None:
+        raise ValueError("completion admission requires payload.completions")
+    original_size = len(payload.completions)
+    if minimum_trainable_completions < 1:
+        raise ValueError("minimum_trainable_completions must be at least 1")
+
+    # Validation and other admission-disabled paths ignore producer admission
+    # metadata completely. Stale training-only masks must not make validation
+    # fail before it can score every completion.
+    if not enabled:
+        return CompletionAdmission(
+            explicit=False,
+            original_size=original_size,
+            eligible_indices=list(range(original_size)),
+            excluded_indices=[],
+            drop_reason_counts={},
+            minimum_trainable_completions=minimum_trainable_completions,
+            group_excluded=False,
+        )
+
+    mask = payload.completion_trainable
+    reasons = payload.completion_drop_reasons
+
+    if mask is not None and len(mask) != original_size:
+        raise ValueError(
+            "completion_trainable must have the same length as completions: "
+            f"got {len(mask)} and {original_size}"
+        )
+    if reasons is not None and len(reasons) != original_size:
+        raise ValueError(
+            "completion_drop_reasons must have the same length as completions: "
+            f"got {len(reasons)} and {original_size}"
+        )
+
+    explicit = mask is not None
+    if not explicit:
+        return CompletionAdmission(
+            explicit=False,
+            original_size=original_size,
+            eligible_indices=list(range(original_size)),
+            excluded_indices=[],
+            drop_reason_counts={},
+            minimum_trainable_completions=minimum_trainable_completions,
+            group_excluded=False,
+        )
+
+    eligible_indices = [i for i, trainable in enumerate(mask) if trainable]
+    excluded_indices = [i for i, trainable in enumerate(mask) if not trainable]
+    reason_counts = Counter(
+        _metric_reason(reasons[i] if reasons is not None else None)
+        for i in excluded_indices
+    )
+    return CompletionAdmission(
+        explicit=True,
+        original_size=original_size,
+        eligible_indices=eligible_indices,
+        excluded_indices=excluded_indices,
+        drop_reason_counts=dict(reason_counts),
+        minimum_trainable_completions=minimum_trainable_completions,
+        group_excluded=len(eligible_indices) < minimum_trainable_completions,
+    )
+
+
+def select_completion_aligned_value(
+    value: Any,
+    indices: Sequence[int],
+    original_size: int,
+    field_name: str,
+) -> Any:
+    if value is None:
+        return None
+    try:
+        value_size = len(value)
+    except TypeError as exc:
+        raise ValueError(f"{field_name} must be completion-aligned") from exc
+    if value_size != original_size:
+        raise ValueError(
+            f"{field_name} must have the same length as completions: "
+            f"got {value_size} and {original_size}"
+        )
+    if isinstance(value, list):
+        return [value[i] for i in indices]
+    if isinstance(value, tuple):
+        return tuple(value[i] for i in indices)
+    try:
+        return value[list(indices)]
+    except (IndexError, TypeError):
+        return [value[i] for i in indices]
+
+
+def select_completion_aligned_mapping(
+    extra_info: Optional[Dict[str, Any]],
+    indices: Sequence[int],
+    original_size: int,
+) -> Optional[Dict[str, Any]]:
+    if extra_info is None:
+        return None
+    selected = {}
+    for key, value in extra_info.items():
+        is_aligned_sequence = (
+            isinstance(value, (list, tuple)) and len(value) == original_size
+        )
+        is_aligned_array = (
+            hasattr(value, "shape")
+            and len(value.shape) > 0
+            and value.shape[0] == original_size
+        )
+        selected[key] = (
+            select_completion_aligned_value(
+                value, indices, original_size, f"extra_info[{key!r}]"
+            )
+            if is_aligned_sequence or is_aligned_array
+            else value
+        )
+    return selected
+
+
+def select_rollout_result_completions(
+    result: RolloutResult, indices: Sequence[int]
+) -> RolloutResult:
+    """Select every completion-aligned rollout-result field identically."""
+
+    original_size = len(result.completions)
+    selected = result.model_copy(deep=False)
+    for field_name in _ROLLOUT_RESULT_COMPLETION_ALIGNED_FIELDS:
+        setattr(
+            selected,
+            field_name,
+            select_completion_aligned_value(
+                getattr(result, field_name), indices, original_size, field_name
+            ),
+        )
+    selected.extra_info = select_completion_aligned_mapping(
+        result.extra_info, indices, original_size
+    )
+    return selected
+
+
+def normalize_rollout_results(generated: Sequence[Any]) -> List[RolloutResult]:
+    """Accept the standard RolloutResult contract and legacy completion lists."""
+
+    from cosmos_rl.rollout.schema import RolloutResult
+
+    return [
+        result
+        if isinstance(result, RolloutResult)
+        else RolloutResult(completions=result)
+        for result in generated
+    ]
+
+
+def apply_rollout_result_to_payload(
+    payload: RLPayload,
+    result: RolloutResult,
+    *,
+    include_completed_conversations: bool,
+) -> RLPayload:
+    """Propagate producer output, including admission, into its payload."""
+
+    payload.completions = result.completions
+    payload.completion_trainable = result.completion_trainable
+    payload.completion_drop_reasons = result.completion_drop_reasons
+    payload.completion_logprobs = result.completion_logprobs
+    payload.completion_token_ids = result.completion_token_ids
+    payload.prompt_logprobs = result.prompt_logprobs
+    payload.prompt_token_ids = result.prompt_token_ids
+    payload.cumulative_logprob = result.cumulative_logprob
+    payload.extra_info = result.extra_info
+    if include_completed_conversations:
+        payload.completed_conversations = result.completed_conversations
+    return payload
+
+
+def select_payload_completions(
+    payload: RLPayload,
+    admission: CompletionAdmission,
+) -> RLPayload:
+    """Return the training payload selected by an admission decision.
+
+    An insufficient group intentionally selects no completions, including the
+    otherwise eligible ones, because the entire group is excluded.
+    """
+
+    selected = payload.model_copy(deep=False)
+    selected_indices = [] if admission.group_excluded else admission.eligible_indices
+    for field_name in _COMPLETION_ALIGNED_FIELDS:
+        setattr(
+            selected,
+            field_name,
+            select_completion_aligned_value(
+                getattr(payload, field_name),
+                selected_indices,
+                admission.original_size,
+                field_name,
+            ),
+        )
+    selected.extra_info = select_completion_aligned_mapping(
+        payload.extra_info, selected_indices, admission.original_size
+    )
+    # Admission has been consumed. Clearing the producer fields prevents an
+    # already-filtered payload from being interpreted as a new group later.
+    selected.completion_trainable = None
+    selected.completion_drop_reasons = None
+    selected.completion_admission_metrics = admission.metrics() or None
+    return selected
+
+
+def consume_completion_admission_metrics(
+    payloads: List[RLPayload],
+) -> tuple[List[RLPayload], Dict[str, int | float]]:
+    """Collect admission counters and remove metadata-only rejected groups."""
+
+    kept_payloads = []
+    aggregate: Dict[str, int | float] = {}
+    for payload in payloads:
+        metrics = payload.completion_admission_metrics
+        if metrics is None:
+            kept_payloads.append(payload)
+            continue
+        for key, value in metrics.items():
+            aggregate[key] = aggregate.get(key, 0) + value
+        payload.completion_admission_metrics = None
+        if metrics.get("rollout/completion_admission_insufficient_group_count", 0) == 0:
+            kept_payloads.append(payload)
+    return kept_payloads, aggregate
+
+
+def prepare_completion_admission_report(
+    metrics: Dict[str, int | float],
+    weight_version: int,
+    *,
+    report_id: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Add stable routing and deduplication metadata to admission metrics.
+
+    The returned dictionary is safe to reuse for an HTTP retry: its report ID
+    is created once here rather than by the controller.  A training discard is
+    carried in the same report so admission telemetry, in-flight settlement,
+    and same-weight replacement capacity share one idempotency boundary.
+    """
+
+    report: Dict[str, Any] = dict(metrics)
+    if not any(key.startswith(COMPLETION_ADMISSION_METRIC_PREFIX) for key in report):
+        return report
+
+    stable_report_id = report_id or uuid.uuid4().hex
+    report[COMPLETION_ADMISSION_REPORT_ID_KEY] = stable_report_id
+    report[COMPLETION_ADMISSION_WEIGHT_VERSION_KEY] = weight_version
+
+    discarded_count = report.get(
+        f"{COMPLETION_ADMISSION_METRIC_PREFIX}training_discarded_count", 0
+    )
+    if type(discarded_count) is int and discarded_count > 0:
+        report[DISCARDED_SAMPLES_KEY] = discarded_count
+        report[DISCARD_REPORT_ID_KEY] = stable_report_id
+        report[DISCARDED_WEIGHT_VERSION_KEY] = weight_version
+    return report

--- a/cosmos_rl/reward/base.py
+++ b/cosmos_rl/reward/base.py
@@ -13,10 +13,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import List
+from typing import Any, Dict, List, Optional
 from cosmos_rl.dispatcher.algo.base import RuleBasedAlgo
 from cosmos_rl.utils.logging import logger
 from cosmos_rl.dispatcher.data.schema import RLPayload, Rollout
+from cosmos_rl.reward.admission import (
+    CompletionAdmission,
+    resolve_completion_admission,
+)
 
 
 class RolloutGroup:
@@ -36,8 +40,16 @@ class RolloutGroup:
         self.payload: RLPayload = payload
         self.is_end: bool = is_end
         self.reference_answer: str = reference_answer
+        self.completion_admission: Optional[CompletionAdmission] = None
+        self.all_reward_metrics: List[Dict[str, Any]] = []
+        self.excluded_reward_metrics: Dict[int, Dict[str, Any]] = {}
 
-    def compute_rollouts(self, algo: RuleBasedAlgo) -> List[Rollout]:
+    def compute_rollouts(
+        self,
+        algo: RuleBasedAlgo,
+        *,
+        apply_completion_admission: bool = True,
+    ) -> List[Rollout]:
         """
         Compute rewards and advantages for the rollouts in the group.
         Args:
@@ -70,7 +82,52 @@ class RolloutGroup:
             "[RolloutGroup] The length of rewards, filter_rewards, reward_metrics should be the same as the length of completions"
         )
         logger.debug(f"[RolloutGroup] Rewards: {rewards}")
-        advantages = algo.compute_advantage([r for r in rewards[0]])
+
+        admission = resolve_completion_admission(
+            self.payload,
+            algo.minimum_trainable_completions,
+            enabled=apply_completion_admission,
+        )
+        self.completion_admission = admission
+        self.all_reward_metrics = rewards[2]
+        training_excluded_indices = (
+            range(admission.original_size)
+            if admission.group_excluded
+            else admission.excluded_indices
+        )
+        self.excluded_reward_metrics = {
+            idx: rewards[2][idx] for idx in training_excluded_indices
+        }
+
+        if admission.excluded_indices:
+            logger.debug(
+                "[CompletionAdmission] Excluding completions from prompt_idx=%s: "
+                "indices=%s reasons=%s reward_metrics=%s",
+                self.prompt_idx,
+                admission.excluded_indices,
+                admission.drop_reason_counts,
+                self.excluded_reward_metrics,
+            )
+
+        if admission.group_excluded:
+            logger.info(
+                "[CompletionAdmission] Excluding prompt_idx=%s group from training: "
+                "original_size=%d eligible_size=%d minimum=%d excluded=%d reasons=%s",
+                self.prompt_idx,
+                admission.original_size,
+                admission.eligible_size,
+                admission.minimum_trainable_completions,
+                len(admission.excluded_indices),
+                admission.drop_reason_counts,
+            )
+            return []
+
+        eligible_rewards = [rewards[0][i] for i in admission.eligible_indices]
+        advantages = algo.compute_advantage(eligible_rewards)
+        assert len(advantages) == admission.eligible_size, (
+            "[RolloutGroup] The length of advantages should be the same as the "
+            "number of admitted completions"
+        )
         logger.debug(f"[RolloutGroup] Advantages: {advantages}")
 
         if self.payload.cumulative_logprob is not None:
@@ -92,9 +149,10 @@ class RolloutGroup:
                     best_reward = reward
                     best_cumulative_logprob = self.payload.cumulative_logprob[i]
             if best_reward is not None:
-                # Only assign the best reward to the first rollout in the group
-                rewards[2][0]["most_likely_mode_reward_mean"] = best_reward
-                rewards[2][0]["most_likely_mode_reward_count"] = 1
+                # Only assign the best reward to the first admitted rollout in the group.
+                first_eligible = admission.eligible_indices[0]
+                rewards[2][first_eligible]["most_likely_mode_reward_mean"] = best_reward
+                rewards[2][first_eligible]["most_likely_mode_reward_count"] = 1
 
         # If the completed_conversations is not provided, we use None for all the rollouts
         if self.payload.completed_conversations is not None:
@@ -112,32 +170,25 @@ class RolloutGroup:
                 [] for _ in range(len(self.payload.completions))
             ]
 
-        return [
-            Rollout(
-                prompt=self.payload.prompt,
-                conversation=self.payload.conversation,
-                completion=completion,
-                completed_conversation=completed_conversation,
-                is_end=self.is_end,
-                reward=reward,
-                advantage=advantage,
-                prompt_idx=self.payload.prompt_idx,
-                filter_reward=filter_reward,
-                completion_logprobs=logprobs,
-                completion_token_ids=token_ids,
-                report_metrics=reward_metrics,
+        rollouts = []
+        for index, advantage in zip(admission.eligible_indices, advantages):
+            rollouts.append(
+                Rollout(
+                    prompt=self.payload.prompt,
+                    conversation=self.payload.conversation,
+                    completion=self.payload.completions[index],
+                    completed_conversation=completed_conversations[index],
+                    is_end=self.is_end,
+                    reward=rewards[0][index],
+                    advantage=advantage,
+                    prompt_idx=self.payload.prompt_idx,
+                    filter_reward=rewards[1][index],
+                    completion_logprobs=self.payload.completion_logprobs[index],
+                    completion_token_ids=self.payload.completion_token_ids[index],
+                    report_metrics=rewards[2][index],
+                )
             )
-            for completion, completed_conversation, reward, filter_reward, reward_metrics, advantage, logprobs, token_ids in zip(
-                self.payload.completions,
-                completed_conversations,
-                rewards[0],
-                rewards[1],
-                rewards[2],
-                advantages,
-                self.payload.completion_logprobs,
-                self.payload.completion_token_ids,
-            )
-        ]
+        return rollouts
 
 
 class BatchedRolloutGroup:

--- a/cosmos_rl/reward/dispatcher.py
+++ b/cosmos_rl/reward/dispatcher.py
@@ -18,8 +18,13 @@ from typing import List, Optional, Callable, Tuple
 from concurrent.futures import Future, ProcessPoolExecutor, ThreadPoolExecutor
 
 from cosmos_rl.dispatcher.data.schema import RLPayload
+from cosmos_rl.dispatcher.algo.base import REGISTERED_ALGOs
 from cosmos_rl.dispatcher.data.packer import BaseDataPacker
 from cosmos_rl.policy.config import Config
+from cosmos_rl.reward.admission import (
+    resolve_completion_admission,
+    select_payload_completions,
+)
 from cosmos_rl.reward.remote_calculator import RemoteRewardCalculator
 from cosmos_rl.reward.local_calculator import LocalRewardCalculator
 
@@ -58,6 +63,9 @@ class RewardDispatcher:
         """
 
         self.is_remote = config.train.train_policy.use_remote_reward
+        self.minimum_trainable_completions = REGISTERED_ALGOs[
+            config.train.train_policy.algo
+        ].minimum_trainable_completions
         if self.is_remote:
             self.remote_batch_size = config.train.train_policy.remote_reward.batch_size
 
@@ -151,7 +159,10 @@ class RewardDispatcher:
         if bypass_reward:
             for i in range(0, len(payloads), self.payload_per_task):
                 # Directly return the payloads with zero rewards and advantages
-                for payload in payloads[i : i + self.payload_per_task]:
+                for payload_idx in range(
+                    i, min(i + self.payload_per_task, len(payloads))
+                ):
+                    payload = payloads[payload_idx]
                     payload.rewards = [0.0 for _ in payload.completions]
                     payload.advantages = [0.0 for _ in payload.completions]
                     payload.filter_rewards = [0.0 for _ in payload.completions]
@@ -172,6 +183,16 @@ class RewardDispatcher:
                         payload.n_ignore_prefix_tokens = [
                             0 for _ in payload.completions
                         ]
+                    admission = resolve_completion_admission(
+                        payload,
+                        self.minimum_trainable_completions,
+                        enabled=not is_validation,
+                    )
+                    payloads[payload_idx] = select_payload_completions(
+                        payload, admission
+                    )
+                    if admission.group_excluded:
+                        payloads[payload_idx].valid = False
                 self.task_queue.put(
                     (
                         payloads[i : i + self.payload_per_task],

--- a/cosmos_rl/reward/local_calculator.py
+++ b/cosmos_rl/reward/local_calculator.py
@@ -21,7 +21,59 @@ from cosmos_rl.dispatcher.algo.reward import Reward
 from cosmos_rl.dispatcher.data.packer import BaseDataPacker
 from cosmos_rl.policy.config import Config
 from cosmos_rl.reward.base import RolloutGroup
+from cosmos_rl.reward.admission import (
+    aggregate_excluded_reward_metrics,
+    select_payload_completions,
+)
 import cosmos_rl.utils.util as util
+
+
+def _training_payload_from_rollouts(
+    source_payload: RLPayload,
+    rollout_group: RolloutGroup,
+    rollouts: List[Rollout],
+    *,
+    valid: bool,
+) -> RLPayload:
+    admission = rollout_group.completion_admission
+    assert admission is not None
+    selected = select_payload_completions(source_payload, admission)
+    if not admission.explicit:
+        # Preserve the historical local-reward payload shape when no producer
+        # opts into admission. The old reconstruction did not forward extra_info.
+        selected.extra_info = None
+    selected.reference_answer = None
+    selected.valid = valid
+    selected.completions = [rollout.completion for rollout in rollouts]
+    selected.completed_conversations = [
+        rollout.completed_conversation for rollout in rollouts
+    ]
+    selected.n_ignore_prefix_tokens = [
+        rollout.n_ignore_prefix_tokens for rollout in rollouts
+    ]
+    selected.rewards = [rollout.reward for rollout in rollouts]
+    selected.filter_rewards = [rollout.filter_reward for rollout in rollouts]
+    selected.advantages = [rollout.advantage for rollout in rollouts]
+    selected.completion_logprobs = [
+        rollout.completion_logprobs if rollout.completion_logprobs is not None else []
+        for rollout in rollouts
+    ]
+    selected.completion_token_ids = [
+        rollout.completion_token_ids if rollout.completion_token_ids is not None else []
+        for rollout in rollouts
+    ]
+    selected.report_metrics = [
+        rollout.report_metrics if rollout.report_metrics is not None else {}
+        for rollout in rollouts
+    ]
+    excluded_reward_metrics = aggregate_excluded_reward_metrics(
+        rollout_group.excluded_reward_metrics.values()
+    )
+    if excluded_reward_metrics:
+        if selected.completion_admission_metrics is None:
+            selected.completion_admission_metrics = {}
+        selected.completion_admission_metrics.update(excluded_reward_metrics)
+    return selected
 
 
 class LocalRewardCalculator:
@@ -139,7 +191,9 @@ class LocalRewardCalculator:
         ]
 
         rollouts_list: List[List[Rollout]] = [
-            rollout_group.compute_rollouts(self.val_rl_algo)
+            rollout_group.compute_rollouts(
+                self.val_rl_algo, apply_completion_admission=False
+            )
             for rollout_group in rollout_groups
         ]
         payload_list: List[RLPayload] = []
@@ -224,6 +278,14 @@ class LocalRewardCalculator:
         payload_list: List[RLPayload] = []
         # Dynamic Sampling: Filter out the rollouts that the rewards are all the same
         for idx, rollouts_group in enumerate(rollouts_list):
+            rollout_group = rollout_groups[idx]
+            if not rollouts_group:
+                payload_list.append(
+                    _training_payload_from_rollouts(
+                        payloads[idx], rollout_group, [], valid=False
+                    )
+                )
+                continue
             if self.config.train.non_text:
                 rollout_tokens = []
             else:
@@ -268,93 +330,15 @@ class LocalRewardCalculator:
                                 ].n_ignore_prefix_tokens = n_ignore_prefix_tokens
 
                 payload_list.append(
-                    RLPayload(
-                        prompt=rollouts_group[0].prompt,
-                        prompt_idx=rollouts_group[0].prompt_idx,
-                        conversation=rollouts_group[0].conversation,
-                        completions=[rollout.completion for rollout in rollouts_group],
-                        completed_conversations=[
-                            rollout.completed_conversation for rollout in rollouts_group
-                        ],
-                        reference_answer=None,
-                        n_ignore_prefix_tokens=[
-                            rollout.n_ignore_prefix_tokens for rollout in rollouts_group
-                        ],
-                        rewards=[rollout.reward for rollout in rollouts_group],
-                        filter_rewards=[
-                            rollout.filter_reward for rollout in rollouts_group
-                        ],
-                        advantages=[rollout.advantage for rollout in rollouts_group],
-                        valid=True,
-                        completion_logprobs=[
-                            rollout.completion_logprobs
-                            if rollout.completion_logprobs is not None
-                            else []
-                            for rollout in rollouts_group
-                        ],
-                        completion_token_ids=[
-                            rollout.completion_token_ids
-                            if rollout.completion_token_ids is not None
-                            else []
-                            for rollout in rollouts_group
-                        ],
-                        weight_version=payloads[idx].weight_version,
-                        report_metrics=[
-                            rollout.report_metrics
-                            if rollout.report_metrics is not None
-                            else {}
-                            for rollout in rollouts_group
-                        ],
-                        cumulative_logprob=payloads[idx].cumulative_logprob,
-                        teacher_result_uuids=payloads[idx].teacher_result_uuids,
-                        prompt_logprobs=payloads[idx].prompt_logprobs,
-                        prompt_token_ids=payloads[idx].prompt_token_ids,
+                    _training_payload_from_rollouts(
+                        payloads[idx], rollout_group, rollouts_group, valid=True
                     )
                 )
             else:
                 # If the rewards are all the same, we need to sample one rollout from the group
                 payload_list.append(
-                    RLPayload(
-                        prompt=rollouts_group[0].prompt,
-                        prompt_idx=rollouts_group[0].prompt_idx,
-                        conversation=rollouts_group[0].conversation,
-                        completions=[rollout.completion for rollout in rollouts_group],
-                        completed_conversations=[
-                            rollout.completed_conversation for rollout in rollouts_group
-                        ],
-                        reference_answer=None,
-                        n_ignore_prefix_tokens=[
-                            rollout.n_ignore_prefix_tokens for rollout in rollouts_group
-                        ],
-                        rewards=[rollout.reward for rollout in rollouts_group],
-                        filter_rewards=[
-                            rollout.filter_reward for rollout in rollouts_group
-                        ],
-                        advantages=[rollout.advantage for rollout in rollouts_group],
-                        valid=False,
-                        completion_logprobs=[
-                            rollout.completion_logprobs
-                            if rollout.completion_logprobs is not None
-                            else []
-                            for rollout in rollouts_group
-                        ],
-                        completion_token_ids=[
-                            rollout.completion_token_ids
-                            if rollout.completion_token_ids is not None
-                            else []
-                            for rollout in rollouts_group
-                        ],
-                        weight_version=payloads[idx].weight_version,
-                        report_metrics=[
-                            rollout.report_metrics
-                            if rollout.report_metrics is not None
-                            else {}
-                            for rollout in rollouts_group
-                        ],
-                        cumulative_logprob=payloads[idx].cumulative_logprob,
-                        teacher_result_uuids=payloads[idx].teacher_result_uuids,
-                        prompt_logprobs=payloads[idx].prompt_logprobs,
-                        prompt_token_ids=payloads[idx].prompt_token_ids,
+                    _training_payload_from_rollouts(
+                        payloads[idx], rollout_group, rollouts_group, valid=False
                     )
                 )
         return payload_list, False, step

--- a/cosmos_rl/reward/remote_calculator.py
+++ b/cosmos_rl/reward/remote_calculator.py
@@ -25,8 +25,14 @@ from typing import List, Optional, Callable, Tuple
 import torch
 
 from cosmos_rl.dispatcher.data.schema import RLPayload
+from cosmos_rl.dispatcher.algo.base import REGISTERED_ALGOs
 from cosmos_rl.dispatcher.data.packer import BaseDataPacker
 from cosmos_rl.policy.config import Config
+from cosmos_rl.reward.admission import (
+    aggregate_excluded_reward_metrics,
+    resolve_completion_admission,
+    select_payload_completions,
+)
 from cosmos_rl.utils.logging import logger
 from cosmos_rl.utils.network_util import make_request_with_retry
 
@@ -72,6 +78,12 @@ class RemoteRewardCalculator:
             return
         self.train_config = config.train.train_policy.remote_reward
         self.val_config = config.validation.remote_reward
+        self.rl_algo = REGISTERED_ALGOs[config.train.train_policy.algo](
+            reward_fn=None,
+            unbiased=config.train.train_policy.unbiased_advantage,
+            config=config,
+        )
+        self.minimum_trainable_completions = self.rl_algo.minimum_trainable_completions
         # We use wan2pt1 VAE tokenizer to encode the images/videos into latents.
         try:
             self.tokenizer = Wan2pt1VAEInterface(
@@ -417,20 +429,84 @@ class RemoteRewardCalculator:
         payload_list: List[RLPayload] = []
         for i, payload in enumerate(valid_payloads):
             rewards = valid_results[i]
-            # Compute advantages (normalize rewards)
-            advantages = (rewards - rewards.mean()) / (rewards.std() + 1e-4)
-            # Handle NaN advantages
-            if torch.isnan(advantages).any():
-                advantages = torch.zeros_like(advantages)
-            # Create a new RLPayload with the reward
-            new_payload = RLPayload(
-                prompt=payload.prompt,
-                prompt_idx=payload.prompt_idx,
-                completions=payload.completions,
-                rewards=rewards.tolist(),
-                advantages=advantages.tolist(),
-                extra_info=payload.extra_info,
+            admission = resolve_completion_admission(
+                payload,
+                self.minimum_trainable_completions,
+                enabled=not is_validation,
             )
-            payload_list.append(new_payload)
+            if admission.explicit:
+                selected_payload = select_payload_completions(payload, admission)
+                training_excluded_indices = (
+                    range(admission.original_size)
+                    if admission.group_excluded
+                    else admission.excluded_indices
+                )
+                excluded_reward_metrics = aggregate_excluded_reward_metrics(
+                    {"reward": rewards[index].item()}
+                    for index in training_excluded_indices
+                )
+                if excluded_reward_metrics:
+                    if selected_payload.completion_admission_metrics is None:
+                        selected_payload.completion_admission_metrics = {}
+                    selected_payload.completion_admission_metrics.update(
+                        excluded_reward_metrics
+                    )
+            else:
+                # Keep the pre-admission remote-reward output contract exact for
+                # producers that do not opt into the new fields.
+                selected_payload = RLPayload(
+                    prompt=payload.prompt,
+                    prompt_idx=payload.prompt_idx,
+                    completions=payload.completions,
+                    extra_info=payload.extra_info,
+                )
+            if admission.excluded_indices:
+                logger.debug(
+                    "[CompletionAdmission] Excluding remote-reward completions "
+                    "from prompt_idx=%s: indices=%s reasons=%s rewards=%s",
+                    payload.prompt_idx,
+                    admission.excluded_indices,
+                    admission.drop_reason_counts,
+                    rewards[admission.excluded_indices].tolist(),
+                )
+            if admission.group_excluded:
+                selected_payload.rewards = []
+                selected_payload.advantages = []
+                selected_payload.filter_rewards = []
+                selected_payload.report_metrics = []
+                selected_payload.valid = False
+                payload_list.append(selected_payload)
+                logger.info(
+                    "[CompletionAdmission] Excluding remote-reward prompt_idx=%s "
+                    "group from training: original_size=%d eligible_size=%d "
+                    "minimum=%d excluded=%d reasons=%s",
+                    payload.prompt_idx,
+                    admission.original_size,
+                    admission.eligible_size,
+                    admission.minimum_trainable_completions,
+                    len(admission.excluded_indices),
+                    admission.drop_reason_counts,
+                )
+                continue
+
+            if admission.explicit:
+                rewards = rewards[admission.eligible_indices]
+                advantages = self.rl_algo.compute_advantage(rewards.tolist())
+                assert len(advantages) == len(rewards), (
+                    "[RemoteRewardCalculator] The length of advantages should be "
+                    "the same as the number of admitted completions"
+                )
+            else:
+                # Preserve the historical remote-reward contract when a
+                # producer does not opt into admission (and during validation).
+                # Explicit admission uses the selected algorithm above.
+                legacy_advantages = (rewards - rewards.mean()) / (rewards.std() + 1e-4)
+                if torch.isnan(legacy_advantages).any():
+                    legacy_advantages = torch.zeros_like(legacy_advantages)
+                advantages = legacy_advantages.tolist()
+            # Create a new RLPayload with the reward
+            selected_payload.rewards = rewards.tolist()
+            selected_payload.advantages = list(advantages)
+            payload_list.append(selected_payload)
 
         return payload_list, is_validation, step

--- a/cosmos_rl/rollout/schema.py
+++ b/cosmos_rl/rollout/schema.py
@@ -35,6 +35,14 @@ class RolloutResult(BaseModel):
     # The generated conversation history for the prompt.
     completed_conversations: Optional[List[ConversationType]] = None
 
+    # Whether each completion may be used for training.  None preserves the
+    # historical behavior and admits every completion.
+    completion_trainable: Optional[List[bool]] = None
+
+    # Optional stable, machine-readable producer reason for excluding each
+    # completion. Unknown reason values are grouped under "other" in metrics.
+    completion_drop_reasons: Optional[List[Optional[str]]] = None
+
     # The logprobs of the generated completions consider top_k tokens
     completion_logprobs: Optional[List[List[List[float]]]] = None
 

--- a/cosmos_rl/rollout/trtllm_rollout/trtllm_rollout.py
+++ b/cosmos_rl/rollout/trtllm_rollout/trtllm_rollout.py
@@ -40,6 +40,7 @@ from transformers import GenerationConfig
 from cosmos_rl.dispatcher.data.schema import (
     RLPayload,
 )
+from cosmos_rl.rollout.schema import RolloutResult
 
 
 class TRTLLM_Rollout(RolloutBase):
@@ -129,7 +130,7 @@ class TRTLLM_Rollout(RolloutBase):
         data_packer: BaseDataPacker,
         data_fetcher: DataFetcherBase,
         sampling_params: SamplingParams,
-    ) -> List[List[str]]:
+    ) -> List[RolloutResult]:
         if not self._engine_initialized:
             raise RuntimeError(
                 "[Rollout] Engine is not initialized, please call init_engine first."
@@ -154,7 +155,7 @@ class TRTLLM_Rollout(RolloutBase):
         #   [completion_str, completion_str, ...],
         #   ...
         # ]
-        response: List[List[str]] = []
+        response: List[RolloutResult] = []
         try:
             results = self.rollout_engine.generate(
                 prompts,
@@ -164,7 +165,11 @@ class TRTLLM_Rollout(RolloutBase):
 
             for output in results:
                 response.append(
-                    [output.outputs[i].text for i in range(len(output.outputs))]
+                    RolloutResult(
+                        completions=[
+                            output.outputs[i].text for i in range(len(output.outputs))
+                        ]
+                    )
                 )
         except Exception as e:
             logger.error(f"[Rollout] Failed in rollout generation: {str(e)}")

--- a/cosmos_rl/rollout/trtllm_rollout/trtllm_rollout_wrapper.py
+++ b/cosmos_rl/rollout/trtllm_rollout/trtllm_rollout_wrapper.py
@@ -56,6 +56,14 @@ from cosmos_rl.dispatcher.data.schema import (
     RLPayload,
 )
 from cosmos_rl.reward.dispatcher import RewardDispatcher
+from cosmos_rl.reward.admission import (
+    apply_rollout_result_to_payload,
+    consume_completion_admission_metrics,
+    normalize_rollout_results,
+    prepare_completion_admission_report,
+    select_rollout_result_completions,
+)
+from cosmos_rl.rollout.schema import RolloutResult
 from cosmos_rl.dispatcher.data.packer.base import BaseDataPacker
 from cosmos_rl.dispatcher.data.data_fetcher import WorkerDataFetcher
 
@@ -198,6 +206,8 @@ class TRTLLMRolloutWrapper(TRTLLMRolloutWorkerBase):
             if payloads is not None:
                 if is_validation:
                     break
+                payloads, metadata = consume_completion_admission_metrics(payloads)
+                metadata = prepare_completion_admission_report(metadata, step)
                 for i in range(len(payloads)):
                     (
                         payloads[i].completions,
@@ -218,6 +228,7 @@ class TRTLLMRolloutWrapper(TRTLLMRolloutWorkerBase):
                 response = RolloutRequest(
                     src_replica_name=self.replica_name,
                     payloads=payloads,
+                    metrics=metadata,
                     is_end=False,
                 )
                 self.api_client.post_rollout_completion(response)
@@ -316,24 +327,29 @@ class TRTLLMRolloutWrapper(TRTLLMRolloutWorkerBase):
 
                     if not validation_queue.empty():
                         payloads_list: List[RLPayload] = validation_queue.get()
-                        completions: List[List[str]] = self.rollout.rollout_generation(
+                        generated = self.rollout.rollout_generation(
                             payloads=payloads_list,
                             data_packer=self.val_data_packer,
                             data_fetcher=self.data_fetcher,
                             sampling_params=self.val_sampling_params,
                         )
-                        if completions:
+                        results = normalize_rollout_results(generated)
+                        if results:
                             prompt_payloads.extend(payloads_list)
-                            validation_results.extend(completions)
+                            validation_results.extend(results)
 
                     if is_end:
                         break
 
                     validation_payloads = []
-                    for old_payload, completions in zip(
-                        prompt_payloads, validation_results
-                    ):
-                        old_payload.completions = completions
+                    for old_payload, result in zip(prompt_payloads, validation_results):
+                        apply_rollout_result_to_payload(
+                            old_payload,
+                            result,
+                            include_completed_conversations=(
+                                result.completed_conversations is not None
+                            ),
+                        )
                         validation_payloads.append(old_payload)
 
                     self.reward_dispatcher.enqueue_rewards_cal(
@@ -398,43 +414,50 @@ class TRTLLMRolloutWrapper(TRTLLMRolloutWorkerBase):
                 payloads: List[RLPayload] = self._prompt_queue.get()
                 logger.debug(f"[Rollout] generate start for prompts: {payloads}")
 
-                completions: List[List[str]] = self.rollout.rollout_generation(
+                generated = self.rollout.rollout_generation(
                     payloads=payloads,
                     data_packer=self.data_packer,
                     data_fetcher=self.data_fetcher,
                     sampling_params=self.sampling_params,
                 )
 
-                logger.debug(
-                    f"[Rollout] completions[-1][-1] of {len(completions[-1])} completions from trtllm: {completions[-1][-1]}"
-                )
+                rollout_results = normalize_rollout_results(generated)
+                if rollout_results and rollout_results[-1].completions:
+                    logger.debug(
+                        "[Rollout] completions[-1][-1] of %d completions from "
+                        "trtllm: %s",
+                        len(rollout_results[-1].completions),
+                        rollout_results[-1].completions[-1],
+                    )
 
-                # Remove empty completions
-                valid_completions: List[List[str]] = []
+                # Remove empty completions while preserving every producer field
+                # aligned with the same completion indices.  TRT-LLM's built-in
+                # producer returns RolloutResult, while accepting the historical
+                # List[List[str]] shape keeps custom backends backward compatible.
+                valid_results: List[RolloutResult] = []
                 prompt_indices_to_remove: List[int] = []
-                if len(completions):
+                if rollout_results:
                     batch_size = len(payloads)
+                    if len(rollout_results) != batch_size:
+                        raise ValueError(
+                            "[Rollout] TRT-LLM must return one result per prompt: "
+                            f"got {len(rollout_results)} results for {batch_size} prompts"
+                        )
                     for i in range(batch_size):
-                        completion = completions[i]
-                        skip_output = False
-                        total_generation_count = len(completion)
-                        empty_generation_count = 0
-                        output_texts = []
-                        for j in range(total_generation_count):
-                            output_text = completion[j]
+                        result = rollout_results[i]
+                        valid_indices = []
+                        for j, output_text in enumerate(result.completions):
                             if output_text == "":
                                 logger.warning(
                                     f"[Rollout] Got empty completion for {i}th prompt {j}th generation"
                                 )
-                                empty_generation_count += 1
                             else:
-                                output_texts.append(output_text)
+                                valid_indices.append(j)
                         # Skip the output if there is one or zero non-empty completions
-                        skip_output = (
-                            total_generation_count - empty_generation_count
-                        ) <= 1
-                        if not skip_output:
-                            valid_completions.append(output_texts)
+                        if len(valid_indices) > 1:
+                            valid_results.append(
+                                select_rollout_result_completions(result, valid_indices)
+                            )
                         else:
                             prompt_indices_to_remove.append(i)
                 if len(prompt_indices_to_remove):
@@ -443,19 +466,25 @@ class TRTLLMRolloutWrapper(TRTLLMRolloutWorkerBase):
                         for i, payload in enumerate(payloads)
                         if i not in prompt_indices_to_remove
                     ]
-                    assert len(payloads) == len(valid_completions), (
-                        "[Rollout] len(prompts) must be the same as len(valid_completions) after removing empty completions"
+                    assert len(payloads) == len(valid_results), (
+                        "[Rollout] len(prompts) must be the same as len(valid_results) after removing empty completions"
                     )
 
                 logger.debug("[Rollout] generate end!")
 
-                should_report = len(valid_completions) > 0
+                should_report = len(valid_results) > 0
 
                 if should_report:
                     # only the first tp rank in the rollout replica will post the completion to the controller.
                     valid_payloads = []
-                    for old_payload, completions in zip(payloads, valid_completions):
-                        old_payload.completions = completions
+                    for old_payload, result in zip(payloads, valid_results):
+                        apply_rollout_result_to_payload(
+                            old_payload,
+                            result,
+                            include_completed_conversations=(
+                                result.completed_conversations is not None
+                            ),
+                        )
                         valid_payloads.append(old_payload)
 
                     self.reward_dispatcher.enqueue_rewards_cal(

--- a/cosmos_rl/rollout/worker/rollout_control.py
+++ b/cosmos_rl/rollout/worker/rollout_control.py
@@ -64,10 +64,7 @@ from cosmos_rl.dispatcher.data.packer.base import BaseDataPacker
 import cosmos_rl.utils.distributed as dist_util
 import cosmos_rl.utils.util as util
 from cosmos_rl.utils import constant
-from cosmos_rl.dispatcher.data.schema import (
-    RLPayload,
-    ConversationType,
-)
+from cosmos_rl.dispatcher.data.schema import RLPayload
 from cosmos_rl.rollout.worker.asynchronous.rollout_task_scheduler import (
     RolloutTaskScheduler,
     RolloutTask,
@@ -75,6 +72,13 @@ from cosmos_rl.rollout.worker.asynchronous.rollout_task_scheduler import (
 )
 from cosmos_rl.rollout.schema import RolloutResult
 from cosmos_rl.reward.dispatcher import RewardDispatcher
+from cosmos_rl.reward.admission import (
+    apply_rollout_result_to_payload,
+    consume_completion_admission_metrics,
+    DISCARDED_WEIGHT_VERSION_KEY,
+    prepare_completion_admission_report,
+    select_rollout_result_completions,
+)
 from cosmos_rl.dispatcher.data.data_fetcher import WorkerDataFetcher
 from cosmos_rl.collective.collective import P2RCollectiveManager
 from cosmos_rl.rollout.worker.weight_sync import (
@@ -88,6 +92,7 @@ from cosmos_rl.rollout.worker.weight_sync import (
     do_nccl_broadcast_tensors,
     install_inference_sync,
 )
+
 
 """
 Keep in mind that torch distributed is not thread safe. So try to keep the usage in the same thread.
@@ -1178,6 +1183,8 @@ class DisaggregatedRolloutControlWorker(RolloutWorkerBase):
             if rollout_results:
                 for p, rr in zip(payloads_list, rollout_results):
                     p.completions = rr.completions
+                    p.completion_trainable = rr.completion_trainable
+                    p.completion_drop_reasons = rr.completion_drop_reasons
                     p.completion_logprobs = rr.completion_logprobs
                     p.completion_token_ids = rr.completion_token_ids
                     p.prompt_logprobs = rr.prompt_logprobs
@@ -2021,7 +2028,11 @@ class DisaggregatedRolloutControlWorker(RolloutWorkerBase):
                 if is_validation:
                     break
 
-                metadata = {}
+                payloads, metadata = consume_completion_admission_metrics(payloads)
+                metadata = prepare_completion_admission_report(
+                    metadata,
+                    step,
+                )
                 if self.config.train.train_policy.variant == "dapo":
                     payloads, metadata_from_dapo = self.dynamic_sampling(payloads)
                     metadata.update(metadata_from_dapo)
@@ -2397,11 +2408,15 @@ class DisaggregatedRolloutControlWorker(RolloutWorkerBase):
                         self.send_end_signal()
         logger.info(f"[Rollout] Main loop of {self.replica_name} finished")
 
-    def _report_discarded_samples(self, count: int) -> None:
+    def _report_discarded_samples(
+        self, count: int, weight_version: Optional[int] = None
+    ) -> None:
         """Report fetched samples that terminated without trainable results."""
         if count <= 0 or not self.should_report:
             return
 
+        if weight_version is None:
+            weight_version = self.current_weight_version
         report_id = uuid.uuid4().hex
         response = RolloutRequest(
             src_replica_name=self.replica_name,
@@ -2410,6 +2425,7 @@ class DisaggregatedRolloutControlWorker(RolloutWorkerBase):
             metrics={
                 "discarded_samples": count,
                 "discard_report_id": report_id,
+                DISCARDED_WEIGHT_VERSION_KEY: weight_version,
             },
             is_end=False,
         )
@@ -2431,27 +2447,50 @@ class DisaggregatedRolloutControlWorker(RolloutWorkerBase):
         # we need filter the result with valid completions or valid completed_conversations
         valid_result: List[RolloutResult] = []
         valid_payloads_list: List[RLPayload] = []
+        partially_discarded_samples: Optional[int] = None
         if self.config.train.non_text:
             for payload, rr in zip(payloads_list, rollout_results):
                 if rr.completions is not None and len(rr.completions) > 0:
                     valid_result.append(rr)
                     valid_payloads_list.append(payload)
         elif self.config.rollout.multi_turn_config.enable:
+            partially_discarded_samples = 0
             for payload, rr in zip(payloads_list, rollout_results):
-                valid_conversations: List[ConversationType] = []
-                # remove those result without valid assistant message
-                flag = False
-                for conversation in rr.completed_conversations:
-                    for msg in conversation:
-                        if msg.role == "assistant" and msg.content != "":
-                            flag = True
-                            break
-                    if flag:
-                        valid_conversations.append(conversation)
-                rr.completed_conversations = valid_conversations
-                if len(rr.completed_conversations) > 0:
-                    valid_result.append(rr)
-                    valid_payloads_list.append(payload)
+                original_size = len(rr.completions)
+                conversations = rr.completed_conversations or []
+                if len(conversations) != original_size:
+                    logger.warning(
+                        "[Rollout] Discarding misaligned multi-turn result: "
+                        "completions=%d completed_conversations=%d",
+                        original_size,
+                        len(conversations),
+                    )
+                    partially_discarded_samples += original_size
+                    continue
+
+                valid_indices = [
+                    index
+                    for index, conversation in enumerate(conversations)
+                    if any(
+                        msg.role == "assistant" and msg.content != ""
+                        for msg in conversation
+                    )
+                ]
+                partially_discarded_samples += original_size - len(valid_indices)
+                if not valid_indices:
+                    continue
+                try:
+                    selected_result = select_rollout_result_completions(
+                        rr, valid_indices
+                    )
+                except ValueError as exc:
+                    logger.warning(
+                        "[Rollout] Discarding malformed multi-turn result: %s", exc
+                    )
+                    partially_discarded_samples += len(valid_indices)
+                    continue
+                valid_result.append(selected_result)
+                valid_payloads_list.append(payload)
         else:
             # Remove empty completions
             for payload, rr in zip(payloads_list, rollout_results):
@@ -2486,7 +2525,9 @@ class DisaggregatedRolloutControlWorker(RolloutWorkerBase):
                     valid_payloads_list.append(payload)
 
         self._report_discarded_samples(
-            (len(payloads_list) - len(valid_payloads_list))
+            partially_discarded_samples
+            if partially_discarded_samples is not None
+            else (len(payloads_list) - len(valid_payloads_list))
             * self.config.rollout.n_generation
         )
 
@@ -2495,17 +2536,14 @@ class DisaggregatedRolloutControlWorker(RolloutWorkerBase):
             valid_payloads: List[RLPayload] = []
             # only the first tp rank in the rollout replica will post the completion to the controller.
             for old_payload, result in zip(valid_payloads_list, valid_result):
-                # update payload
-                old_payload.completions = result.completions
-                old_payload.completion_logprobs = result.completion_logprobs
-                old_payload.completion_token_ids = result.completion_token_ids
-                old_payload.prompt_logprobs = result.prompt_logprobs
-                old_payload.prompt_token_ids = result.prompt_token_ids
+                apply_rollout_result_to_payload(
+                    old_payload,
+                    result,
+                    include_completed_conversations=(
+                        self.config.rollout.multi_turn_config.enable
+                    ),
+                )
                 old_payload.weight_version = self.current_weight_version
-                old_payload.cumulative_logprob = result.cumulative_logprob
-                old_payload.extra_info = result.extra_info
-                if self.config.rollout.multi_turn_config.enable:
-                    old_payload.completed_conversations = result.completed_conversations
                 if self.config.train.local_dataset:
                     old_payload.reference_answer = (
                         self.data_fetcher.query_reference_answer(

--- a/cosmos_rl/tools/slurm/README.md
+++ b/cosmos_rl/tools/slurm/README.md
@@ -272,7 +272,9 @@ baked-in code/tests with a working-tree checkout (mounted at `/opt/cosmos-rl`
 and put on `PYTHONPATH`), so you can iterate on code/tests and re-run CI without
 rebuilding the image. Logs land under `<output-root>/cosmos_ci_<timestamp>/slurm/`
 (`slurm_<jobid>.log` plus a `run_<jobid>/run_test.log` with the per-test
-PASS/FAIL summary).
+PASS/FAIL summary). Because `cosmos_rl/_version.py` is generated and ignored,
+mount mode copies that module from the installed package when the checkout does
+not already contain it, before the checkout is added to `PYTHONPATH`.
 
 Use `--dry-run` to print the exact `sbatch` command without submitting.
 

--- a/cosmos_rl/tools/slurm/cosmos_rl_ci_job.sh
+++ b/cosmos_rl/tools/slurm/cosmos_rl_ci_job.sh
@@ -283,9 +283,40 @@ srun \
 
     python -c "import cosmos_rl; print(f\"cosmos_rl location: {cosmos_rl.__file__}\"); print(f\"cosmos_rl version: {cosmos_rl.__version__}\")" 2>/dev/null || true
 
+    materialize_mounted_version_module() {
+        local repo_root="$1"
+        local target="${repo_root}/cosmos_rl/_version.py"
+        local installed_version_file
+        local temporary_target
+
+        # setuptools-scm generates this ignored file when the package is built.
+        # A raw checkout mounted over the installed package does not contain it,
+        # so preserve the generated module from the image before PYTHONPATH
+        # makes the checkout authoritative.
+        if [[ -f "${target}" ]]; then
+            return 0
+        fi
+        if ! installed_version_file="$(python -c "import sys; from pathlib import Path; matches = [candidate for entry in sys.path if (candidate := Path(entry) / \"cosmos_rl\" / \"_version.py\").is_file()]; print(matches[0] if matches else \"\"); raise SystemExit(not matches)")"; then
+            echo "ERROR: mounted repo lacks cosmos_rl/_version.py and no installed generated version module was found" >&2
+            return 1
+        fi
+
+        temporary_target="${target}.tmp.$$"
+        if ! cp "${installed_version_file}" "${temporary_target}"; then
+            echo "ERROR: failed to copy generated version module from ${installed_version_file}" >&2
+            return 1
+        fi
+        if ! mv "${temporary_target}" "${target}"; then
+            echo "ERROR: failed to install generated version module at ${target}" >&2
+            return 1
+        fi
+        echo "Materialized generated version module at ${target}"
+    }
+
     if [[ -d /opt/cosmos-rl/tests ]]; then
         # --repo-root-path was mounted: override the baked-in code/tests and run
         # against the working-tree copy (PYTHONPATH shadows the installed pkg).
+        materialize_mounted_version_module /opt/cosmos-rl || exit 1
         export PYTHONPATH="/opt/cosmos-rl:${PYTHONPATH}"
         cd /opt/cosmos-rl
         echo "Using mounted repo at /opt/cosmos-rl (overrides baked-in)"

--- a/tests/run_test.sh
+++ b/tests/run_test.sh
@@ -171,7 +171,7 @@ run python tests/test_put_rollouts.py
 run python tests/test_trajectory_iteration.py
 run python tests/test_gym_example.py
 # Pytest-style CPU suites; install pytest in case the image lacks it.
-run /bin/bash -c "python -m pip install --quiet pytest && python -m pytest -q tests/test_weight_sync.py tests/test_checkpoint.py tests/test_ranked_rollout_end_and_wst_fence.py tests/test_rollout_mesh_guard.py tests/test_r2r_unseeded_source.py tests/test_terminal_checkpoint_trainer_hooks.py tests/test_terminal_drain_protocol.py tests/test_training_complete_checkpoint.py tests/test_p2r_grouping.py tests/test_tensor_packing.py"
+run /bin/bash -c "python -m pip install --quiet pytest && python -m pytest -q tests/test_completion_admission.py tests/test_discarded_rollout_accounting.py tests/test_weight_sync.py tests/test_checkpoint.py tests/test_ranked_rollout_end_and_wst_fence.py tests/test_rollout_mesh_guard.py tests/test_r2r_unseeded_source.py tests/test_terminal_checkpoint_trainer_hooks.py tests/test_terminal_drain_protocol.py tests/test_training_complete_checkpoint.py tests/test_p2r_grouping.py tests/test_tensor_packing.py"
 run python -m unittest -v tests.contracts.test_trainer_metrics_contract
 run python -m unittest -v tests.contracts.test_config_routing_contract
 run python -m unittest -v tests.contracts.test_model_registry_contract

--- a/tests/test_completion_admission.py
+++ b/tests/test_completion_admission.py
@@ -1,0 +1,712 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from queue import Queue
+import pickle
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import numpy as np
+import pytest
+import torch
+
+from cosmos_rl.dispatcher.algo.grpo import GRPO
+from cosmos_rl.dispatcher.algo.base import REGISTERED_ALGOs
+from cosmos_rl.dispatcher.data.schema import ChatMessage, RLPayload
+from cosmos_rl.dispatcher.status import PolicyStatusManager
+from cosmos_rl.reward.admission import (
+    COMPLETION_ADMISSION_REPORT_ID_KEY,
+    COMPLETION_ADMISSION_WEIGHT_VERSION_KEY,
+    apply_rollout_result_to_payload,
+    consume_completion_admission_metrics,
+    normalize_rollout_results,
+    prepare_completion_admission_report,
+    resolve_completion_admission,
+    select_payload_completions,
+)
+from cosmos_rl.reward.base import RolloutGroup
+from cosmos_rl.reward.dispatcher import RewardDispatcher
+from cosmos_rl.reward.local_calculator import LocalRewardCalculator
+from cosmos_rl.reward.remote_calculator import RemoteRewardCalculator
+from cosmos_rl.rollout.schema import RolloutResult
+from cosmos_rl.rollout.worker.rollout_control import DisaggregatedRolloutControlWorker
+from cosmos_rl.utils.payload import extract_rollouts
+
+
+class _TestAlgo(GRPO):
+    def __init__(self, rewards):
+        super().__init__(reward_fn=None)
+        self.rewards = rewards
+        self.reward_inputs = None
+
+    def compute_reward(self, to_be_evaluated, reference, prompt=None, **kwargs):
+        self.reward_inputs = list(to_be_evaluated)
+        return (
+            list(self.rewards),
+            list(self.rewards),
+            [{"reward_metric": reward} for reward in self.rewards],
+        )
+
+
+class _IdentityAdvantageAlgo(_TestAlgo):
+    minimum_trainable_completions = 1
+
+    def __init__(self, reward_fn=None, **kwargs):
+        del reward_fn, kwargs
+        super().__init__([])
+        self.advantage_inputs = None
+
+    def compute_advantage(self, rewards):
+        self.advantage_inputs = list(rewards)
+        return [reward + 10.0 for reward in rewards]
+
+
+def _payload(mask=None, reasons=None):
+    return RLPayload(
+        prompt="prompt",
+        prompt_idx=7,
+        reference_answer="answer",
+        completions=["c0", "c1", "c2", "c3"],
+        completed_conversations=[[], [], [], []],
+        completion_logprobs=[[[0.0]], [[1.0]], [[2.0]], [[3.0]]],
+        completion_token_ids=[[[0]], [[1]], [[2]], [[3]]],
+        cumulative_logprob=[0.0, 1.0, 2.0, 3.0],
+        teacher_result_uuids=["u0", "u1", "u2", "u3"],
+        extra_info={"aligned": [10, 11, 12, 13], "group": "metadata"},
+        completion_trainable=mask,
+        completion_drop_reasons=reasons,
+    )
+
+
+@pytest.mark.parametrize("invalid_index", [0, 1, 3])
+def test_rollout_group_excludes_before_advantage(invalid_index):
+    rewards = [1.0, 7.0, 3.0, 5.0]
+    mask = [True] * 4
+    mask[invalid_index] = False
+    reasons = [None] * 4
+    reasons[invalid_index] = "missing_log_probs"
+    payload = _payload(mask, reasons)
+    algo = _TestAlgo(rewards)
+    group = RolloutGroup(7, payload, False, "answer")
+
+    rollouts = group.compute_rollouts(algo)
+
+    eligible_indices = [i for i in range(4) if i != invalid_index]
+    eligible_rewards = np.asarray([rewards[i] for i in eligible_indices])
+    expected = (eligible_rewards - eligible_rewards.mean()) / (
+        eligible_rewards.std() + 1e-6
+    )
+    assert algo.reward_inputs == payload.completions
+    assert [rollout.completion for rollout in rollouts] == [
+        payload.completions[i] for i in eligible_indices
+    ]
+    assert [rollout.advantage for rollout in rollouts] == pytest.approx(expected)
+    assert group.excluded_reward_metrics == {
+        invalid_index: {"reward_metric": rewards[invalid_index]}
+    }
+    assert group.completion_admission.drop_reason_counts == {"missing_log_probs": 1}
+
+
+@pytest.mark.parametrize(
+    "mask",
+    [
+        [False, False, False, False],
+        [False, True, False, False],
+    ],
+)
+def test_rollout_group_skips_insufficient_explicit_group(mask):
+    algo = _TestAlgo([1.0, 2.0, 3.0, 4.0])
+    group = RolloutGroup(7, _payload(mask), False, "answer")
+
+    assert group.compute_rollouts(algo) == []
+    assert algo.reward_inputs == ["c0", "c1", "c2", "c3"]
+    assert group.completion_admission.group_excluded
+
+
+def test_absent_mask_preserves_single_completion_group():
+    payload = RLPayload(
+        prompt_idx=1,
+        completions=["only"],
+        reference_answer="answer",
+    )
+    group = RolloutGroup(1, payload, False, "answer")
+
+    rollouts = group.compute_rollouts(_TestAlgo([2.0]))
+
+    assert len(rollouts) == 1
+    assert rollouts[0].completion == "only"
+    assert rollouts[0].advantage == 0.0
+    assert rollouts[0].report_metrics == {"reward_metric": 2.0}
+
+
+def test_validation_does_not_apply_training_admission():
+    payload = _payload([False, True, False, False])
+    group = RolloutGroup(7, payload, True, "answer")
+
+    rollouts = group.compute_rollouts(
+        _TestAlgo([1.0, 2.0, 3.0, 4.0]),
+        apply_completion_admission=False,
+    )
+
+    assert [rollout.completion for rollout in rollouts] == payload.completions
+
+
+def test_validation_ignores_misaligned_training_admission_metadata():
+    payload = _payload([False], ["stale", "metadata"])
+    group = RolloutGroup(7, payload, True, "answer")
+
+    rollouts = group.compute_rollouts(
+        _TestAlgo([1.0, 2.0, 3.0, 4.0]),
+        apply_completion_admission=False,
+    )
+
+    assert [rollout.completion for rollout in rollouts] == payload.completions
+
+
+def test_admission_rejects_misaligned_fields():
+    payload = _payload([True, False], [None, "bad"])
+
+    with pytest.raises(ValueError, match="completion_trainable"):
+        resolve_completion_admission(payload, 2)
+
+
+def test_select_payload_keeps_completion_fields_aligned():
+    payload = _payload(
+        [False, True, False, True],
+        ["bad-0", None, "bad-2", None],
+    )
+    admission = resolve_completion_admission(payload, 2)
+
+    selected = select_payload_completions(payload, admission)
+
+    assert selected.completions == ["c1", "c3"]
+    assert selected.completion_logprobs == [[[1.0]], [[3.0]]]
+    assert selected.completion_token_ids == [[[1]], [[3]]]
+    assert selected.cumulative_logprob == [1.0, 3.0]
+    assert selected.teacher_result_uuids == ["u1", "u3"]
+    assert selected.extra_info == {
+        "aligned": [11, 13],
+        "group": "metadata",
+    }
+    assert selected.completion_trainable is None
+    assert selected.completion_drop_reasons is None
+
+
+def test_select_payload_supports_tensor_native_completions():
+    completions = torch.arange(8).reshape(4, 2)
+    payload = RLPayload(
+        completions=completions,
+        completion_trainable=[False, True, False, True],
+    )
+
+    selected = select_payload_completions(
+        payload, resolve_completion_admission(payload, 2)
+    )
+
+    assert torch.equal(selected.completions, completions[[1, 3]])
+
+
+def test_insufficient_payload_is_metadata_only_and_accounted():
+    payload = _payload([False, True, False, False])
+    admission = resolve_completion_admission(payload, 2)
+    selected = select_payload_completions(payload, admission)
+
+    kept, metrics = consume_completion_admission_metrics([selected])
+
+    assert kept == []
+    assert metrics["rollout/completion_admission_original_count"] == 4
+    assert metrics["rollout/completion_admission_eligible_count"] == 1
+    assert metrics["rollout/completion_admission_excluded_count"] == 3
+    assert metrics["rollout/completion_admission_insufficient_group_count"] == 1
+    assert metrics["rollout/completion_admission_training_discarded_count"] == 4
+
+
+def test_partial_admission_keeps_payload_and_accounts_reason():
+    payload = _payload([True, False, True, True])
+    selected = select_payload_completions(
+        payload, resolve_completion_admission(payload, 2)
+    )
+
+    kept, metrics = consume_completion_admission_metrics([selected])
+
+    assert kept == [selected]
+    assert metrics["rollout/completion_admission_excluded_count"] == 1
+    assert metrics["rollout/completion_admission_training_discarded_count"] == 1
+    assert metrics["rollout/completion_admission_reason_unspecified_count"] == 1
+
+
+def test_unknown_drop_reasons_use_bounded_other_metric():
+    payload = _payload(
+        [False, False, False, True],
+        ["request-specific-1", "request-specific-2", "missing_log_probs", None],
+    )
+
+    admission = resolve_completion_admission(payload, 1)
+
+    assert admission.drop_reason_counts == {
+        "other": 2,
+        "missing_log_probs": 1,
+    }
+    assert all("request_specific" not in key for key in admission.metrics())
+
+
+def test_internal_admission_metrics_survive_reward_worker_pickle_only():
+    payload = _payload([True, False, True, True])
+    selected = select_payload_completions(
+        payload, resolve_completion_admission(payload, 2)
+    )
+
+    restored = pickle.loads(pickle.dumps(selected))
+
+    assert (
+        restored.completion_admission_metrics == selected.completion_admission_metrics
+    )
+    assert "completion_admission_metrics" not in selected.model_dump()
+
+
+def test_controller_accumulates_admission_metrics():
+    manager = object.__new__(PolicyStatusManager)
+    manager.completion_admission_records = {}
+    manager._applied_completion_admission_report_ids = {}
+    metrics = {
+        "rollout/completion_admission_excluded_count": 2,
+        "rollout/completion_admission_reason_missing_log_probs_count": 2,
+        "rollout/completion_admission_excluded_reward_score_sum": -3.5,
+        "rollout/completion_admission_excluded_reward_score_count": 2,
+        "unrelated": 99,
+    }
+
+    assert manager.update_completion_admission_statistics(
+        metrics,
+        source_replica="rollout-0",
+        report_id="report-0",
+        training_step=3,
+    )
+    assert manager.update_completion_admission_statistics(
+        metrics,
+        source_replica="rollout-0",
+        report_id="report-1",
+        training_step=3,
+    )
+
+    assert manager.completion_admission_records == {
+        3: {
+            "rollout/completion_admission_excluded_count": 4,
+            "rollout/completion_admission_reason_missing_log_probs_count": 4,
+            "rollout/completion_admission_excluded_reward_score_sum": -7.0,
+            "rollout/completion_admission_excluded_reward_score_count": 4,
+        }
+    }
+
+    taken = manager._take_completion_admission_statistics(3)
+    assert taken
+    assert manager.completion_admission_records == {}
+
+
+def test_controller_keeps_admission_metrics_separate_by_training_step_and_report():
+    manager = object.__new__(PolicyStatusManager)
+    manager.completion_admission_records = {}
+    manager._applied_completion_admission_report_ids = {}
+    metrics = {"rollout/completion_admission_excluded_count": 1}
+
+    assert manager.update_completion_admission_statistics(
+        metrics,
+        source_replica="rollout-0",
+        report_id="version-4",
+        training_step=4,
+    )
+    assert manager.update_completion_admission_statistics(
+        metrics,
+        source_replica="rollout-0",
+        report_id="version-5",
+        training_step=5,
+    )
+    assert not manager.update_completion_admission_statistics(
+        metrics,
+        source_replica="rollout-0",
+        report_id="version-4",
+        training_step=4,
+    )
+
+    assert manager._take_completion_admission_statistics(4) == metrics
+    assert manager.completion_admission_records == {5: metrics}
+
+
+def test_controller_targets_admission_metrics_to_next_unfilled_training_step():
+    manager = PolicyStatusManager()
+    manager.current_step = 10
+    manager.config = SimpleNamespace(
+        train=SimpleNamespace(
+            train_batch_per_replica=4,
+            train_policy=SimpleNamespace(data_dispatch_as_rank_in_mesh=False),
+        )
+    )
+
+    assert manager.next_rollout_training_step() == 11
+    for _ in range(4):
+        manager.rollout_buffer.put(object())
+    assert manager.next_rollout_training_step() == 12
+
+
+def test_local_reward_payload_remains_aligned_after_admission():
+    calculator = LocalRewardCalculator()
+    calculator.rl_algo = _TestAlgo([1.0, 100.0, 3.0, 5.0])
+    calculator.config = SimpleNamespace(
+        train=SimpleNamespace(
+            non_text=True,
+            train_policy=SimpleNamespace(min_filter_prefix_tokens=None),
+        )
+    )
+    payload = _payload([True, False, True, True])
+
+    result, is_validation, step = calculator.compute_rewards([payload], False, 4)
+
+    assert not is_validation
+    assert step == 4
+    assert result[0].completions == ["c0", "c2", "c3"]
+    assert result[0].completion_logprobs == [[[0.0]], [[2.0]], [[3.0]]]
+    assert result[0].cumulative_logprob == [0.0, 2.0, 3.0]
+    assert result[0].teacher_result_uuids == ["u0", "u2", "u3"]
+    assert result[0].extra_info["aligned"] == [10, 12, 13]
+    admitted_payloads, metrics = consume_completion_admission_metrics(result)
+    assert (
+        metrics["rollout/completion_admission_excluded_reward_reward_metric_sum"]
+        == 100.0
+    )
+    assert (
+        metrics["rollout/completion_admission_excluded_reward_reward_metric_count"] == 1
+    )
+    trainer_rollouts = extract_rollouts(admitted_payloads, is_end=False)
+    assert [rollout.completion for rollout in trainer_rollouts[0]] == [
+        "c0",
+        "c2",
+        "c3",
+    ]
+
+
+def test_fully_rejected_group_preserves_excluded_reward_telemetry():
+    calculator = LocalRewardCalculator()
+    calculator.rl_algo = _TestAlgo([1.0, 2.0, 3.0, 4.0])
+    calculator.config = SimpleNamespace(
+        train=SimpleNamespace(
+            non_text=True,
+            train_policy=SimpleNamespace(min_filter_prefix_tokens=None),
+        )
+    )
+    payload = _payload([False, True, False, False])
+
+    result, _, _ = calculator.compute_rewards([payload], False, 4)
+    kept, metrics = consume_completion_admission_metrics(result)
+
+    assert kept == []
+    assert (
+        metrics["rollout/completion_admission_excluded_reward_reward_metric_sum"]
+        == 10.0
+    )
+    assert (
+        metrics["rollout/completion_admission_excluded_reward_reward_metric_count"] == 4
+    )
+
+
+def test_remote_reward_filters_before_normalization(monkeypatch):
+    payload = _payload(
+        [True, False, True, True],
+        [None, "missing_log_probs", None, None],
+    )
+    calculator = RemoteRewardCalculator()
+    calculator.minimum_trainable_completions = 2
+    calculator.rl_algo = _TestAlgo([])
+    calculator.uuid2payload = {"request": [payload]}
+    calculator.uuid2replica = {"request": None}
+    calculator.uuid2stage = {"request": "training"}
+    calculator.uuid2step = {"request": 9}
+    calculator.uuid2completions_per_payload = {"request": [4]}
+    all_rewards = torch.tensor([1.0, 100.0, 3.0, 5.0])
+    monkeypatch.setattr(calculator, "fetch_reward", lambda *_: all_rewards)
+    requests = Queue()
+    requests.put("request")
+
+    result, is_validation, step = calculator.get_results(requests)
+
+    eligible_rewards = np.asarray([1.0, 3.0, 5.0])
+    expected = (eligible_rewards - eligible_rewards.mean()) / (
+        eligible_rewards.std() + 1e-6
+    )
+    assert not is_validation
+    assert step == 9
+    assert result[0].completions == ["c0", "c2", "c3"]
+    assert result[0].rewards == [1.0, 3.0, 5.0]
+    assert result[0].advantages == pytest.approx(expected.tolist())
+    assert result[0].completion_logprobs == [[[0.0]], [[2.0]], [[3.0]]]
+
+
+def test_remote_reward_uses_registered_algorithm_advantage(monkeypatch):
+    payload = _payload([True, False, True, True])
+    calculator = RemoteRewardCalculator()
+    algo_name = "test_identity_advantage"
+    monkeypatch.setitem(REGISTERED_ALGOs, algo_name, _IdentityAdvantageAlgo)
+    monkeypatch.setattr(
+        "cosmos_rl.reward.remote_calculator.Wan2pt1VAEInterface",
+        lambda **_: None,
+        raising=False,
+    )
+    config = SimpleNamespace(
+        train=SimpleNamespace(
+            train_policy=SimpleNamespace(
+                algo=algo_name,
+                unbiased_advantage=False,
+                remote_reward=SimpleNamespace(),
+            )
+        ),
+        validation=SimpleNamespace(remote_reward=SimpleNamespace()),
+        policy=SimpleNamespace(
+            diffusers=SimpleNamespace(tokenizer=SimpleNamespace(model_dump=lambda: {}))
+        ),
+    )
+    calculator.setup(config)
+    calculator.uuid2payload = {"request": [payload]}
+    calculator.uuid2replica = {"request": None}
+    calculator.uuid2stage = {"request": "training"}
+    calculator.uuid2step = {"request": 9}
+    calculator.uuid2completions_per_payload = {"request": [4]}
+    monkeypatch.setattr(
+        calculator, "fetch_reward", lambda *_: torch.tensor([1.0, 100.0, 3.0, 5.0])
+    )
+    requests = Queue()
+    requests.put("request")
+
+    result, _, _ = calculator.get_results(requests)
+
+    assert calculator.rl_algo.advantage_inputs == [1.0, 3.0, 5.0]
+    assert result[0].advantages == [11.0, 13.0, 15.0]
+
+
+def test_remote_validation_ignores_misaligned_admission_metadata(monkeypatch):
+    payload = _payload([False], ["stale"])
+    calculator = RemoteRewardCalculator()
+    calculator.rl_algo = _IdentityAdvantageAlgo()
+    calculator.minimum_trainable_completions = 1
+    calculator.uuid2payload = {"request": [payload]}
+    calculator.uuid2replica = {"request": None}
+    calculator.uuid2stage = {"request": "validation"}
+    calculator.uuid2step = {"request": 9}
+    calculator.uuid2completions_per_payload = {"request": [4]}
+    monkeypatch.setattr(
+        calculator, "fetch_reward", lambda *_: torch.tensor([1.0, 2.0, 3.0, 4.0])
+    )
+    requests = Queue()
+    requests.put("request")
+
+    result, is_validation, _ = calculator.get_results(requests)
+
+    rewards = torch.tensor([1.0, 2.0, 3.0, 4.0])
+    expected = (rewards - rewards.mean()) / (rewards.std() + 1e-4)
+    assert is_validation
+    assert result[0].completions == payload.completions
+    assert result[0].advantages == pytest.approx(expected.tolist())
+    assert calculator.rl_algo.advantage_inputs is None
+
+
+def test_bypass_reward_applies_admission():
+    dispatcher = RewardDispatcher(payload_per_task=1)
+    dispatcher.is_remote = False
+    dispatcher.minimum_trainable_completions = 2
+    payload = _payload([False, True, False, True])
+
+    dispatcher.enqueue_rewards_cal([payload], False, 3, bypass_reward=True)
+    result, is_validation, step, all_done = dispatcher.dequeue_rewards_cal()
+
+    assert not is_validation
+    assert step == 3
+    assert not all_done
+    assert result[0].completions == ["c1", "c3"]
+    assert result[0].rewards == [0.0, 0.0]
+    assert result[0].advantages == [0.0, 0.0]
+
+
+def test_rollout_worker_propagates_producer_admission_fields():
+    worker = object.__new__(DisaggregatedRolloutControlWorker)
+    worker.config = SimpleNamespace(
+        train=SimpleNamespace(
+            non_text=False,
+            local_dataset=False,
+            train_policy=SimpleNamespace(bypass_reward=False),
+        ),
+        rollout=SimpleNamespace(
+            n_generation=2,
+            multi_turn_config=SimpleNamespace(enable=False),
+        ),
+    )
+    worker.should_report = True
+    worker.eos_token = "<eos>"
+    worker.current_weight_version = 5
+    worker._report_discarded_samples = lambda _: None
+    worker.enqueue_teacher_calculation = lambda payloads: payloads
+    enqueued = []
+    worker.reward_dispatcher = SimpleNamespace(
+        enqueue_rewards_cal=lambda payloads, *args, **kwargs: enqueued.extend(payloads)
+    )
+    result = RolloutResult(
+        completions=["good", "bad"],
+        completion_trainable=[True, False],
+        completion_drop_reasons=[None, "missing_log_probs"],
+    )
+
+    worker._filter_valid_rollout_results_and_report([result], [RLPayload(prompt_idx=3)])
+
+    assert enqueued[0].completion_trainable == [True, False]
+    assert enqueued[0].completion_drop_reasons == [None, "missing_log_probs"]
+
+
+def test_multiturn_filter_keeps_every_completion_field_aligned():
+    worker = object.__new__(DisaggregatedRolloutControlWorker)
+    worker.config = SimpleNamespace(
+        train=SimpleNamespace(
+            non_text=False,
+            local_dataset=False,
+            train_policy=SimpleNamespace(bypass_reward=False),
+        ),
+        rollout=SimpleNamespace(
+            n_generation=2,
+            multi_turn_config=SimpleNamespace(enable=True),
+        ),
+    )
+    worker.should_report = True
+    worker.current_weight_version = 5
+    worker._report_discarded_samples = MagicMock()
+    worker.enqueue_teacher_calculation = lambda payloads: payloads
+    enqueued = []
+    worker.reward_dispatcher = SimpleNamespace(
+        enqueue_rewards_cal=lambda payloads, *args, **kwargs: enqueued.extend(payloads)
+    )
+    invalid_conversation = [ChatMessage(role="assistant", content="")]
+    valid_conversation = [ChatMessage(role="assistant", content="answer")]
+    result = RolloutResult(
+        completions=["invalid", "valid"],
+        completed_conversations=[invalid_conversation, valid_conversation],
+        completion_trainable=[False, True],
+        completion_drop_reasons=["invalid_completion", None],
+        completion_logprobs=[[[0.0]], [[1.0]]],
+        completion_token_ids=[[[10]], [[20]]],
+        cumulative_logprob=[-2.0, -1.0],
+        extra_info={"aligned": ["bad", "good"], "group": "metadata"},
+    )
+
+    valid_payloads, valid_results = worker._filter_valid_rollout_results_and_report(
+        [result], [RLPayload(prompt_idx=3)]
+    )
+
+    assert len(valid_payloads) == 1
+    assert valid_payloads[0].prompt_idx == 3
+    assert valid_results[0].completions == ["valid"]
+    assert valid_results[0].completed_conversations == [valid_conversation]
+    assert valid_results[0].completion_trainable == [True]
+    assert valid_results[0].completion_drop_reasons == [None]
+    assert valid_results[0].completion_logprobs == [[[1.0]]]
+    assert valid_results[0].completion_token_ids == [[[20]]]
+    assert valid_results[0].cumulative_logprob == [-1.0]
+    assert valid_results[0].extra_info == {
+        "aligned": ["good"],
+        "group": "metadata",
+    }
+    assert enqueued[0].completions == ["valid"]
+    worker._report_discarded_samples.assert_called_once_with(1)
+
+
+def test_rollout_reporter_accounts_for_excluded_completion():
+    payload = _payload([True, False, True, True])
+    payload = select_payload_completions(
+        payload, resolve_completion_admission(payload, 2)
+    )
+    results = iter(
+        [
+            ([payload], False, 2, False),
+            (None, False, -1, True),
+        ]
+    )
+    worker = object.__new__(DisaggregatedRolloutControlWorker)
+    worker.reward_dispatcher = SimpleNamespace(
+        dequeue_rewards_cal=lambda: next(results)
+    )
+    worker.config = SimpleNamespace(
+        train=SimpleNamespace(
+            local_dataset=False,
+            train_policy=SimpleNamespace(
+                variant="grpo",
+                rollout_as_token_ids=False,
+            ),
+        )
+    )
+    worker.data_packer = SimpleNamespace(
+        get_rollout_output=lambda *values: (*values, None)
+    )
+    worker.replica_name = "rollout-0"
+    worker.api_client = SimpleNamespace(post_rollout_completion=MagicMock())
+
+    worker.report_rollouts()
+
+    request = worker.api_client.post_rollout_completion.call_args.args[0]
+    assert request.payloads[0].completions == ["c0", "c2", "c3"]
+    assert request.metrics["rollout/completion_admission_excluded_count"] == 1
+    assert request.metrics["discarded_samples"] == 1
+    assert request.metrics["discarded_weight_version"] == 2
+    assert request.metrics[COMPLETION_ADMISSION_WEIGHT_VERSION_KEY] == 2
+    assert request.metrics[COMPLETION_ADMISSION_REPORT_ID_KEY]
+    assert (
+        request.metrics["discard_report_id"]
+        == request.metrics[COMPLETION_ADMISSION_REPORT_ID_KEY]
+    )
+
+
+def test_prepare_admission_report_is_stable_for_http_retry():
+    report = prepare_completion_admission_report(
+        {
+            "rollout/completion_admission_excluded_count": 1,
+            "rollout/completion_admission_training_discarded_count": 1,
+        },
+        weight_version=7,
+        report_id="stable-report",
+    )
+
+    assert report[COMPLETION_ADMISSION_REPORT_ID_KEY] == "stable-report"
+    assert report[COMPLETION_ADMISSION_WEIGHT_VERSION_KEY] == 7
+    assert report["discard_report_id"] == "stable-report"
+    assert report["discarded_weight_version"] == 7
+
+
+def test_rollout_result_admission_propagates_for_all_backend_wrappers():
+    payload = RLPayload(prompt_idx=3)
+    result = RolloutResult(
+        completions=["keep", "drop"],
+        completion_trainable=[True, False],
+        completion_drop_reasons=[None, "missing_log_probs"],
+        completion_logprobs=[[[1.0]], [[2.0]]],
+        completion_token_ids=[[[10]], [[20]]],
+        cumulative_logprob=[-1.0, -2.0],
+        extra_info={"source": "custom_trtllm"},
+    )
+
+    apply_rollout_result_to_payload(
+        payload, result, include_completed_conversations=True
+    )
+
+    assert payload.completion_trainable == [True, False]
+    assert payload.completion_drop_reasons == [None, "missing_log_probs"]
+    assert payload.completion_logprobs == [[[1.0]], [[2.0]]]
+    assert payload.completion_token_ids == [[[10]], [[20]]]
+    assert payload.extra_info == {"source": "custom_trtllm"}
+
+
+def test_rollout_result_normalization_preserves_masks_and_legacy_outputs():
+    explicit = RolloutResult(
+        completions=["keep", "drop"],
+        completion_trainable=[True, False],
+        completion_drop_reasons=[None, "missing_log_probs"],
+    )
+
+    normalized = normalize_rollout_results([explicit, ["legacy-0", "legacy-1"]])
+
+    assert normalized[0] is explicit
+    assert normalized[0].completion_trainable == [True, False]
+    assert normalized[1].completions == ["legacy-0", "legacy-1"]
+    assert normalized[1].completion_trainable is None

--- a/tests/test_discarded_rollout_accounting.py
+++ b/tests/test_discarded_rollout_accounting.py
@@ -6,8 +6,11 @@ from queue import Queue
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
+from cosmos_rl.dispatcher.controller import Controller
+from cosmos_rl.dispatcher.data.schema import RLPayload
 from cosmos_rl.dispatcher.protocol import RolloutRequest
 from cosmos_rl.dispatcher.status import PolicyStatusManager
+from cosmos_rl.reward.admission import prepare_completion_admission_report
 from cosmos_rl.rollout.schema import RolloutResult
 from cosmos_rl.rollout.worker.colocated.rollout_control import (
     ColocatedRolloutControlWorker,
@@ -65,6 +68,7 @@ def test_empty_non_text_result_reports_reserved_samples():
     assert request.src_global_rank == 3
     assert request.metrics["discarded_samples"] == 2
     assert request.metrics["discard_report_id"]
+    assert request.metrics["discarded_weight_version"] == 0
 
 
 def test_empty_outer_result_reports_every_consumed_prompt():
@@ -133,12 +137,124 @@ def test_discard_settlement_requires_report_id():
     assert manager.filter_records == {}
 
 
+def test_on_policy_discard_reopens_prompt_slot_for_same_weight_version():
+    controller = object.__new__(Controller)
+    controller.config = SimpleNamespace(
+        mode="disaggregated",
+        rollout=SimpleNamespace(n_generation=4),
+        train=SimpleNamespace(
+            train_policy=SimpleNamespace(on_policy=True, variant="grpo")
+        ),
+    )
+    controller.weight_version_to_prompt_num = {5: 2}
+    controller.weight_version_to_replacement_prompt_num = {}
+    replacement = RLPayload(prompt_idx=9)
+
+    assert controller.register_discarded_samples_for_refill(5, 1) == 1
+    controller._assign_prompt_weight_versions(
+        [replacement], starting_weight_version=5, prompt_quota=2
+    )
+
+    assert replacement.weight_version == 5
+    assert controller.weight_version_to_prompt_num == {5: 3}
+    assert controller.weight_version_to_replacement_prompt_num == {5: 0}
+    assert controller.weight_version_to_replacement_prompt_issued == {5: 1}
+
+
+def test_partial_discard_reports_share_one_replacement_prompt():
+    controller = object.__new__(Controller)
+    controller.config = SimpleNamespace(
+        mode="disaggregated",
+        rollout=SimpleNamespace(n_generation=4),
+        train=SimpleNamespace(
+            train_policy=SimpleNamespace(on_policy=True, variant="grpo")
+        ),
+    )
+    controller.weight_version_to_prompt_num = {5: 2}
+    controller.weight_version_to_replacement_prompt_num = {}
+
+    assert controller.register_discarded_samples_for_refill(5, 1) == 1
+    assert controller.register_discarded_samples_for_refill(5, 1) == 0
+    assert controller.weight_version_to_replacement_prompt_num == {5: 1}
+
+
+def test_non_on_policy_discard_does_not_change_prompt_version_capacity():
+    controller = object.__new__(Controller)
+    controller.config = SimpleNamespace(
+        mode="disaggregated",
+        rollout=SimpleNamespace(n_generation=4),
+        train=SimpleNamespace(
+            train_policy=SimpleNamespace(on_policy=False, variant="grpo")
+        ),
+    )
+
+    assert controller.register_discarded_samples_for_refill(5, 1) == 0
+    assert not hasattr(controller, "weight_version_to_replacement_prompt_num")
+
+
+def test_prompt_without_refill_credit_advances_to_next_weight_version():
+    controller = object.__new__(Controller)
+    controller.weight_version_to_prompt_num = {5: 2}
+    controller.weight_version_to_replacement_prompt_num = {}
+    payload = RLPayload(prompt_idx=9)
+
+    controller._assign_prompt_weight_versions(
+        [payload], starting_weight_version=5, prompt_quota=2
+    )
+
+    assert payload.weight_version == 6
+
+
+def test_on_policy_prompt_fetch_uses_same_weight_after_partial_admission():
+    controller = object.__new__(Controller)
+    policy_status = MagicMock()
+    policy_status.__len__.return_value = 1
+    policy_status.current_step = 5
+    policy_status.total_pending_rollouts.return_value = 7
+    policy_status.samples_on_the_fly = 7
+    policy_status.replica_scaling_log = []
+    policy_status.training_finished.return_value = False
+    controller.policy_status_manager = policy_status
+    controller.rollout_status_manager = SimpleNamespace(replica_scaling_log=[])
+    controller.data_fetcher = SimpleNamespace(
+        get_batched_prompt=MagicMock(return_value=([RLPayload(prompt_idx=9)], False))
+    )
+    controller.config = SimpleNamespace(
+        mode="disaggregated",
+        validation=SimpleNamespace(enable=False),
+        rollout=SimpleNamespace(n_generation=4),
+        train=SimpleNamespace(
+            train_batch_per_replica=8,
+            train_policy=SimpleNamespace(
+                type="grpo",
+                variant="grpo",
+                on_policy=True,
+                allowed_outdated_steps=0,
+                outdated_rollout_fetch_batch_size=0,
+                max_inflight_steps=None,
+                max_retry_for_on_policy=0,
+            ),
+        ),
+    )
+    controller.weight_version_to_prompt_num = {5: 2}
+    controller.weight_version_to_replacement_prompt_num = {}
+    controller._soft_throttle_engaged_since = None
+    controller._soft_throttle_last_log_ts = 0.0
+    controller.register_discarded_samples_for_refill(5, 1)
+
+    payloads, is_end = asyncio.run(controller._get_batched_prompt_impl(1))
+
+    assert not is_end
+    assert [payload.weight_version for payload in payloads] == [5]
+    assert policy_status.samples_on_the_fly == 11
+
+
 def test_http_discard_report_settles_before_normal_admission():
     from cosmos_rl.dispatcher import run_web_panel
 
     policy_status = SimpleNamespace(
         _parse_non_negative_count=PolicyStatusManager._parse_non_negative_count,
-        settle_discarded_samples=MagicMock(),
+        settle_discarded_samples=MagicMock(return_value=4),
         rollout_admission_closed=lambda: False,
         filter_outdated_rollouts=lambda rollouts: rollouts,
     )
@@ -148,6 +264,7 @@ def test_http_discard_report_settles_before_normal_admission():
             train=SimpleNamespace(train_policy=SimpleNamespace(variant="grpo"))
         ),
         put_rollouts=AsyncMock(),
+        register_discarded_samples_for_refill=MagicMock(),
     )
     request = RolloutRequest(
         src_replica_name="rollout-0",
@@ -167,4 +284,124 @@ def test_http_discard_report_settles_before_normal_admission():
         report_id="report-1",
         count=4,
     )
+    fake_controller.register_discarded_samples_for_refill.assert_called_once_with(
+        None, 4
+    )
     fake_controller.put_rollouts.assert_awaited_once_with([])
+
+
+def test_http_admission_retry_is_idempotent_for_metrics_settlement_and_refill():
+    from cosmos_rl.dispatcher import run_web_panel
+
+    policy_status = PolicyStatusManager()
+    policy_status.samples_on_the_fly = 5
+    policy_status.config = SimpleNamespace(
+        train=SimpleNamespace(
+            train_batch_per_replica=4,
+            train_policy=SimpleNamespace(data_dispatch_as_rank_in_mesh=False),
+        )
+    )
+    policy_status.rollout_admission_closed = lambda: False
+    policy_status.filter_outdated_rollouts = lambda rollouts: rollouts
+    fake_controller = SimpleNamespace(
+        policy_status_manager=policy_status,
+        config=SimpleNamespace(
+            train=SimpleNamespace(train_policy=SimpleNamespace(variant="grpo"))
+        ),
+        put_rollouts=AsyncMock(),
+        register_discarded_samples_for_refill=MagicMock(),
+    )
+    metrics = prepare_completion_admission_report(
+        {
+            "rollout/completion_admission_excluded_count": 1,
+            "rollout/completion_admission_training_discarded_count": 1,
+        },
+        weight_version=3,
+        report_id="stable-admission-report",
+    )
+    request = RolloutRequest(
+        src_replica_name="rollout-0",
+        payloads=[],
+        metrics=metrics,
+    )
+
+    with patch.object(run_web_panel, "controller", fake_controller):
+        asyncio.run(run_web_panel.put_rollout_group(request))
+        asyncio.run(run_web_panel.put_rollout_group(request))
+
+    assert policy_status.completion_admission_records == {
+        1: {
+            "rollout/completion_admission_excluded_count": 1,
+            "rollout/completion_admission_training_discarded_count": 1,
+        }
+    }
+    assert policy_status.samples_on_the_fly == 4
+    fake_controller.register_discarded_samples_for_refill.assert_called_once_with(3, 1)
+
+
+def test_http_admission_discard_refills_strict_on_policy_step_at_same_weight():
+    from cosmos_rl.dispatcher import run_web_panel
+
+    config = SimpleNamespace(
+        mode="disaggregated",
+        validation=SimpleNamespace(enable=False),
+        rollout=SimpleNamespace(n_generation=4),
+        train=SimpleNamespace(
+            train_batch_per_replica=8,
+            train_policy=SimpleNamespace(
+                type="grpo",
+                variant="grpo",
+                on_policy=True,
+                data_dispatch_as_rank_in_mesh=False,
+                allowed_outdated_steps=0,
+                outdated_rollout_fetch_batch_size=0,
+                max_inflight_steps=None,
+                max_retry_for_on_policy=0,
+            ),
+        ),
+    )
+    policy_status = PolicyStatusManager()
+    policy_status.config = config
+    policy_status.current_step = 5
+    policy_status.total_steps = 100
+    policy_status.samples_on_the_fly = 8
+    policy_status.remain_samples_num = 100
+    policy_status.policy_replicas = {
+        "policy-0": SimpleNamespace(all_atoms_arrived=True)
+    }
+    for _ in range(7):
+        policy_status.rollout_buffer.put(object())
+
+    controller = object.__new__(Controller)
+    controller.config = config
+    controller.policy_status_manager = policy_status
+    controller.rollout_status_manager = SimpleNamespace(replica_scaling_log=[])
+    controller.data_fetcher = SimpleNamespace(
+        get_batched_prompt=MagicMock(return_value=([RLPayload(prompt_idx=9)], False))
+    )
+    controller.weight_version_to_prompt_num = {5: 2}
+    controller.weight_version_to_replacement_prompt_num = {}
+    controller._soft_throttle_engaged_since = None
+    controller._soft_throttle_last_log_ts = 0.0
+    controller.put_rollouts = AsyncMock()
+
+    request = RolloutRequest(
+        src_replica_name="rollout-0",
+        payloads=[],
+        metrics=prepare_completion_admission_report(
+            {
+                "rollout/completion_admission_excluded_count": 1,
+                "rollout/completion_admission_training_discarded_count": 1,
+            },
+            weight_version=5,
+            report_id="strict-on-policy-discard",
+        ),
+    )
+
+    with patch.object(run_web_panel, "controller", controller):
+        asyncio.run(run_web_panel.put_rollout_group(request))
+    replacement_payloads, is_end = asyncio.run(controller._get_batched_prompt_impl(1))
+
+    assert not is_end
+    assert policy_status.samples_on_the_fly == 11
+    assert replacement_payloads[0].weight_version == 5


### PR DESCRIPTION
## Summary

- add producer-controlled, per-completion training admission through `completion_trainable` and optional stable `completion_drop_reasons`
- apply admission before advantage calculation and reward normalization while keeping all completion-aligned payload fields synchronized
- require each algorithm's minimum useful admitted group size (`2` for GRPO, `1` by default), excluding undersized groups from training
- preserve backward compatibility: absent admission metadata admits every completion, and validation does not apply training admission
- propagate admission through local, remote, bypass-reward, rollout-worker, multi-turn, and TRT-LLM paths
- report admitted/excluded counts, reasons, undersized groups, discarded training samples, and aggregate reward metrics for excluded completions

## Correctness and reliability

- replenish strict on-policy prompt credit at the discarded completions' weight version so admission filtering cannot deadlock a training step
- attribute pipelined admission telemetry to its actual target training step
- give admission/discard reports stable IDs and bounded controller-side deduplication so HTTP retries do not double-count metrics or prompt credit
- normalize standard and legacy TRT-LLM results and preserve admission metadata when empty completions are removed
- make the Slurm CI mount-mode runner materialize the installed, generated `_version.py` before a raw checkout shadows the installed package

## Validation

- `235 passed` in the post-rebase local admission, accounting, weight-sync, checkpoint, shutdown, grouping, packing, and Slurm mount-mode regression set
- Ruff lint and format checks passed
- `bash -n` passed for `tests/run_test.sh` and `cosmos_rl/tools/slurm/cosmos_rl_ci_job.sh`
- `git diff --check upstream/main..HEAD` passed
- exact feature canary Slurm job `2154930`: completed `0:0` on one 8-GPU node, including focused admission/accounting tests and distributed process flow
- broad 8-GPU Slurm CI job `2154893`: all substantive suites passed, including the 8-rank data-loader case; its sole aggregate failure was the pre-existing mount-mode `_version.py` issue fixed here
- exact mount-mode regression Slurm job `2156708`: started from a checkout without `_version.py`, materialized it, imported code from `/opt/cosmos-rl`, and completed `0:0`

The redundant full rerun `2156685` was canceled after the focused mount-mode proof passed; no product test had failed in the completed broad run.
