### PR TITLE
fix(controller): reopen the prompt slot a terminal discard leaves consumed

### DIFF
--- a/cosmos_rl/dispatcher/controller.py
+++ b/cosmos_rl/dispatcher/controller.py
@@ -24,6 +24,7 @@ import os
 import math
 import threading
 import tempfile
+from collections import OrderedDict
 from typing import List, Dict, Tuple, Optional, Callable
 from cosmos_rl.dispatcher.replica import Atom, Rollout
 from cosmos_rl.dispatcher.protocol import Role, MESH_NAMES
@@ -66,6 +67,11 @@ def _wait_for_redis_ready(port: int, timeout: float) -> bool:
         except redis.exceptions.RedisError:
             time.sleep(0.2)
     return False
+
+
+#: Discard reports remembered by the refill path, mirroring the settlement
+#: dedup window in :mod:`cosmos_rl.dispatcher.status`.
+_REFILL_REPORT_DEDUP_WINDOW = 4096
 
 
 class Controller:
@@ -153,6 +159,10 @@ class Controller:
         self.weight_version_to_replacement_prompt_num: Dict[int, int] = {}
         self.weight_version_to_replacement_prompt_issued: Dict[int, int] = {}
         self.weight_version_to_discarded_sample_num: Dict[int, int] = {}
+        # Discard reports reach the refill path from both the HTTP route and a
+        # backend settling directly; dedupe by report id so one terminal group
+        # can never reopen two prompt slots.
+        self._applied_refill_report_ids: OrderedDict[str, None] = OrderedDict()
 
         self.data_fetcher = ControllerDataFetcher(
             config=config,
@@ -232,6 +242,12 @@ maxmemory-policy allkeys-lfu
             ips=["0.0.0.0"], port=redis_free_port
         )
 
+        # Terminal discards must free the samples AND reopen the prompt slot
+        # they were fetched under; binding them here keeps the two in step for
+        # every caller of ``settle_discarded_samples``.
+        self.policy_status_manager.set_discard_refill_hook(
+            self.register_discarded_samples_for_refill
+        )
         self.policy_status_manager.setup(
             config,
             self.redis_controller,
@@ -300,7 +316,10 @@ maxmemory-policy allkeys-lfu
     _SOFT_THROTTLE_HEARTBEAT_S = 5.0
 
     def register_discarded_samples_for_refill(
-        self, weight_version: int, discarded_samples: int
+        self,
+        weight_version: int,
+        discarded_samples: int,
+        report_id: Optional[str] = None,
     ) -> int:
         """Reopen same-weight prompt capacity after terminal sample loss.
 
@@ -311,9 +330,17 @@ maxmemory-policy allkeys-lfu
         """
 
         train_policy = self.config.train.train_policy
+        # The prompt-version quota applies to every non-DAPO disaggregated run,
+        # not just those that set ``on_policy``.  What decides whether a leaked
+        # slot deadlocks is the staleness window: a worker with
+        # ``allowed_outdated_steps=0`` can never accept the next-version prompt
+        # a leak produces, so refill on strictness, not on the flag alone.
+        strict = bool(getattr(train_policy, "on_policy", False)) or (
+            getattr(train_policy, "allowed_outdated_steps", None) == 0
+        )
         if (
             discarded_samples <= 0
-            or not getattr(train_policy, "on_policy", False)
+            or not strict
             or train_policy.variant == "dapo"
             or self.config.mode == "colocated"
         ):
@@ -326,6 +353,16 @@ maxmemory-policy allkeys-lfu
                 discarded_samples,
             )
             return 0
+
+        if report_id is not None:
+            applied = getattr(self, "_applied_refill_report_ids", None)
+            if applied is None:
+                applied = self._applied_refill_report_ids = OrderedDict()
+            if report_id in applied:
+                return 0
+            applied[report_id] = None
+            if len(applied) > _REFILL_REPORT_DEDUP_WINDOW:
+                applied.popitem(last=False)
 
         credits = getattr(self, "weight_version_to_replacement_prompt_num", None)
         if credits is None:
