### PR TITLE
fix(payload): pack singleton tensors whose last stride is not 1

### DIFF
--- a/cosmos_rl/utils/payload_transport/nccl/mixins.py
+++ b/cosmos_rl/utils/payload_transport/nccl/mixins.py
@@ -379,7 +379,15 @@ class NCCLRolloutMixin:
                 EPISODE_LENGTH: ep_len,
             }
         except Exception as e:
-            logger.error("[NCCLRolloutMixin] write_to_buffer failed: %s", e)
+            # Name the rollout so a disk fallback is attributable; the packer
+            # already names the offending schema field in its message.
+            logger.error(
+                "[NCCLRolloutMixin] write_to_buffer failed for replica=%s "
+                "rollout_idx=%s; falling back to the plain trajectory: %s",
+                self._nccl_replica_id,
+                self._nccl_rollout_idx,
+                e,
+            )
             return None
 
     def _pack(self, trajectory: Dict[str, Any], ep_len: int, transfer_id: str):

--- a/cosmos_rl/utils/payload_transport/pack.py
+++ b/cosmos_rl/utils/payload_transport/pack.py
@@ -92,6 +92,44 @@ def _coerce(tensor: torch.Tensor, spec: TensorSpec) -> torch.Tensor:
     return tensor
 
 
+def _layout_error(spec: TensorSpec, tensor: torch.Tensor, exc: Exception) -> str:
+    """Message naming the offending field, so a pack failure is actionable.
+
+    ``write_to_buffer`` logs only the exception text before falling back to
+    the plain trajectory; without the field identity that log says a payload
+    failed but not which one.
+    """
+    return (
+        f"[pack] field '{spec.name}' cannot be viewed as bytes: "
+        f"dtype={tensor.dtype} shape={tuple(tensor.shape)} "
+        f"stride={tuple(tensor.stride())} device={tensor.device} "
+        f"schema_dtype={spec.dtype} schema_shape={tuple(spec.shape)}: {exc}"
+    )
+
+
+def _canonical_for_byte_view(tensor: torch.Tensor) -> torch.Tensor:
+    """Return ``tensor`` in storage that ``view(torch.uint8)`` accepts.
+
+    ``.contiguous()`` alone is NOT enough.  PyTorch's contiguity rules ignore
+    the stride of a size-1 dimension, so an int64 column view such as
+    ``sampled_modes[:, idx]`` -- ``shape=(1,), stride=(8,)`` -- reports
+    ``is_contiguous() is True`` and ``.contiguous()`` returns it untouched.
+    ``view(dtype)`` applies the stricter byte-layout rule and requires
+    ``stride(-1) == 1`` when the element size changes, so that tensor raises
+    "self.stride(-1) must be 1 to view Long as Byte".
+
+    Tensors that already satisfy the byte-view rule are returned as-is, so the
+    common case still packs without an extra copy.
+    """
+    if tensor.is_contiguous() and (tensor.dim() == 0 or tensor.stride(-1) == 1):
+        return tensor
+    # Explicitly allocate canonical storage: a fresh empty + copy_ is the only
+    # form guaranteed to produce unit last stride for every legal input layout.
+    canonical = torch.empty(tensor.shape, dtype=tensor.dtype, device=tensor.device)
+    canonical.copy_(tensor)
+    return canonical
+
+
 def pack_trajectory_into(
     flat: torch.Tensor,
     trajectory: Dict[str, Any],
@@ -127,7 +165,10 @@ def pack_trajectory_into(
                 )
                 padded[: tensor.shape[0]] = tensor
                 tensor = padded
-        tensor = tensor.reshape(spec.shape).contiguous()
-        chunk = tensor.view(torch.uint8).reshape(-1)
+        tensor = _canonical_for_byte_view(tensor.reshape(spec.shape))
+        try:
+            chunk = tensor.view(torch.uint8).reshape(-1)
+        except RuntimeError as e:  # pragma: no cover - defensive
+            raise RuntimeError(_layout_error(spec, tensor, e)) from e
         off = offsets[spec.name]
         flat[off : off + chunk.numel()] = chunk

--- a/tests/run_test.sh
+++ b/tests/run_test.sh
@@ -142,6 +142,7 @@ run python tests/test_nccl_rendezvous.py
 run python tests/test_nccl_rollout_mixin.py
 run python tests/test_nccl_streams.py
 run python tests/test_nccl_transport.py
+run python tests/test_pack_canonical_stride.py
 run python tests/test_payload_rotation.py
 run python tests/test_payload_transport.py
 run python tests/test_profiler_ucxx.py

--- a/tests/test_nccl_e2e.py
+++ b/tests/test_nccl_e2e.py
@@ -103,6 +103,7 @@ def _worker(
     composed: bool = False,
     strided: bool = False,
     run_id: str = "",
+    action_dim: int = 2,
 ):
     """Entry point for each spawned rank.  Reports failures via err_queue.
 
@@ -125,8 +126,11 @@ def _worker(
         client = redis.Redis(host=REDIS_HOST, port=REDIS_PORT, decode_responses=True)
 
         config = _Config()
-        dims = dict(max_steps=8, obs_dim=4, action_dim=2)
-        build = _make_strided_trajectory if strided else _make_trajectory
+        dims = dict(max_steps=8, obs_dim=4, action_dim=action_dim)
+
+        def build(dev):
+            fn = _make_strided_trajectory if strided else _make_trajectory
+            return fn(dev, action_dim=action_dim)
 
         if rank == 0:
             # Producer.
@@ -350,7 +354,9 @@ class TestNcclE2E(unittest.TestCase):
         for key in (_META_KEY, _DONE_KEY):
             self.client.delete(key)
 
-    def _run_roundtrip(self, composed: bool, strided: bool = False):
+    def _run_roundtrip(
+        self, composed: bool, strided: bool = False, action_dim: int = 2
+    ):
         import torch.multiprocessing as mp
 
         # One Redis namespace per roundtrip: a producer serves for up to 60s,
@@ -361,7 +367,8 @@ class TestNcclE2E(unittest.TestCase):
         err_queue = ctx.Queue()
         procs = [
             ctx.Process(
-                target=_worker, args=(rank, 2, err_queue, composed, strided, run_id)
+                target=_worker,
+                args=(rank, 2, err_queue, composed, strided, run_id, action_dim),
             )
             for rank in range(2)
         ]
@@ -392,6 +399,21 @@ class TestNcclE2E(unittest.TestCase):
         differently, the payload comes back wrong or not at all.
         """
         self._run_roundtrip(composed=True)
+
+    def test_two_rank_roundtrip_narrow_action_dim(self):
+        """A payload schema narrower than the consumer config must still resolve.
+
+        The consumer decodes from the schema the producer ships in its
+        metadata, so ``action_dim=1`` against a config declaring 2 should be
+        transparent.  When this shape was first tried the payload packed and
+        the consumer then dropped the reference inside ``_rendezvous_one``
+        within 18ms -- no bytes moved and the episode fell back to Redis.
+        Ordinary trajectory here, so only the dim differs: if this fails, the
+        consumer path is still sizing from config rather than from the
+        reference, and any backend whose schema differs loses payloads
+        silently.
+        """
+        self._run_roundtrip(composed=False, action_dim=1)
 
     def test_two_rank_roundtrip_strided_field(self):
         """A field with a non-unit last stride must survive the real transfer.

--- a/tests/test_nccl_e2e.py
+++ b/tests/test_nccl_e2e.py
@@ -66,29 +66,34 @@ def _make_trajectory(device, ep_len=8, obs_dim=4, action_dim=2):
     }
 
 
-def _make_strided_trajectory(device, ep_len=8, obs_dim=4):
-    """Trajectory whose ``actions`` field has a non-unit last stride.
+#: Extra schema field for the strided case, mirroring the per-generation
+#: sampled-mode column an NDAS producer emits.
+STRIDED_FIELD = "sampled_mode"
+STRIDED_VALUE = 3
 
-    ``actions`` is a ``(ep_len, 1)`` view carrying stride ``(1, ep_len)``.  A
-    size-1 dimension may hold any stride, so PyTorch calls this contiguous and
-    ``.contiguous()`` leaves it alone -- yet ``view(torch.uint8)`` rejects it.
-    Producers emit exactly this shape when they slice one column out of a
-    per-generation tensor, and before the packer materialized canonical
-    storage the whole payload silently fell back off the NCCL path.
+
+def _strided_scalar(device):
+    """``shape=(1,)`` int64 whose last stride is 8, yet reports contiguous.
+
+    A size-1 dimension may hold any stride, so ``.contiguous()`` leaves this
+    untouched and ``view(torch.uint8)`` then rejects it.  Producers emit
+    exactly this when they slice one column out of a per-generation tensor.
     """
-    base = torch.arange(ep_len * 2, dtype=torch.float32, device=device).reshape(
-        2, ep_len
-    )
-    actions = base.t()[:, :1]
-    assert actions.is_contiguous() and actions.stride(-1) != 1
-    return {
-        "observations": torch.arange(
-            ep_len * obs_dim, dtype=torch.float32, device=device
-        ).reshape(ep_len, obs_dim),
-        "actions": actions,
-        "rewards": torch.arange(ep_len, dtype=torch.float32, device=device),
-        "episode_length": ep_len,
-    }
+    row = torch.arange(8, dtype=torch.int64, device=device).reshape(1, 8)
+    value = row[:, STRIDED_VALUE]
+    assert value.is_contiguous() and value.stride(-1) != 1
+    return value
+
+
+def _make_strided_trajectory(device, ep_len=8, obs_dim=4, action_dim=2):
+    """The ordinary trajectory plus one field with a non-unit last stride.
+
+    Dims stay exactly as the passing roundtrips use them: the stride is the
+    only variable, so a failure here cannot be blamed on an unusual schema.
+    """
+    traj = _make_trajectory(device, ep_len, obs_dim, action_dim)
+    traj[STRIDED_FIELD] = _strided_scalar(device)
+    return traj
 
 
 def _worker(
@@ -120,14 +125,30 @@ def _worker(
         client = redis.Redis(host=REDIS_HOST, port=REDIS_PORT, decode_responses=True)
 
         config = _Config()
-        # A strided run declares action_dim=1: the offending layout needs a
-        # size-1 trailing dimension, which is what lets a non-unit stride
-        # survive the contiguity check.
-        dims = dict(max_steps=8, obs_dim=4, action_dim=1 if strided else 2)
+        dims = dict(max_steps=8, obs_dim=4, action_dim=2)
         build = _make_strided_trajectory if strided else _make_trajectory
 
         if rank == 0:
             # Producer.
+            if strided:
+                # Extend the schema the way a backend does -- before setup, so
+                # the mixin sizes its buffers from it.  The consumer needs no
+                # change: the producer ships the schema in its metadata.
+                import numpy as np
+
+                import cosmos_rl.utils.payload_transport.nccl.mixins as _mixins
+                from cosmos_rl.utils.trajectory import TensorSpec
+
+                _base_build = _mixins.build_trajectory_schema
+
+                def _build_with_strided_field(dims_arg):
+                    schema = _base_build(dims_arg)
+                    schema.append(
+                        TensorSpec(name=STRIDED_FIELD, shape=(1,), dtype=np.int64)
+                    )
+                    return schema
+
+                _mixins.build_trajectory_schema = _build_with_strided_field
             producer = NCCLRolloutMixin()
             producer.setup_nccl(
                 replica_id="rollout-0",
@@ -196,10 +217,10 @@ def _worker(
             if strided:
                 # The point of the strided run: the non-unit-stride field must
                 # arrive intact rather than taking the pack fallback.
-                actions = resolved["actions"].float().reshape(-1)
-                assert torch.allclose(
-                    actions, expected_traj["actions"].float().reshape(-1)
-                ), "strided field mismatch"
+                got = resolved[STRIDED_FIELD].reshape(-1)[0].item()
+                assert got == STRIDED_VALUE, (
+                    "strided field mismatch: got %r want %r" % (got, STRIDED_VALUE)
+                )
             client.set(done_key, "1")
             if composed:
                 # No transport-specific teardown to call: shutdown_prefetch

--- a/tests/test_nccl_e2e.py
+++ b/tests/test_nccl_e2e.py
@@ -65,7 +65,38 @@ def _make_trajectory(device, ep_len=8, obs_dim=4, action_dim=2):
     }
 
 
-def _worker(rank: int, world_size: int, err_queue, composed: bool = False):
+def _make_strided_trajectory(device, ep_len=8, obs_dim=4):
+    """Trajectory whose ``actions`` field has a non-unit last stride.
+
+    ``actions`` is a ``(ep_len, 1)`` view carrying stride ``(1, ep_len)``.  A
+    size-1 dimension may hold any stride, so PyTorch calls this contiguous and
+    ``.contiguous()`` leaves it alone -- yet ``view(torch.uint8)`` rejects it.
+    Producers emit exactly this shape when they slice one column out of a
+    per-generation tensor, and before the packer materialized canonical
+    storage the whole payload silently fell back off the NCCL path.
+    """
+    base = torch.arange(ep_len * 2, dtype=torch.float32, device=device).reshape(
+        2, ep_len
+    )
+    actions = base.t()[:, :1]
+    assert actions.is_contiguous() and actions.stride(-1) != 1
+    return {
+        "observations": torch.arange(
+            ep_len * obs_dim, dtype=torch.float32, device=device
+        ).reshape(ep_len, obs_dim),
+        "actions": actions,
+        "rewards": torch.arange(ep_len, dtype=torch.float32, device=device),
+        "episode_length": ep_len,
+    }
+
+
+def _worker(
+    rank: int,
+    world_size: int,
+    err_queue,
+    composed: bool = False,
+    strided: bool = False,
+):
     """Entry point for each spawned rank.  Reports failures via err_queue."""
     try:
         import redis
@@ -79,7 +110,11 @@ def _worker(rank: int, world_size: int, err_queue, composed: bool = False):
         client = redis.Redis(host=REDIS_HOST, port=REDIS_PORT, decode_responses=True)
 
         config = _Config()
-        dims = dict(max_steps=8, obs_dim=4, action_dim=2)
+        # A strided run declares action_dim=1: the offending layout needs a
+        # size-1 trailing dimension, which is what lets a non-unit stride
+        # survive the contiguity check.
+        dims = dict(max_steps=8, obs_dim=4, action_dim=1 if strided else 2)
+        build = _make_strided_trajectory if strided else _make_trajectory
 
         if rank == 0:
             # Producer.
@@ -93,7 +128,7 @@ def _worker(rank: int, world_size: int, err_queue, composed: bool = False):
                 device=device,
                 **dims,
             )
-            traj = _make_trajectory(device)
+            traj = build(device)
             meta = producer.write_to_buffer(traj)
             assert meta is not None, "producer failed to pack buffer"
             client.set(_META_KEY, json.dumps(meta))
@@ -143,9 +178,18 @@ def _worker(rank: int, world_size: int, err_queue, composed: bool = False):
 
             resolved = packer.get_policy_input(rollout_output=meta)
             assert resolved is not None, "consumer failed to resolve NCCL ref"
+            expected_traj = build(device)
             obs = resolved["observations"]
-            expected = _make_trajectory(device)["observations"]
-            assert torch.allclose(obs.float(), expected), "payload mismatch"
+            assert torch.allclose(obs.float(), expected_traj["observations"]), (
+                "payload mismatch"
+            )
+            if strided:
+                # The point of the strided run: the non-unit-stride field must
+                # arrive intact rather than taking the pack fallback.
+                actions = resolved["actions"].float().reshape(-1)
+                assert torch.allclose(
+                    actions, expected_traj["actions"].float().reshape(-1)
+                ), "strided field mismatch"
             client.set(_DONE_KEY, "1")
             if composed:
                 # No transport-specific teardown to call: shutdown_prefetch
@@ -275,13 +319,13 @@ class TestNcclE2E(unittest.TestCase):
         for key in (_META_KEY, _DONE_KEY):
             self.client.delete(key)
 
-    def _run_roundtrip(self, composed: bool):
+    def _run_roundtrip(self, composed: bool, strided: bool = False):
         import torch.multiprocessing as mp
 
         ctx = mp.get_context("spawn")
         err_queue = ctx.Queue()
         procs = [
-            ctx.Process(target=_worker, args=(rank, 2, err_queue, composed))
+            ctx.Process(target=_worker, args=(rank, 2, err_queue, composed, strided))
             for rank in range(2)
         ]
         for p in procs:
@@ -311,6 +355,15 @@ class TestNcclE2E(unittest.TestCase):
         differently, the payload comes back wrong or not at all.
         """
         self._run_roundtrip(composed=True)
+
+    def test_two_rank_roundtrip_strided_field(self):
+        """A field with a non-unit last stride must survive the real transfer.
+
+        CPU tests cover the packer in isolation; this proves the same payload
+        packs, sends, and unpacks GPU->GPU instead of failing in
+        ``write_to_buffer`` and dropping the run to the disk fallback.
+        """
+        self._run_roundtrip(composed=False, strided=True)
 
 
 if __name__ == "__main__":

--- a/tests/test_nccl_e2e.py
+++ b/tests/test_nccl_e2e.py
@@ -31,6 +31,7 @@ existing instance with ``COSMOS_TEST_REDIS_HOST`` / ``COSMOS_TEST_REDIS_PORT``.
 
 import json
 import os
+import uuid
 import time
 import unittest
 
@@ -96,8 +97,17 @@ def _worker(
     err_queue,
     composed: bool = False,
     strided: bool = False,
+    run_id: str = "",
 ):
-    """Entry point for each spawned rank.  Reports failures via err_queue."""
+    """Entry point for each spawned rank.  Reports failures via err_queue.
+
+    ``run_id`` namespaces the Redis keys.  Module-level keys let a producer
+    that outlived its own test -- it serves for up to 60s -- be picked up by
+    the next test in the session, which then hangs waiting on a peer that is
+    already tearing down.  One namespace per roundtrip removes that coupling.
+    """
+    meta_key = "%s:%s" % (_META_KEY, run_id) if run_id else _META_KEY
+    done_key = "%s:%s" % (_DONE_KEY, run_id) if run_id else _DONE_KEY
     try:
         import redis
 
@@ -131,10 +141,10 @@ def _worker(
             traj = build(device)
             meta = producer.write_to_buffer(traj)
             assert meta is not None, "producer failed to pack buffer"
-            client.set(_META_KEY, json.dumps(meta))
+            client.set(meta_key, json.dumps(meta))
             # Serve until the consumer signals completion (bounded).
             deadline = time.monotonic() + 60
-            while time.monotonic() < deadline and not client.get(_DONE_KEY):
+            while time.monotonic() < deadline and not client.get(done_key):
                 time.sleep(0.05)
             producer.cleanup_nccl()
         else:
@@ -170,7 +180,7 @@ def _worker(
             raw = None
             deadline = time.monotonic() + 30
             while time.monotonic() < deadline and raw is None:
-                raw = client.get(_META_KEY)
+                raw = client.get(meta_key)
                 if raw is None:
                     time.sleep(0.05)
             assert raw is not None, "consumer never saw producer metadata"
@@ -190,7 +200,7 @@ def _worker(
                 assert torch.allclose(
                     actions, expected_traj["actions"].float().reshape(-1)
                 ), "strided field mismatch"
-            client.set(_DONE_KEY, "1")
+            client.set(done_key, "1")
             if composed:
                 # No transport-specific teardown to call: shutdown_prefetch
                 # defaults before_join to the attached strategy, which is the
@@ -322,10 +332,16 @@ class TestNcclE2E(unittest.TestCase):
     def _run_roundtrip(self, composed: bool, strided: bool = False):
         import torch.multiprocessing as mp
 
+        # One Redis namespace per roundtrip: a producer serves for up to 60s,
+        # so with shared keys it can outlive its own test and be picked up by
+        # the next one, which then waits on a peer that is tearing down.
+        run_id = uuid.uuid4().hex[:8]
         ctx = mp.get_context("spawn")
         err_queue = ctx.Queue()
         procs = [
-            ctx.Process(target=_worker, args=(rank, 2, err_queue, composed, strided))
+            ctx.Process(
+                target=_worker, args=(rank, 2, err_queue, composed, strided, run_id)
+            )
             for rank in range(2)
         ]
         for p in procs:

--- a/tests/test_pack_canonical_stride.py
+++ b/tests/test_pack_canonical_stride.py
@@ -1,0 +1,230 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""The payload packer must accept every legal layout of a supported tensor.
+
+The layout that motivated these tests is an int64 column view --
+``sampled_modes[:, idx]`` with ``shape=(1,)`` and ``stride=(8,)``.  PyTorch
+calls it contiguous (size-1 dimensions may carry any stride), so the packer's
+``.contiguous()`` was a no-op and the following ``view(torch.uint8)`` raised
+"self.stride(-1) must be 1 to view Long as Byte".  The producer caught that,
+returned ``None``, and every affected payload silently fell back to disk
+instead of the NCCL fast path.
+"""
+
+import threading
+import unittest
+from unittest import mock
+
+import numpy as np
+import torch
+
+from cosmos_rl.utils.payload_transport.nccl.buffer_registry import SendBufferRegistry
+from cosmos_rl.utils.payload_transport.nccl.mixins import NCCLRolloutMixin
+from cosmos_rl.utils.payload_transport.pack import (
+    _canonical_for_byte_view,
+    pack_trajectory_into,
+    torch_dtype_for,
+)
+from cosmos_rl.utils.trajectory import (
+    TensorSpec,
+    build_trajectory_schema,
+    schema_layout,
+)
+
+
+def _singleton_column(dtype=torch.int64):
+    """``shape=(1,)``, non-unit last stride, yet ``is_contiguous()`` is True."""
+    row = torch.arange(8, dtype=dtype).reshape(1, 8)
+    return row[:, 0]
+
+
+def _pack_and_recover(spec, tensor):
+    """Pack one field through the real schema path and read it back."""
+    schema = [spec]
+    offsets, entry_size = schema_layout(schema)
+    flat = torch.zeros(entry_size, dtype=torch.uint8)
+    pack_trajectory_into(flat, {spec.name: tensor}, schema, offsets, ep_len=1)
+    off = offsets[spec.name]
+    return (
+        flat[off : off + spec.nbytes]
+        .view(torch_dtype_for(spec.dtype))
+        .reshape(spec.shape)
+    )
+
+
+class TestCanonicalForByteView(unittest.TestCase):
+    def test_reproducer_layout_is_the_bug(self):
+        """Guard the premise: this layout really does defeat ``.contiguous()``."""
+        value = _singleton_column()
+        self.assertEqual(tuple(value.shape), (1,))
+        self.assertEqual(value.stride(), (8,))
+        self.assertTrue(value.is_contiguous())
+        with self.assertRaises(RuntimeError):
+            value.contiguous().view(torch.uint8)
+
+    def test_canonicalized_tensor_accepts_the_byte_view(self):
+        canonical = _canonical_for_byte_view(_singleton_column())
+        self.assertEqual(canonical.stride(), (1,))
+        self.assertEqual(canonical.view(torch.uint8).numel(), 8)
+        self.assertTrue(torch.equal(canonical, _singleton_column()))
+
+    def test_canonical_input_is_not_copied(self):
+        """An already-canonical tensor keeps the existing zero-copy fast path."""
+        tensor = torch.arange(12, dtype=torch.float32).reshape(3, 4)
+        self.assertIs(_canonical_for_byte_view(tensor), tensor)
+
+    def test_zero_dim_and_empty_tensors(self):
+        scalar = torch.tensor(5, dtype=torch.int64)
+        self.assertIs(_canonical_for_byte_view(scalar), scalar)
+        empty = torch.empty((0,), dtype=torch.int64)
+        self.assertIs(_canonical_for_byte_view(empty), empty)
+
+    def test_non_contiguous_transpose_is_materialized(self):
+        transposed = torch.arange(12, dtype=torch.float32).reshape(3, 4).t()
+        canonical = _canonical_for_byte_view(transposed)
+        self.assertTrue(canonical.is_contiguous())
+        self.assertEqual(canonical.stride(-1), 1)
+        self.assertTrue(torch.equal(canonical, transposed))
+
+
+class TestPackSingletonStride(unittest.TestCase):
+    def test_int64_singleton_column_round_trips(self):
+        spec = TensorSpec(name="sampled_mode", shape=(1,), dtype=np.int64)
+        value = _singleton_column()
+        recovered = _pack_and_recover(spec, value)
+        self.assertEqual(recovered.dtype, torch.int64)
+        self.assertEqual(tuple(recovered.shape), (1,))
+        self.assertTrue(torch.equal(recovered, value))
+
+    def test_size_one_dimension_in_each_position(self):
+        base = torch.arange(2 * 3 * 4, dtype=torch.int64).reshape(2, 3, 4)
+        cases = {
+            "leading": (base[:1], (1, 3, 4)),
+            "middle": (base[:, :1], (2, 1, 4)),
+            "trailing": (base[:, :, :1], (2, 3, 1)),
+        }
+        for name, (view, shape) in cases.items():
+            with self.subTest(position=name):
+                spec = TensorSpec(name=f"field_{name}", shape=shape, dtype=np.int64)
+                recovered = _pack_and_recover(spec, view)
+                self.assertTrue(torch.equal(recovered, view))
+
+    def test_other_multibyte_dtypes(self):
+        for np_dtype, torch_dtype in (
+            (np.float32, torch.float32),
+            (np.float64, torch.float64),
+            (np.int32, torch.int32),
+            (np.int16, torch.int16),
+        ):
+            with self.subTest(dtype=np_dtype):
+                spec = TensorSpec(name="value", shape=(1,), dtype=np_dtype)
+                value = _singleton_column(dtype=torch_dtype)
+                self.assertNotEqual(value.stride(-1), 1)
+                recovered = _pack_and_recover(spec, value)
+                self.assertTrue(torch.equal(recovered, value))
+
+    def test_single_byte_dtype_still_round_trips(self):
+        spec = TensorSpec(name="flag", shape=(1,), dtype=np.uint8)
+        value = torch.arange(8, dtype=torch.uint8).reshape(1, 8)[:, 0]
+        self.assertTrue(torch.equal(_pack_and_recover(spec, value), value))
+
+    @unittest.skipUnless(torch.cuda.is_available(), "requires a GPU")
+    def test_gpu_singleton_column_round_trips(self):
+        spec = TensorSpec(name="sampled_mode", shape=(1,), dtype=np.int64)
+        value = _singleton_column().cuda()
+        schema = [spec]
+        offsets, entry_size = schema_layout(schema)
+        flat = torch.zeros(entry_size, dtype=torch.uint8, device="cuda")
+        pack_trajectory_into(
+            flat, {spec.name: value}, schema, offsets, ep_len=1, device=value.device
+        )
+        recovered = flat[: spec.nbytes].view(torch.int64).reshape(spec.shape)
+        self.assertTrue(torch.equal(recovered.cpu(), value.cpu()))
+
+
+class TestPackErrorNamesTheField(unittest.TestCase):
+    def test_failure_message_carries_field_identity(self):
+        """A layout the packer cannot handle must say which field it was."""
+        spec = TensorSpec(name="sampled_mode", shape=(1,), dtype=np.int64)
+        schema = [spec]
+        offsets, entry_size = schema_layout(schema)
+        flat = torch.zeros(entry_size, dtype=torch.uint8)
+
+        # Force the byte view to fail after canonicalization, standing in for
+        # any future layout the canonical copy cannot repair.
+        def _passthrough(tensor):
+            return tensor
+
+        with mock.patch(
+            "cosmos_rl.utils.payload_transport.pack._canonical_for_byte_view",
+            _passthrough,
+        ):
+            with self.assertRaises(RuntimeError) as ctx:
+                pack_trajectory_into(
+                    flat,
+                    {spec.name: _singleton_column()},
+                    schema,
+                    offsets,
+                    ep_len=1,
+                )
+        message = str(ctx.exception)
+        self.assertIn("sampled_mode", message)
+        self.assertIn("torch.int64", message)
+        self.assertIn("stride=(8,)", message)
+        self.assertIn("shape=(1,)", message)
+
+
+class TestProducerKeepsNcclPath(unittest.TestCase):
+    """End-to-end producer check: no silent fallback to disk."""
+
+    def _producer(self):
+        p = NCCLRolloutMixin()
+        p._nccl_enabled = True
+        p._nccl_replica_id = "rollout-test-0"
+        p._nccl_rollout_idx = 0
+        p._nccl_sender_rank = 0
+        p._nccl_device = None  # CPU tensors
+        p._nccl_schema = build_trajectory_schema(
+            {"max_steps": 4, "obs_dim": 2, "action_dim": 2}
+        )
+        # A producer-supplied extra field is what carries the offending layout.
+        p._nccl_schema.append(
+            TensorSpec(name="sampled_mode", shape=(1,), dtype=np.int64)
+        )
+        p._nccl_offsets, p._nccl_entry_size = schema_layout(p._nccl_schema)
+        p._nccl_registry = SendBufferRegistry(capacity=4, on_free=p._on_buffer_free)
+        p._nccl_streams = None
+        p._nccl_send_lock = threading.Lock()
+        return p
+
+    def test_write_to_buffer_returns_a_reference(self):
+        p = self._producer()
+        meta = p.write_to_buffer(
+            {
+                "observations": torch.zeros(4, 2),
+                "actions": torch.zeros(4, 2),
+                "rewards": torch.zeros(4),
+                "episode_length": 4,
+                "sampled_mode": _singleton_column(),
+            }
+        )
+        self.assertIsNotNone(meta, "packing must not fall back to the disk path")
+        self.assertTrue(meta["_nccl"])
+        self.assertIn(meta["_transfer_id"], p._nccl_registry)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

A size-1 dimension may carry any stride, so PyTorch reports `is_contiguous() is True` for an int64 column view such as `sampled_modes[:, idx]` -- `shape=(1,)`, `stride=(8,)` -- and `.contiguous()` returns it untouched. The following `view(torch.uint8)` applies the stricter byte-layout rule and raises:

```
self.stride(-1) must be 1 to view Long as Byte (different element sizes), but got 8
```

`NCCLRolloutMixin.write_to_buffer` caught that, returned `None`, and every affected payload silently fell back to disk instead of the NCCL fast path -- 256 occurrences in a single completed job. Training stayed correct, so the only symptom was repeated error logs and the transport quietly not being used.

## What changed

- `pack.py` canonicalizes with an explicit `torch.empty(...).copy_()` before the byte view, the only form guaranteed to produce a unit last stride for any legal input layout. Tensors that already satisfy the rule are returned untouched, so the common case still packs without an extra copy. Both the NCCL and UCXX producers share this packer, so one fix covers both.
- A pack failure now names the schema field, dtype, shape, stride and device, and the producer log names the replica and rollout -- a disk fallback is attributable instead of reading as a bare NCCL failure.

## Tests

- `tests/test_pack_canonical_stride.py`: the reproducer layout, size-1 dimensions in leading/middle/trailing position, several multi-byte dtypes, a no-extra-copy assertion for canonical input, the error message carrying field identity, and a producer-level check that `write_to_buffer` returns a reference rather than `None`. Registered in `tests/run_test.sh`.
- `tests/test_nccl_e2e.py` gains a case that moves a stride-8 `sampled_mode` field through the real 2-GPU transfer, plus one asserting that a payload schema narrower than the consumer's config still resolves. E2E Redis keys are now namespaced per roundtrip -- a producer serves for up to 60s and could otherwise be adopted by the next test in the session.

## Validation on hardware

GCP Slurm, 2 GPUs, the packer under test mounted PYTHONPATH-first:

| Arm | Result |
|---|---|
| fix | strided transfer passes; 14 packer assertions pass on CUDA including the GPU singleton round-trip |
| control (canonicalization reverted to `.contiguous()`) | `field 'sampled_mode' ... dtype=torch.int64 shape=(1,) stride=(8,) device=cuda:0: stride(-1) must be 1` |

An 80-step single-node NCCL training run with that field injected into every payload completed with zero `write_to_buffer failed` lines.