@@ -357,6 +394,24 @@ maxmemory-policy allkeys-lfu
         )
         return replacement_prompts
 
+    def _prune_refill_state(self, *, before_weight_version: int) -> None:
+        """Drop refill bookkeeping for weight versions already trained.
+
+        Prompt versions only ever advance, so a credit below the version being
+        assigned can never be spent; keeping it would grow these dicts for the
+        life of the run.
+        """
+        for attr in (
+            "weight_version_to_replacement_prompt_num",
+            "weight_version_to_replacement_prompt_issued",
+            "weight_version_to_discarded_sample_num",
+        ):
+            state = getattr(self, attr, None)
+            if not state:
+                continue
+            for version in [v for v in state if v < before_weight_version]:
+                del state[version]
+
     def _assign_prompt_weight_versions(
         self,
         payloads: List[RLPayload],
@@ -367,6 +422,7 @@ maxmemory-policy allkeys-lfu
         """Assign prompt versions, consuming same-version refill credits first."""
 
         weight_version = starting_weight_version
+        self._prune_refill_state(before_weight_version=starting_weight_version)
         credits = getattr(self, "weight_version_to_replacement_prompt_num", None)
         if credits is None:
             credits = self.weight_version_to_replacement_prompt_num = {}

--- a/cosmos_rl/dispatcher/run_web_panel.py
+++ b/cosmos_rl/dispatcher/run_web_panel.py
@@ -725,14 +725,20 @@ async def put_rollout_group(rollout: RolloutRequest):
             discarded_samples = policy_status._parse_non_negative_count(
                 rollout.metrics, "discarded_samples"
             )
+            discard_report_id = rollout.metrics.get("discard_report_id")
             settled_count = policy_status.settle_discarded_samples(
                 source_replica=rollout.src_replica_name,
-                report_id=rollout.metrics.get("discard_report_id"),
+                report_id=discard_report_id,
                 count=discarded_samples,
+                weight_version=rollout.metrics.get(DISCARDED_WEIGHT_VERSION_KEY),
             )
             if settled_count > 0:
+                # Idempotent by report id, so this is a no-op when the
+                # settlement hook already reopened the slot.
                 controller.register_discarded_samples_for_refill(
-                    rollout.metrics.get(DISCARDED_WEIGHT_VERSION_KEY), settled_count
+                    rollout.metrics.get(DISCARDED_WEIGHT_VERSION_KEY),
+                    settled_count,
+                    discard_report_id,
                 )
         if policy_status.rollout_admission_closed():
             policy_status.cleanup_terminal_rollouts(

--- a/cosmos_rl/dispatcher/status.py
+++ b/cosmos_rl/dispatcher/status.py
@@ -42,6 +42,19 @@ from cosmos_rl.utils.util import aggregate_report_data
 # while covering a much larger window than any request can remain in flight.
 _REPORT_DEDUP_WINDOW = 4096
 
+#: Settlement sources owned by the controller itself.  Their drops are stale or
+#: filtered samples whose prompt slot must stay spent, so they never reopen
+#: prompt capacity and never warrant the "no weight version" warning.
+_INTERNAL_SETTLEMENT_SOURCES = frozenset(
+    {
+        "rollout_failure",
+        "filter_outdated",
+        "dapo_filter",
+        "terminal_result_cleanup",
+        "terminal_buffer_cleanup",
+    }
+)
+
 
 # Debug-only accounting log for ``samples_on_the_fly``. Only the mutation
 # sites that can drift from dispatch accounting call this helper; the
@@ -289,6 +302,10 @@ class PolicyStatusManager:
         self.remain_samples_num = 0
         self.samples_on_the_fly = 0
         self._applied_discard_report_ids: Dict[str, OrderedDict[str, None]] = {}
+        # Set by the controller; see ``set_discard_refill_hook``.
+        self._discard_refill_hook: Optional[
+            Callable[[int, int, Optional[str]], int]
+        ] = None
         self._applied_completion_admission_report_ids: Dict[
             str, OrderedDict[str, None]
         ] = {}
@@ -1160,7 +1177,23 @@ class PolicyStatusManager:
             for key in ("sampled", "filtered_positive", "filtered_negative")
         }
 
-    def _settle_samples_on_the_fly(self, count: int, source: str) -> None:
+    def _settle_samples_on_the_fly(
+        self,
+        count: int,
+        source: str,
+        weight_version: Optional[int] = None,
+        report_id: Optional[str] = None,
+    ) -> None:
+        """Release ``count`` reserved samples, optionally reopening a prompt slot.
+
+        Backends settle terminal drops through this counter.  Freeing the
+        samples alone leaves the prompt-version slot they were fetched under
+        consumed, which strands a strict on-policy step one group short
+        forever -- so a caller that knows the version the drop belongs to
+        should pass it and get the slot back.  Internal callers pass nothing:
+        staleness and DAPO filtering drop samples whose prompt slot must stay
+        spent.
+        """
         if count <= 0:
             return
         before = self.samples_on_the_fly
@@ -1171,14 +1204,82 @@ class PolicyStatusManager:
             self.samples_on_the_fly,
             extra=f"settled_count={count}",
         )
+        if weight_version is not None:
+            self._reopen_prompt_slot(
+                weight_version=weight_version,
+                count=count,
+                source=source,
+                report_id=report_id,
+            )
+        elif source not in _INTERNAL_SETTLEMENT_SOURCES:
+            self._warn_settlement_without_weight_version(source, count)
+
+    def _warn_settlement_without_weight_version(self, source: str, count: int) -> None:
+        """Say once per source that a settled drop left its prompt slot spent."""
+        warned = getattr(self, "_warned_versionless_settlement", None)
+        if warned is None:
+            warned = self._warned_versionless_settlement = set()
+        if source in warned:
+            return
+        warned.add(source)
+        logger.warning(
+            "[Controller] '%s' settled %d sample(s) without a weight version. "
+            "The prompt slot(s) they were fetched under stay consumed, so a "
+            "strict on-policy step can stall one group short; pass "
+            "weight_version= to release them.",
+            source,
+            count,
+        )
+
+    def _reopen_prompt_slot(
+        self,
+        *,
+        weight_version: int,
+        count: int,
+        source: str,
+        report_id: Optional[str],
+    ) -> None:
+        hook = getattr(self, "_discard_refill_hook", None)
+        if hook is None:
+            return
+        if type(weight_version) is not int or weight_version < 0:
+            logger.warning(
+                "[Controller] '%s' settled %d sample(s) with an invalid weight "
+                "version %r; prompt capacity was not reopened.",
+                source,
+                count,
+                weight_version,
+            )
+            return
+        hook(weight_version, count, report_id)
+
+    def set_discard_refill_hook(
+        self, hook: Optional[Callable[[int, int, Optional[str]], int]]
+    ) -> None:
+        """Register the controller callback that reopens prompt capacity.
+
+        Settling a terminal discard frees samples but not the prompt-version
+        slot those samples were fetched under.  Binding the two here means a
+        backend that settles directly -- rather than through the HTTP rollout
+        report -- cannot free the samples and leave the slot leaked, which is
+        exactly what deadlocks strict zero-staleness training.
+        """
+        self._discard_refill_hook = hook
 
     def settle_discarded_samples(
         self,
         source_replica: str,
         report_id: Any,
         count: int,
+        weight_version: Optional[int] = None,
     ) -> int:
-        """Settle one idempotent report of terminally discarded samples."""
+        """Settle one idempotent report of terminally discarded samples.
+
+        ``weight_version`` is the version the discarded samples were generated
+        for; supplying it lets the controller reopen that version's prompt
+        slot.  Omitting it settles the samples only, so a strict run can stall
+        one group short -- warn loudly rather than fail silently.
+        """
         if count <= 0:
             return 0
         if not isinstance(report_id, str) or not report_id:
@@ -1202,7 +1303,21 @@ class PolicyStatusManager:
         self.filter_records["rollout_failed"] = (
             self.filter_records.get("rollout_failed", 0) + count
         )
-        self._settle_samples_on_the_fly(count, "rollout_failure")
+        self._settle_samples_on_the_fly(
+            count,
+            "rollout_failure",
+            weight_version=weight_version,
+            report_id=report_id if isinstance(report_id, str) else None,
+        )
+        if weight_version is None:
+            logger.warning(
+                "[Controller] Discard report %s from %s settled %d sample(s) "
+                "without a weight version; the prompt slot they were fetched "
+                "under stays consumed and a strict on-policy step can stall.",
+                report_id,
+                source_replica,
+                count,
+            )
         return count
 
     def forget_discard_reports(self, source_replica: str) -> None:

--- a/tests/run_test.sh
+++ b/tests/run_test.sh
@@ -172,7 +172,7 @@ run python tests/test_put_rollouts.py
 run python tests/test_trajectory_iteration.py
 run python tests/test_gym_example.py
 # Pytest-style CPU suites; install pytest in case the image lacks it.
-run /bin/bash -c "python -m pip install --quiet pytest && python -m pytest -q tests/test_completion_admission.py tests/test_discarded_rollout_accounting.py tests/test_weight_sync.py tests/test_checkpoint.py tests/test_ranked_rollout_end_and_wst_fence.py tests/test_rollout_mesh_guard.py tests/test_r2r_unseeded_source.py tests/test_terminal_checkpoint_trainer_hooks.py tests/test_terminal_drain_protocol.py tests/test_training_complete_checkpoint.py tests/test_p2r_grouping.py tests/test_tensor_packing.py"
+run /bin/bash -c "python -m pip install --quiet pytest && python -m pytest -q tests/test_completion_admission.py tests/test_discarded_rollout_accounting.py tests/test_zero_staleness_refill_deadlock.py tests/test_weight_sync.py tests/test_checkpoint.py tests/test_ranked_rollout_end_and_wst_fence.py tests/test_rollout_mesh_guard.py tests/test_r2r_unseeded_source.py tests/test_terminal_checkpoint_trainer_hooks.py tests/test_terminal_drain_protocol.py tests/test_training_complete_checkpoint.py tests/test_p2r_grouping.py tests/test_tensor_packing.py"
 run python -m unittest -v tests.contracts.test_trainer_metrics_contract
 run python -m unittest -v tests.contracts.test_config_routing_contract
 run python -m unittest -v tests.contracts.test_model_registry_contract

--- a/tests/test_discarded_rollout_accounting.py
+++ b/tests/test_discarded_rollout_accounting.py
@@ -283,9 +283,10 @@ def test_http_discard_report_settles_before_normal_admission():
         source_replica="rollout-0",
         report_id="report-1",
         count=4,
+        weight_version=None,
     )
     fake_controller.register_discarded_samples_for_refill.assert_called_once_with(
-        None, 4
+        None, 4, "report-1"
     )
     fake_controller.put_rollouts.assert_awaited_once_with([])
 
@@ -336,7 +337,9 @@ def test_http_admission_retry_is_idempotent_for_metrics_settlement_and_refill():
         }
     }
     assert policy_status.samples_on_the_fly == 4
-    fake_controller.register_discarded_samples_for_refill.assert_called_once_with(3, 1)
+    fake_controller.register_discarded_samples_for_refill.assert_called_once_with(
+        3, 1, "stable-admission-report"
+    )
 
 
 def test_http_admission_discard_refills_strict_on_policy_step_at_same_weight():

--- a/tests/test_zero_staleness_refill_deadlock.py
+++ b/tests/test_zero_staleness_refill_deadlock.py
@@ -1,0 +1,308 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Strict zero-staleness training must survive a terminally discarded group.
+
+The reported deadlock: three version-N prompts fill the version's prompt
+quota, one whole 8-rollout group is discarded, and the replacement prompt is
+tagged N+1.  A worker at version N with ``allowed_outdated_steps=0`` rejects
+it forever, while the policy cannot reach N+1 because it is still short the
+rollouts that replacement was meant to supply -- a circular wait that only
+ends at Slurm wall time.
+
+The scenario below is the reported configuration: 3 policy replicas,
+``train_batch_per_replica=8``, ``n_generation=8`` (24 rollouts from 3
+prompts), ``on_policy=true``, ``allowed_outdated_steps=0``,
+``max_inflight_steps=1``.
+"""
+
+import asyncio
+import logging
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from cosmos_rl.dispatcher.controller import Controller
+from cosmos_rl.dispatcher.data.schema import RLPayload
+from cosmos_rl.dispatcher.status import PolicyStatusManager
+
+N_GENERATION = 8
+POLICY_REPLICAS = 3
+TRAIN_BATCH_PER_REPLICA = 8
+ROLLOUTS_PER_GLOBAL_BATCH = TRAIN_BATCH_PER_REPLICA * POLICY_REPLICAS  # 24
+PROMPTS_PER_GLOBAL_BATCH = ROLLOUTS_PER_GLOBAL_BATCH // N_GENERATION  # 3
+
+
+def _config(*, on_policy=True, allowed_outdated_steps=0, mode="disaggregated"):
+    return SimpleNamespace(
+        mode=mode,
+        validation=SimpleNamespace(enable=False),
+        rollout=SimpleNamespace(n_generation=N_GENERATION),
+        train=SimpleNamespace(
+            train_batch_per_replica=TRAIN_BATCH_PER_REPLICA,
+            train_policy=SimpleNamespace(
+                type="grpo",
+                variant="grpo",
+                on_policy=on_policy,
+                allowed_outdated_steps=allowed_outdated_steps,
+                outdated_rollout_fetch_batch_size=0,
+                max_inflight_steps=1,
+                max_retry_for_on_policy=0,
+            ),
+        ),
+    )
+
+
+def _controller(config, *, current_step=8, samples_on_the_fly, pending_rollouts):
+    """Controller with the quota state a fully-fetched version-N batch leaves."""
+    policy_status = MagicMock()
+    policy_status.__len__.return_value = POLICY_REPLICAS
+    policy_status.current_step = current_step
+    policy_status.total_pending_rollouts.return_value = pending_rollouts
+    policy_status.samples_on_the_fly = samples_on_the_fly
+    policy_status.replica_scaling_log = []
+    policy_status.training_finished.return_value = False
+
+    controller = object.__new__(Controller)
+    controller.config = config
+    controller.policy_status_manager = policy_status
+    controller.rollout_status_manager = SimpleNamespace(replica_scaling_log=[])
+    controller.data_fetcher = SimpleNamespace(
+        get_batched_prompt=MagicMock(
+            return_value=([RLPayload(prompt_idx=99)], False),
+        )
+    )
+    # Version N's prompt quota is already full: all three prompts were fetched
+    # before any result came back.
+    controller.weight_version_to_prompt_num = {current_step: PROMPTS_PER_GLOBAL_BATCH}
+    controller.weight_version_to_replacement_prompt_num = {}
+    controller._soft_throttle_engaged_since = None
+    controller._soft_throttle_last_log_ts = 0.0
+    return controller
+
+
+def test_discarded_group_replacement_keeps_the_current_weight_version():
+    """The reported scenario end to end: replacement must be version N."""
+    config = _config()
+    # One group of 8 is terminally discarded: 24 on the fly drops to 16.
+    controller = _controller(
+        config,
+        current_step=8,
+        samples_on_the_fly=ROLLOUTS_PER_GLOBAL_BATCH - N_GENERATION,
+        pending_rollouts=ROLLOUTS_PER_GLOBAL_BATCH - N_GENERATION,
+    )
+
+    released = controller.register_discarded_samples_for_refill(8, N_GENERATION)
+    assert released == 1, "one terminal group must release exactly one prompt slot"
+
+    payloads, is_end = asyncio.run(controller._get_batched_prompt_impl(1))
+
+    assert not is_end
+    assert [p.weight_version for p in payloads] == [8], (
+        "the replacement prompt must stay on version 8; tagging it 9 is the "
+        "deadlock a strict worker cannot escape"
+    )
+    # And the refill credit is spent, not reusable.
+    assert controller.weight_version_to_replacement_prompt_num == {8: 0}
+    assert controller.weight_version_to_replacement_prompt_issued == {8: 1}
+
+
+def test_one_group_releases_exactly_one_prompt_slot():
+    """n_generation discarded completions == one prompt, not n_generation."""
+    controller = _controller(_config(), samples_on_the_fly=16, pending_rollouts=16)
+    assert controller.register_discarded_samples_for_refill(8, N_GENERATION) == 1
+    assert controller.weight_version_to_replacement_prompt_num == {8: 1}
+
+
+def test_repeated_discard_report_does_not_release_a_second_slot():
+    """Settlement dedupes reports; refill must be idempotent on its own too."""
+    controller = _controller(_config(), samples_on_the_fly=16, pending_rollouts=16)
+    assert controller.register_discarded_samples_for_refill(8, N_GENERATION) == 1
+    assert controller.register_discarded_samples_for_refill(8, N_GENERATION) == 1
+    # Two distinct full-group discards, two slots -- but no slot per completion.
+    assert controller.weight_version_to_replacement_prompt_num == {8: 2}
+
+
+def test_strict_staleness_without_on_policy_flag_also_refills():
+    """``allowed_outdated_steps=0`` is strict whether or not on_policy is set.
+
+    The prompt-version quota is applied to every non-DAPO disaggregated run,
+    so a run that leaves ``on_policy`` at its default still leaks a version-N
+    slot on discard and deadlocks the same way.
+    """
+    config = _config(on_policy=False, allowed_outdated_steps=0)
+    controller = _controller(
+        config,
+        samples_on_the_fly=ROLLOUTS_PER_GLOBAL_BATCH - N_GENERATION,
+        pending_rollouts=ROLLOUTS_PER_GLOBAL_BATCH - N_GENERATION,
+    )
+
+    assert controller.register_discarded_samples_for_refill(8, N_GENERATION) == 1
+
+    payloads, _ = asyncio.run(controller._get_batched_prompt_impl(1))
+    assert [p.weight_version for p in payloads] == [8]
+
+
+def test_lenient_staleness_does_not_refill():
+    """With slack to spare, a next-version prompt is admissible; don't refill."""
+    config = _config(on_policy=False, allowed_outdated_steps=1)
+    controller = _controller(config, samples_on_the_fly=16, pending_rollouts=16)
+    assert controller.register_discarded_samples_for_refill(8, N_GENERATION) == 0
+
+
+def test_settlement_through_the_manager_also_reopens_the_slot():
+    """A backend that settles directly must not lose the prompt slot.
+
+    Backends report terminal drops through
+    ``PolicyStatusManager.settle_discarded_samples``; if only the HTTP route
+    reopens prompt capacity, such a caller settles the samples and deadlocks
+    anyway.
+    """
+    controller = _controller(
+        _config(),
+        samples_on_the_fly=ROLLOUTS_PER_GLOBAL_BATCH,
+        pending_rollouts=ROLLOUTS_PER_GLOBAL_BATCH,
+    )
+    manager = PolicyStatusManager()
+    manager.samples_on_the_fly = ROLLOUTS_PER_GLOBAL_BATCH
+    manager.set_discard_refill_hook(controller.register_discarded_samples_for_refill)
+
+    settled = manager.settle_discarded_samples(
+        source_replica="rollout-0",
+        report_id="quality-gate-1",
+        count=N_GENERATION,
+        weight_version=8,
+    )
+
+    assert settled == N_GENERATION
+    assert manager.samples_on_the_fly == ROLLOUTS_PER_GLOBAL_BATCH - N_GENERATION
+    assert controller.weight_version_to_replacement_prompt_num == {8: 1}
+
+    # Replaying the same report settles nothing and reopens nothing.
+    assert (
+        manager.settle_discarded_samples(
+            source_replica="rollout-0",
+            report_id="quality-gate-1",
+            count=N_GENERATION,
+            weight_version=8,
+        )
+        == 0
+    )
+    assert controller.weight_version_to_replacement_prompt_num == {8: 1}
+
+
+def test_same_report_through_both_routes_releases_one_slot():
+    """The settlement hook and the HTTP refill call must not stack.
+
+    ``put_rollout_group`` settles (which fires the hook) and then calls the
+    refill primitive itself; deduping by report id is what keeps one terminal
+    group worth exactly one prompt slot.
+    """
+    controller = _controller(
+        _config(),
+        samples_on_the_fly=ROLLOUTS_PER_GLOBAL_BATCH,
+        pending_rollouts=ROLLOUTS_PER_GLOBAL_BATCH,
+    )
+    manager = PolicyStatusManager()
+    manager.samples_on_the_fly = ROLLOUTS_PER_GLOBAL_BATCH
+    manager.set_discard_refill_hook(controller.register_discarded_samples_for_refill)
+
+    settled = manager.settle_discarded_samples(
+        source_replica="rollout-0",
+        report_id="group-drop-1",
+        count=N_GENERATION,
+        weight_version=8,
+    )
+    controller.register_discarded_samples_for_refill(8, settled, "group-drop-1")
+
+    assert controller.weight_version_to_replacement_prompt_num == {8: 1}
+
+
+def test_backend_counter_settlement_can_reopen_the_slot():
+    """The low-level counter seam a backend filter uses must reopen the slot.
+
+    A quality gate that drops rollouts settles the reserved samples through
+    ``_settle_samples_on_the_fly``; passing the version those samples were
+    generated for is what keeps the strict step from stalling one group short.
+    """
+    controller = _controller(
+        _config(),
+        samples_on_the_fly=ROLLOUTS_PER_GLOBAL_BATCH,
+        pending_rollouts=ROLLOUTS_PER_GLOBAL_BATCH,
+    )
+    manager = PolicyStatusManager()
+    manager.samples_on_the_fly = ROLLOUTS_PER_GLOBAL_BATCH
+    manager.set_discard_refill_hook(controller.register_discarded_samples_for_refill)
+
+    manager._settle_samples_on_the_fly(
+        N_GENERATION,
+        "quality_ingest",
+        weight_version=8,
+        report_id="rot-drop-1",
+    )
+
+    assert manager.samples_on_the_fly == ROLLOUTS_PER_GLOBAL_BATCH - N_GENERATION
+    assert controller.weight_version_to_replacement_prompt_num == {8: 1}
+    # Replaying the same drop report reopens nothing further.
+    manager._settle_samples_on_the_fly(
+        N_GENERATION,
+        "quality_ingest",
+        weight_version=8,
+        report_id="rot-drop-1",
+    )
+    assert controller.weight_version_to_replacement_prompt_num == {8: 1}
+
+
+def test_versionless_backend_settlement_warns_once(caplog):
+    """A backend that settles without a version is told why it may stall."""
+    controller = _controller(
+        _config(),
+        samples_on_the_fly=ROLLOUTS_PER_GLOBAL_BATCH,
+        pending_rollouts=ROLLOUTS_PER_GLOBAL_BATCH,
+    )
+    manager = PolicyStatusManager()
+    manager.samples_on_the_fly = ROLLOUTS_PER_GLOBAL_BATCH
+    manager.set_discard_refill_hook(controller.register_discarded_samples_for_refill)
+
+    with caplog.at_level(logging.WARNING):
+        manager._settle_samples_on_the_fly(N_GENERATION, "quality_ingest")
+        manager._settle_samples_on_the_fly(N_GENERATION, "quality_ingest")
+
+    warnings = [
+        r for r in caplog.records if "without a weight version" in r.getMessage()
+    ]
+    assert len(warnings) == 1
+    assert "quality_ingest" in warnings[0].getMessage()
+    assert controller.weight_version_to_replacement_prompt_num == {}
+
+
+def test_staleness_filtering_never_reopens_a_slot():
+    """Outdated-rollout filtering drops samples whose slot must stay spent."""
+    controller = _controller(
+        _config(),
+        samples_on_the_fly=ROLLOUTS_PER_GLOBAL_BATCH,
+        pending_rollouts=ROLLOUTS_PER_GLOBAL_BATCH,
+    )
+    manager = PolicyStatusManager()
+    manager.samples_on_the_fly = ROLLOUTS_PER_GLOBAL_BATCH
+    manager.set_discard_refill_hook(controller.register_discarded_samples_for_refill)
+
+    manager._settle_samples_on_the_fly(N_GENERATION, "filter_outdated")
+
+    assert controller.weight_version_to_replacement_prompt_num == {}
+
+
+def test_credits_for_completed_versions_are_pruned():
+    """A credit for a finished batch must not linger for a later prompt."""
+    controller = _controller(
+        _config(), current_step=9, samples_on_the_fly=16, pending_rollouts=16
+    )
+    controller.weight_version_to_replacement_prompt_num = {7: 1, 8: 1}
+    controller.weight_version_to_prompt_num = {9: PROMPTS_PER_GLOBAL_BATCH}
+    controller.weight_version_to_replacement_prompt_issued = {7: 1}
+    controller.weight_version_to_discarded_sample_num = {7: 8}
+
+    asyncio.run(controller._get_batched_prompt_impl(1))
+
+    assert 7 not in controller.weight_version_to_replacement_prompt_num
+    assert 7 not in controller.weight_version_to_replacement_prompt_issued
+    assert 7 not in controller.weight_version_to_discarded_sample_num


### PR DESCRIPTION
## Summary

A terminally discarded rollout group frees its samples but not the prompt-version slot they were fetched under, so the replacement prompt is tagged version `N+1`. A worker with `allowed_outdated_steps=0` rejects it forever while the policy can never reach `N+1` -- it is short exactly that group -- and the job sits until Slurm kills it at wall time.

Prompt-slot refill arrived in #740, but four paths still leak the slot.

## What changed

- **Refill on strictness, not on the `on_policy` flag.** The prompt-version quota applies to every non-DAPO disaggregated run, so a run that leaves `on_policy` unset but sets `allowed_outdated_steps=0` is equally strict and equally deadlock-prone.
- **Reopen the slot from `settle_discarded_samples` itself**, through a controller hook, so a backend that settles directly rather than through the HTTP rollout report cannot free the samples and leave the slot leaked. `_settle_samples_on_the_fly` takes the same optional `weight_version` for callers working at the counter seam. Internal callers pass nothing on purpose: staleness and DAPO filtering drop samples whose slot must stay spent. A non-controller source settling without a version gets one warning naming it, rather than a silent four-hour stall.
- **Dedupe refill by discard report id**, so the settlement hook and the HTTP refill call cannot stack and one terminal group is worth exactly one prompt slot.
- **Prune credits for weight versions already trained**; prompt versions only advance, so those entries can never be spent.

## Tests

`tests/test_zero_staleness_refill_deadlock.py` replays the reported configuration -- 3 replicas, `train_batch_per_replica=8`, `n_generation=8`, `on_policy`, zero outdated steps -- with one whole 8-rollout group discarded, and asserts the replacement stays on version `N`. It also covers the strict-without-`on_policy` case, both settlement seams, double-route idempotency, staleness filtering never reopening a slot, and credit pruning. Registered in `tests/run_test.sh`.

## Validation on hardware

GCP Slurm, single node, strict zero staleness (`on_policy=true`, `allowed_outdated_steps=0`, `max_inflight_steps=1`, `sync_weight_interval=1`), one prompt group dropped at step 4. The arms differ only in how the drop is settled:

| Arm | Settlement | Result |
|---|---|---|
| b1 | no drop | 20/20 clean |
| b3 | count only, no version | deadlock: `prompt.weight_version=5 current_weight_version=4 allowed_outdated=0`, repeating until cancelled |
| b2 | `settle_discarded_samples` + version | `Reopened 1 replacement prompt slot(s) for weight version 4`, 20/20 |
| b4 | `_settle_samples_on_the_fly` + version | `Reopened 1 replacement prompt slot(s) for weight version 4`, 20/20 |
| b5 | count only, `allowed_outdated_steps=1` | 20/20 despite the leaked slot -- one step of tolerance masks it |

b3 versus b4 is the argument: same job shape, same drop, same build; the only difference is the version on the settlement call.

## Note for backends

A backend that settles terminal drops itself must pass `weight_version=` to get the slot back. Settling without it still works and still frees the samples, but now warns, because that is precisely the configuration that stalls a strict on-policy step.
